### PR TITLE
feat: migrate from Freezed v2 to v3

### DIFF
--- a/app/backend/lib/graphql/__generated__/schema.ast.gql.dart
+++ b/app/backend/lib/graphql/__generated__/schema.ast.gql.dart
@@ -539,7 +539,7 @@ const MainQuestRelationsConstraint = _i1.EnumTypeDefinitionNode(
     _i1.EnumValueDefinitionNode(
       name: _i1.NameNode(value: 'main_quest_relations_pkey'),
       directives: [],
-    ),
+    )
   ],
 );
 const MainQuestRelationsInsertInput = _i1.InputObjectTypeDefinitionNode(
@@ -742,29 +742,29 @@ const MainQuestRelationsStreamCursorInput = _i1.InputObjectTypeDefinitionNode(
 );
 const MainQuestRelationsStreamCursorValueInput =
     _i1.InputObjectTypeDefinitionNode(
-      name: _i1.NameNode(value: 'MainQuestRelationsStreamCursorValueInput'),
+  name: _i1.NameNode(value: 'MainQuestRelationsStreamCursorValueInput'),
+  directives: [],
+  fields: [
+    _i1.InputValueDefinitionNode(
+      name: _i1.NameNode(value: 'childQuestId'),
       directives: [],
-      fields: [
-        _i1.InputValueDefinitionNode(
-          name: _i1.NameNode(value: 'childQuestId'),
-          directives: [],
-          type: _i1.NamedTypeNode(
-            name: _i1.NameNode(value: 'uuid'),
-            isNonNull: false,
-          ),
-          defaultValue: null,
-        ),
-        _i1.InputValueDefinitionNode(
-          name: _i1.NameNode(value: 'parentQuestId'),
-          directives: [],
-          type: _i1.NamedTypeNode(
-            name: _i1.NameNode(value: 'uuid'),
-            isNonNull: false,
-          ),
-          defaultValue: null,
-        ),
-      ],
-    );
+      type: _i1.NamedTypeNode(
+        name: _i1.NameNode(value: 'uuid'),
+        isNonNull: false,
+      ),
+      defaultValue: null,
+    ),
+    _i1.InputValueDefinitionNode(
+      name: _i1.NameNode(value: 'parentQuestId'),
+      directives: [],
+      type: _i1.NamedTypeNode(
+        name: _i1.NameNode(value: 'uuid'),
+        isNonNull: false,
+      ),
+      defaultValue: null,
+    ),
+  ],
+);
 const MainQuestRelationsUpdateColumn = _i1.EnumTypeDefinitionNode(
   name: _i1.NameNode(value: 'MainQuestRelationsUpdateColumn'),
   directives: [],
@@ -1090,7 +1090,7 @@ const MainQuestsConstraint = _i1.EnumTypeDefinitionNode(
     _i1.EnumValueDefinitionNode(
       name: _i1.NameNode(value: 'main_quests_pkey'),
       directives: [],
-    ),
+    )
   ],
 );
 const MainQuestsInsertInput = _i1.InputObjectTypeDefinitionNode(
@@ -1415,7 +1415,7 @@ const MainQuestsPkColumnsInput = _i1.InputObjectTypeDefinitionNode(
         isNonNull: true,
       ),
       defaultValue: null,
-    ),
+    )
   ],
 );
 const MainQuestsSelectColumn = _i1.EnumTypeDefinitionNode(
@@ -3202,7 +3202,7 @@ const QuestStatus = _i1.ObjectTypeDefinitionNode(
         name: _i1.NameNode(value: 'String'),
         isNonNull: true,
       ),
-    ),
+    )
   ],
 );
 const QuestStatusBoolExp = _i1.InputObjectTypeDefinitionNode(
@@ -3352,7 +3352,7 @@ const QuestStatusOrderBy = _i1.InputObjectTypeDefinitionNode(
         isNonNull: false,
       ),
       defaultValue: null,
-    ),
+    )
   ],
 );
 const QuestStatusSelectColumn = _i1.EnumTypeDefinitionNode(
@@ -3362,7 +3362,7 @@ const QuestStatusSelectColumn = _i1.EnumTypeDefinitionNode(
     _i1.EnumValueDefinitionNode(
       name: _i1.NameNode(value: 'value'),
       directives: [],
-    ),
+    )
   ],
 );
 const QuestStatusStreamCursorInput = _i1.InputObjectTypeDefinitionNode(
@@ -3401,7 +3401,7 @@ const QuestStatusStreamCursorValueInput = _i1.InputObjectTypeDefinitionNode(
         isNonNull: false,
       ),
       defaultValue: null,
-    ),
+    )
   ],
 );
 const Seos = _i1.ObjectTypeDefinitionNode(
@@ -4442,29 +4442,29 @@ const UserAchievementsStreamCursorInput = _i1.InputObjectTypeDefinitionNode(
 );
 const UserAchievementsStreamCursorValueInput =
     _i1.InputObjectTypeDefinitionNode(
-      name: _i1.NameNode(value: 'UserAchievementsStreamCursorValueInput'),
+  name: _i1.NameNode(value: 'UserAchievementsStreamCursorValueInput'),
+  directives: [],
+  fields: [
+    _i1.InputValueDefinitionNode(
+      name: _i1.NameNode(value: 'achievementId'),
       directives: [],
-      fields: [
-        _i1.InputValueDefinitionNode(
-          name: _i1.NameNode(value: 'achievementId'),
-          directives: [],
-          type: _i1.NamedTypeNode(
-            name: _i1.NameNode(value: 'uuid'),
-            isNonNull: false,
-          ),
-          defaultValue: null,
-        ),
-        _i1.InputValueDefinitionNode(
-          name: _i1.NameNode(value: 'userId'),
-          directives: [],
-          type: _i1.NamedTypeNode(
-            name: _i1.NameNode(value: 'String'),
-            isNonNull: false,
-          ),
-          defaultValue: null,
-        ),
-      ],
-    );
+      type: _i1.NamedTypeNode(
+        name: _i1.NameNode(value: 'uuid'),
+        isNonNull: false,
+      ),
+      defaultValue: null,
+    ),
+    _i1.InputValueDefinitionNode(
+      name: _i1.NameNode(value: 'userId'),
+      directives: [],
+      type: _i1.NamedTypeNode(
+        name: _i1.NameNode(value: 'String'),
+        isNonNull: false,
+      ),
+      defaultValue: null,
+    ),
+  ],
+);
 const Users = _i1.ObjectTypeDefinitionNode(
   name: _i1.NameNode(value: 'Users'),
   directives: [],
@@ -5023,7 +5023,7 @@ const mutation_root = _i1.ObjectTypeDefinitionNode(
             isNonNull: true,
           ),
           defaultValue: null,
-        ),
+        )
       ],
       type: _i1.NamedTypeNode(
         name: _i1.NameNode(value: 'MainQuestRelationsMutationResponse'),
@@ -5070,7 +5070,7 @@ const mutation_root = _i1.ObjectTypeDefinitionNode(
             isNonNull: true,
           ),
           defaultValue: null,
-        ),
+        )
       ],
       type: _i1.NamedTypeNode(
         name: _i1.NameNode(value: 'MainQuestsMutationResponse'),
@@ -5089,7 +5089,7 @@ const mutation_root = _i1.ObjectTypeDefinitionNode(
             isNonNull: true,
           ),
           defaultValue: null,
-        ),
+        )
       ],
       type: _i1.NamedTypeNode(
         name: _i1.NameNode(value: 'MainQuests'),
@@ -5285,7 +5285,7 @@ const mutation_root = _i1.ObjectTypeDefinitionNode(
             isNonNull: true,
           ),
           defaultValue: null,
-        ),
+        )
       ],
       type: _i1.ListTypeNode(
         type: _i1.NamedTypeNode(
@@ -5366,7 +5366,7 @@ const mutation_root = _i1.ObjectTypeDefinitionNode(
             isNonNull: true,
           ),
           defaultValue: null,
-        ),
+        )
       ],
       type: _i1.ListTypeNode(
         type: _i1.NamedTypeNode(
@@ -5459,7 +5459,7 @@ const query_root = _i1.ObjectTypeDefinitionNode(
             isNonNull: true,
           ),
           defaultValue: null,
-        ),
+        )
       ],
       type: _i1.NamedTypeNode(
         name: _i1.NameNode(value: 'Achievements'),
@@ -5634,7 +5634,7 @@ const query_root = _i1.ObjectTypeDefinitionNode(
             isNonNull: true,
           ),
           defaultValue: null,
-        ),
+        )
       ],
       type: _i1.NamedTypeNode(
         name: _i1.NameNode(value: 'MainQuests'),
@@ -5717,7 +5717,7 @@ const query_root = _i1.ObjectTypeDefinitionNode(
             isNonNull: true,
           ),
           defaultValue: null,
-        ),
+        )
       ],
       type: _i1.NamedTypeNode(
         name: _i1.NameNode(value: 'News'),
@@ -5800,7 +5800,7 @@ const query_root = _i1.ObjectTypeDefinitionNode(
             isNonNull: true,
           ),
           defaultValue: null,
-        ),
+        )
       ],
       type: _i1.NamedTypeNode(
         name: _i1.NameNode(value: 'Notifications'),
@@ -5883,7 +5883,7 @@ const query_root = _i1.ObjectTypeDefinitionNode(
             isNonNull: true,
           ),
           defaultValue: null,
-        ),
+        )
       ],
       type: _i1.NamedTypeNode(
         name: _i1.NameNode(value: 'QuestCategories'),
@@ -5966,7 +5966,7 @@ const query_root = _i1.ObjectTypeDefinitionNode(
             isNonNull: true,
           ),
           defaultValue: null,
-        ),
+        )
       ],
       type: _i1.NamedTypeNode(
         name: _i1.NameNode(value: 'QuestStatus'),
@@ -6049,7 +6049,7 @@ const query_root = _i1.ObjectTypeDefinitionNode(
             isNonNull: true,
           ),
           defaultValue: null,
-        ),
+        )
       ],
       type: _i1.NamedTypeNode(
         name: _i1.NameNode(value: 'Seos'),
@@ -6132,7 +6132,7 @@ const query_root = _i1.ObjectTypeDefinitionNode(
             isNonNull: true,
           ),
           defaultValue: null,
-        ),
+        )
       ],
       type: _i1.NamedTypeNode(
         name: _i1.NameNode(value: 'Tags'),
@@ -6307,7 +6307,7 @@ const query_root = _i1.ObjectTypeDefinitionNode(
             isNonNull: true,
           ),
           defaultValue: null,
-        ),
+        )
       ],
       type: _i1.NamedTypeNode(
         name: _i1.NameNode(value: 'Users'),
@@ -6397,7 +6397,7 @@ const subscription_root = _i1.ObjectTypeDefinitionNode(
             isNonNull: true,
           ),
           defaultValue: null,
-        ),
+        )
       ],
       type: _i1.NamedTypeNode(
         name: _i1.NameNode(value: 'Achievements'),
@@ -6658,7 +6658,7 @@ const subscription_root = _i1.ObjectTypeDefinitionNode(
             isNonNull: true,
           ),
           defaultValue: null,
-        ),
+        )
       ],
       type: _i1.NamedTypeNode(
         name: _i1.NameNode(value: 'MainQuests'),
@@ -6784,7 +6784,7 @@ const subscription_root = _i1.ObjectTypeDefinitionNode(
             isNonNull: true,
           ),
           defaultValue: null,
-        ),
+        )
       ],
       type: _i1.NamedTypeNode(
         name: _i1.NameNode(value: 'News'),
@@ -6910,7 +6910,7 @@ const subscription_root = _i1.ObjectTypeDefinitionNode(
             isNonNull: true,
           ),
           defaultValue: null,
-        ),
+        )
       ],
       type: _i1.NamedTypeNode(
         name: _i1.NameNode(value: 'Notifications'),
@@ -7036,7 +7036,7 @@ const subscription_root = _i1.ObjectTypeDefinitionNode(
             isNonNull: true,
           ),
           defaultValue: null,
-        ),
+        )
       ],
       type: _i1.NamedTypeNode(
         name: _i1.NameNode(value: 'QuestCategories'),
@@ -7162,7 +7162,7 @@ const subscription_root = _i1.ObjectTypeDefinitionNode(
             isNonNull: true,
           ),
           defaultValue: null,
-        ),
+        )
       ],
       type: _i1.NamedTypeNode(
         name: _i1.NameNode(value: 'QuestStatus'),
@@ -7288,7 +7288,7 @@ const subscription_root = _i1.ObjectTypeDefinitionNode(
             isNonNull: true,
           ),
           defaultValue: null,
-        ),
+        )
       ],
       type: _i1.NamedTypeNode(
         name: _i1.NameNode(value: 'Seos'),
@@ -7414,7 +7414,7 @@ const subscription_root = _i1.ObjectTypeDefinitionNode(
             isNonNull: true,
           ),
           defaultValue: null,
-        ),
+        )
       ],
       type: _i1.NamedTypeNode(
         name: _i1.NameNode(value: 'Tags'),
@@ -7675,7 +7675,7 @@ const subscription_root = _i1.ObjectTypeDefinitionNode(
             isNonNull: true,
           ),
           defaultValue: null,
-        ),
+        )
       ],
       type: _i1.NamedTypeNode(
         name: _i1.NameNode(value: 'Users'),
@@ -7735,104 +7735,102 @@ const uuid = _i1.ScalarTypeDefinitionNode(
   name: _i1.NameNode(value: 'uuid'),
   directives: [],
 );
-const document = _i1.DocumentNode(
-  definitions: [
-    schema,
-    cached,
-    Achievements,
-    AchievementsBoolExp,
-    AchievementsOrderBy,
-    AchievementsSelectColumn,
-    AchievementsStreamCursorInput,
-    AchievementsStreamCursorValueInput,
-    CursorOrdering,
-    IntComparisonExp,
-    MainQuestRelations,
-    MainQuestRelationsBoolExp,
-    MainQuestRelationsConstraint,
-    MainQuestRelationsInsertInput,
-    MainQuestRelationsMutationResponse,
-    MainQuestRelationsOnConflict,
-    MainQuestRelationsOrderBy,
-    MainQuestRelationsPkColumnsInput,
-    MainQuestRelationsSelectColumn,
-    MainQuestRelationsSetInput,
-    MainQuestRelationsStreamCursorInput,
-    MainQuestRelationsStreamCursorValueInput,
-    MainQuestRelationsUpdateColumn,
-    MainQuestRelationsUpdates,
-    MainQuests,
-    MainQuestsBoolExp,
-    MainQuestsConstraint,
-    MainQuestsInsertInput,
-    MainQuestsMutationResponse,
-    MainQuestsOnConflict,
-    MainQuestsOrderBy,
-    MainQuestsPkColumnsInput,
-    MainQuestsSelectColumn,
-    MainQuestsSetInput,
-    MainQuestsStreamCursorInput,
-    MainQuestsStreamCursorValueInput,
-    MainQuestsUpdateColumn,
-    MainQuestsUpdates,
-    News,
-    NewsBoolExp,
-    NewsOrderBy,
-    NewsSelectColumn,
-    NewsStreamCursorInput,
-    NewsStreamCursorValueInput,
-    Notifications,
-    NotificationsBoolExp,
-    NotificationsOrderBy,
-    NotificationsSelectColumn,
-    NotificationsStreamCursorInput,
-    NotificationsStreamCursorValueInput,
-    OrderBy,
-    QuestCategories,
-    QuestCategoriesBoolExp,
-    QuestCategoriesOrderBy,
-    QuestCategoriesSelectColumn,
-    QuestCategoriesStreamCursorInput,
-    QuestCategoriesStreamCursorValueInput,
-    QuestStatus,
-    QuestStatusBoolExp,
-    QuestStatusEnum,
-    QuestStatusEnumComparisonExp,
-    QuestStatusOrderBy,
-    QuestStatusSelectColumn,
-    QuestStatusStreamCursorInput,
-    QuestStatusStreamCursorValueInput,
-    Seos,
-    SeosBoolExp,
-    SeosOrderBy,
-    SeosSelectColumn,
-    SeosStreamCursorInput,
-    SeosStreamCursorValueInput,
-    StringComparisonExp,
-    Tags,
-    TagsBoolExp,
-    TagsOrderBy,
-    TagsSelectColumn,
-    TagsStreamCursorInput,
-    TagsStreamCursorValueInput,
-    TimestamptzComparisonExp,
-    UserAchievements,
-    UserAchievementsBoolExp,
-    UserAchievementsOrderBy,
-    UserAchievementsSelectColumn,
-    UserAchievementsStreamCursorInput,
-    UserAchievementsStreamCursorValueInput,
-    Users,
-    UsersBoolExp,
-    UsersOrderBy,
-    UsersSelectColumn,
-    UsersStreamCursorInput,
-    UsersStreamCursorValueInput,
-    UuidComparisonExp,
-    mutation_root,
-    query_root,
-    subscription_root,
-    timestamptz,
-    uuid,
-  ],
-);
+const document = _i1.DocumentNode(definitions: [
+  schema,
+  cached,
+  Achievements,
+  AchievementsBoolExp,
+  AchievementsOrderBy,
+  AchievementsSelectColumn,
+  AchievementsStreamCursorInput,
+  AchievementsStreamCursorValueInput,
+  CursorOrdering,
+  IntComparisonExp,
+  MainQuestRelations,
+  MainQuestRelationsBoolExp,
+  MainQuestRelationsConstraint,
+  MainQuestRelationsInsertInput,
+  MainQuestRelationsMutationResponse,
+  MainQuestRelationsOnConflict,
+  MainQuestRelationsOrderBy,
+  MainQuestRelationsPkColumnsInput,
+  MainQuestRelationsSelectColumn,
+  MainQuestRelationsSetInput,
+  MainQuestRelationsStreamCursorInput,
+  MainQuestRelationsStreamCursorValueInput,
+  MainQuestRelationsUpdateColumn,
+  MainQuestRelationsUpdates,
+  MainQuests,
+  MainQuestsBoolExp,
+  MainQuestsConstraint,
+  MainQuestsInsertInput,
+  MainQuestsMutationResponse,
+  MainQuestsOnConflict,
+  MainQuestsOrderBy,
+  MainQuestsPkColumnsInput,
+  MainQuestsSelectColumn,
+  MainQuestsSetInput,
+  MainQuestsStreamCursorInput,
+  MainQuestsStreamCursorValueInput,
+  MainQuestsUpdateColumn,
+  MainQuestsUpdates,
+  News,
+  NewsBoolExp,
+  NewsOrderBy,
+  NewsSelectColumn,
+  NewsStreamCursorInput,
+  NewsStreamCursorValueInput,
+  Notifications,
+  NotificationsBoolExp,
+  NotificationsOrderBy,
+  NotificationsSelectColumn,
+  NotificationsStreamCursorInput,
+  NotificationsStreamCursorValueInput,
+  OrderBy,
+  QuestCategories,
+  QuestCategoriesBoolExp,
+  QuestCategoriesOrderBy,
+  QuestCategoriesSelectColumn,
+  QuestCategoriesStreamCursorInput,
+  QuestCategoriesStreamCursorValueInput,
+  QuestStatus,
+  QuestStatusBoolExp,
+  QuestStatusEnum,
+  QuestStatusEnumComparisonExp,
+  QuestStatusOrderBy,
+  QuestStatusSelectColumn,
+  QuestStatusStreamCursorInput,
+  QuestStatusStreamCursorValueInput,
+  Seos,
+  SeosBoolExp,
+  SeosOrderBy,
+  SeosSelectColumn,
+  SeosStreamCursorInput,
+  SeosStreamCursorValueInput,
+  StringComparisonExp,
+  Tags,
+  TagsBoolExp,
+  TagsOrderBy,
+  TagsSelectColumn,
+  TagsStreamCursorInput,
+  TagsStreamCursorValueInput,
+  TimestamptzComparisonExp,
+  UserAchievements,
+  UserAchievementsBoolExp,
+  UserAchievementsOrderBy,
+  UserAchievementsSelectColumn,
+  UserAchievementsStreamCursorInput,
+  UserAchievementsStreamCursorValueInput,
+  Users,
+  UsersBoolExp,
+  UsersOrderBy,
+  UsersSelectColumn,
+  UsersStreamCursorInput,
+  UsersStreamCursorValueInput,
+  UuidComparisonExp,
+  mutation_root,
+  query_root,
+  subscription_root,
+  timestamptz,
+  uuid,
+]);

--- a/app/backend/lib/graphql/__generated__/schema.schema.gql.dart
+++ b/app/backend/lib/graphql/__generated__/schema.schema.gql.dart
@@ -13,9 +13,9 @@ abstract class GAchievementsBoolExp
     implements Built<GAchievementsBoolExp, GAchievementsBoolExpBuilder> {
   GAchievementsBoolExp._();
 
-  factory GAchievementsBoolExp([
-    void Function(GAchievementsBoolExpBuilder b) updates,
-  ]) = _$GAchievementsBoolExp;
+  factory GAchievementsBoolExp(
+          [void Function(GAchievementsBoolExpBuilder b) updates]) =
+      _$GAchievementsBoolExp;
 
   @BuiltValueField(wireName: '_and')
   BuiltList<GAchievementsBoolExp>? get G_and;
@@ -31,21 +31,25 @@ abstract class GAchievementsBoolExp
   static Serializer<GAchievementsBoolExp> get serializer =>
       _$gAchievementsBoolExpSerializer;
 
-  Map<String, dynamic> toJson() =>
-      (_i1.serializers.serializeWith(GAchievementsBoolExp.serializer, this)
-          as Map<String, dynamic>);
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GAchievementsBoolExp.serializer,
+        this,
+      ) as Map<String, dynamic>);
 
   static GAchievementsBoolExp? fromJson(Map<String, dynamic> json) =>
-      _i1.serializers.deserializeWith(GAchievementsBoolExp.serializer, json);
+      _i1.serializers.deserializeWith(
+        GAchievementsBoolExp.serializer,
+        json,
+      );
 }
 
 abstract class GAchievementsOrderBy
     implements Built<GAchievementsOrderBy, GAchievementsOrderByBuilder> {
   GAchievementsOrderBy._();
 
-  factory GAchievementsOrderBy([
-    void Function(GAchievementsOrderByBuilder b) updates,
-  ]) = _$GAchievementsOrderBy;
+  factory GAchievementsOrderBy(
+          [void Function(GAchievementsOrderByBuilder b) updates]) =
+      _$GAchievementsOrderBy;
 
   GOrderBy? get createdAt;
   GOrderBy? get description;
@@ -55,12 +59,16 @@ abstract class GAchievementsOrderBy
   static Serializer<GAchievementsOrderBy> get serializer =>
       _$gAchievementsOrderBySerializer;
 
-  Map<String, dynamic> toJson() =>
-      (_i1.serializers.serializeWith(GAchievementsOrderBy.serializer, this)
-          as Map<String, dynamic>);
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GAchievementsOrderBy.serializer,
+        this,
+      ) as Map<String, dynamic>);
 
   static GAchievementsOrderBy? fromJson(Map<String, dynamic> json) =>
-      _i1.serializers.deserializeWith(GAchievementsOrderBy.serializer, json);
+      _i1.serializers.deserializeWith(
+        GAchievementsOrderBy.serializer,
+        json,
+      );
 }
 
 class GAchievementsSelectColumn extends EnumClass {
@@ -93,27 +101,23 @@ class GAchievementsSelectColumn extends EnumClass {
 
 abstract class GAchievementsStreamCursorInput
     implements
-        Built<
-          GAchievementsStreamCursorInput,
-          GAchievementsStreamCursorInputBuilder
-        > {
+        Built<GAchievementsStreamCursorInput,
+            GAchievementsStreamCursorInputBuilder> {
   GAchievementsStreamCursorInput._();
 
-  factory GAchievementsStreamCursorInput([
-    void Function(GAchievementsStreamCursorInputBuilder b) updates,
-  ]) = _$GAchievementsStreamCursorInput;
+  factory GAchievementsStreamCursorInput(
+          [void Function(GAchievementsStreamCursorInputBuilder b) updates]) =
+      _$GAchievementsStreamCursorInput;
 
   GAchievementsStreamCursorValueInput get initialValue;
   GCursorOrdering? get ordering;
   static Serializer<GAchievementsStreamCursorInput> get serializer =>
       _$gAchievementsStreamCursorInputSerializer;
 
-  Map<String, dynamic> toJson() =>
-      (_i1.serializers.serializeWith(
-            GAchievementsStreamCursorInput.serializer,
-            this,
-          )
-          as Map<String, dynamic>);
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GAchievementsStreamCursorInput.serializer,
+        this,
+      ) as Map<String, dynamic>);
 
   static GAchievementsStreamCursorInput? fromJson(Map<String, dynamic> json) =>
       _i1.serializers.deserializeWith(
@@ -124,15 +128,13 @@ abstract class GAchievementsStreamCursorInput
 
 abstract class GAchievementsStreamCursorValueInput
     implements
-        Built<
-          GAchievementsStreamCursorValueInput,
-          GAchievementsStreamCursorValueInputBuilder
-        > {
+        Built<GAchievementsStreamCursorValueInput,
+            GAchievementsStreamCursorValueInputBuilder> {
   GAchievementsStreamCursorValueInput._();
 
-  factory GAchievementsStreamCursorValueInput([
-    void Function(GAchievementsStreamCursorValueInputBuilder b) updates,
-  ]) = _$GAchievementsStreamCursorValueInput;
+  factory GAchievementsStreamCursorValueInput(
+      [void Function(GAchievementsStreamCursorValueInputBuilder b)
+          updates]) = _$GAchievementsStreamCursorValueInput;
 
   DateTime? get createdAt;
   String? get description;
@@ -142,19 +144,17 @@ abstract class GAchievementsStreamCursorValueInput
   static Serializer<GAchievementsStreamCursorValueInput> get serializer =>
       _$gAchievementsStreamCursorValueInputSerializer;
 
-  Map<String, dynamic> toJson() =>
-      (_i1.serializers.serializeWith(
-            GAchievementsStreamCursorValueInput.serializer,
-            this,
-          )
-          as Map<String, dynamic>);
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GAchievementsStreamCursorValueInput.serializer,
+        this,
+      ) as Map<String, dynamic>);
 
   static GAchievementsStreamCursorValueInput? fromJson(
-    Map<String, dynamic> json,
-  ) => _i1.serializers.deserializeWith(
-    GAchievementsStreamCursorValueInput.serializer,
-    json,
-  );
+          Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GAchievementsStreamCursorValueInput.serializer,
+        json,
+      );
 }
 
 class GCursorOrdering extends EnumClass {
@@ -176,9 +176,9 @@ abstract class GIntComparisonExp
     implements Built<GIntComparisonExp, GIntComparisonExpBuilder> {
   GIntComparisonExp._();
 
-  factory GIntComparisonExp([
-    void Function(GIntComparisonExpBuilder b) updates,
-  ]) = _$GIntComparisonExp;
+  factory GIntComparisonExp(
+          [void Function(GIntComparisonExpBuilder b) updates]) =
+      _$GIntComparisonExp;
 
   @BuiltValueField(wireName: '_eq')
   int? get G_eq;
@@ -201,12 +201,16 @@ abstract class GIntComparisonExp
   static Serializer<GIntComparisonExp> get serializer =>
       _$gIntComparisonExpSerializer;
 
-  Map<String, dynamic> toJson() =>
-      (_i1.serializers.serializeWith(GIntComparisonExp.serializer, this)
-          as Map<String, dynamic>);
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GIntComparisonExp.serializer,
+        this,
+      ) as Map<String, dynamic>);
 
   static GIntComparisonExp? fromJson(Map<String, dynamic> json) =>
-      _i1.serializers.deserializeWith(GIntComparisonExp.serializer, json);
+      _i1.serializers.deserializeWith(
+        GIntComparisonExp.serializer,
+        json,
+      );
 }
 
 abstract class GMainQuestRelationsBoolExp
@@ -214,9 +218,9 @@ abstract class GMainQuestRelationsBoolExp
         Built<GMainQuestRelationsBoolExp, GMainQuestRelationsBoolExpBuilder> {
   GMainQuestRelationsBoolExp._();
 
-  factory GMainQuestRelationsBoolExp([
-    void Function(GMainQuestRelationsBoolExpBuilder b) updates,
-  ]) = _$GMainQuestRelationsBoolExp;
+  factory GMainQuestRelationsBoolExp(
+          [void Function(GMainQuestRelationsBoolExpBuilder b) updates]) =
+      _$GMainQuestRelationsBoolExp;
 
   @BuiltValueField(wireName: '_and')
   BuiltList<GMainQuestRelationsBoolExp>? get G_and;
@@ -229,16 +233,16 @@ abstract class GMainQuestRelationsBoolExp
   static Serializer<GMainQuestRelationsBoolExp> get serializer =>
       _$gMainQuestRelationsBoolExpSerializer;
 
-  Map<String, dynamic> toJson() =>
-      (_i1.serializers.serializeWith(
-            GMainQuestRelationsBoolExp.serializer,
-            this,
-          )
-          as Map<String, dynamic>);
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GMainQuestRelationsBoolExp.serializer,
+        this,
+      ) as Map<String, dynamic>);
 
-  static GMainQuestRelationsBoolExp? fromJson(Map<String, dynamic> json) => _i1
-      .serializers
-      .deserializeWith(GMainQuestRelationsBoolExp.serializer, json);
+  static GMainQuestRelationsBoolExp? fromJson(Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GMainQuestRelationsBoolExp.serializer,
+        json,
+      );
 }
 
 class GMainQuestRelationsConstraint extends EnumClass {
@@ -259,27 +263,23 @@ class GMainQuestRelationsConstraint extends EnumClass {
 
 abstract class GMainQuestRelationsInsertInput
     implements
-        Built<
-          GMainQuestRelationsInsertInput,
-          GMainQuestRelationsInsertInputBuilder
-        > {
+        Built<GMainQuestRelationsInsertInput,
+            GMainQuestRelationsInsertInputBuilder> {
   GMainQuestRelationsInsertInput._();
 
-  factory GMainQuestRelationsInsertInput([
-    void Function(GMainQuestRelationsInsertInputBuilder b) updates,
-  ]) = _$GMainQuestRelationsInsertInput;
+  factory GMainQuestRelationsInsertInput(
+          [void Function(GMainQuestRelationsInsertInputBuilder b) updates]) =
+      _$GMainQuestRelationsInsertInput;
 
   String? get childQuestId;
   String? get parentQuestId;
   static Serializer<GMainQuestRelationsInsertInput> get serializer =>
       _$gMainQuestRelationsInsertInputSerializer;
 
-  Map<String, dynamic> toJson() =>
-      (_i1.serializers.serializeWith(
-            GMainQuestRelationsInsertInput.serializer,
-            this,
-          )
-          as Map<String, dynamic>);
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GMainQuestRelationsInsertInput.serializer,
+        this,
+      ) as Map<String, dynamic>);
 
   static GMainQuestRelationsInsertInput? fromJson(Map<String, dynamic> json) =>
       _i1.serializers.deserializeWith(
@@ -290,15 +290,13 @@ abstract class GMainQuestRelationsInsertInput
 
 abstract class GMainQuestRelationsOnConflict
     implements
-        Built<
-          GMainQuestRelationsOnConflict,
-          GMainQuestRelationsOnConflictBuilder
-        > {
+        Built<GMainQuestRelationsOnConflict,
+            GMainQuestRelationsOnConflictBuilder> {
   GMainQuestRelationsOnConflict._();
 
-  factory GMainQuestRelationsOnConflict([
-    void Function(GMainQuestRelationsOnConflictBuilder b) updates,
-  ]) = _$GMainQuestRelationsOnConflict;
+  factory GMainQuestRelationsOnConflict(
+          [void Function(GMainQuestRelationsOnConflictBuilder b) updates]) =
+      _$GMainQuestRelationsOnConflict;
 
   GMainQuestRelationsConstraint get constraint;
   BuiltList<GMainQuestRelationsUpdateColumn> get updateColumns;
@@ -306,12 +304,10 @@ abstract class GMainQuestRelationsOnConflict
   static Serializer<GMainQuestRelationsOnConflict> get serializer =>
       _$gMainQuestRelationsOnConflictSerializer;
 
-  Map<String, dynamic> toJson() =>
-      (_i1.serializers.serializeWith(
-            GMainQuestRelationsOnConflict.serializer,
-            this,
-          )
-          as Map<String, dynamic>);
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GMainQuestRelationsOnConflict.serializer,
+        this,
+      ) as Map<String, dynamic>);
 
   static GMainQuestRelationsOnConflict? fromJson(Map<String, dynamic> json) =>
       _i1.serializers.deserializeWith(
@@ -325,57 +321,53 @@ abstract class GMainQuestRelationsOrderBy
         Built<GMainQuestRelationsOrderBy, GMainQuestRelationsOrderByBuilder> {
   GMainQuestRelationsOrderBy._();
 
-  factory GMainQuestRelationsOrderBy([
-    void Function(GMainQuestRelationsOrderByBuilder b) updates,
-  ]) = _$GMainQuestRelationsOrderBy;
+  factory GMainQuestRelationsOrderBy(
+          [void Function(GMainQuestRelationsOrderByBuilder b) updates]) =
+      _$GMainQuestRelationsOrderBy;
 
   GOrderBy? get childQuestId;
   GOrderBy? get parentQuestId;
   static Serializer<GMainQuestRelationsOrderBy> get serializer =>
       _$gMainQuestRelationsOrderBySerializer;
 
-  Map<String, dynamic> toJson() =>
-      (_i1.serializers.serializeWith(
-            GMainQuestRelationsOrderBy.serializer,
-            this,
-          )
-          as Map<String, dynamic>);
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GMainQuestRelationsOrderBy.serializer,
+        this,
+      ) as Map<String, dynamic>);
 
-  static GMainQuestRelationsOrderBy? fromJson(Map<String, dynamic> json) => _i1
-      .serializers
-      .deserializeWith(GMainQuestRelationsOrderBy.serializer, json);
+  static GMainQuestRelationsOrderBy? fromJson(Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GMainQuestRelationsOrderBy.serializer,
+        json,
+      );
 }
 
 abstract class GMainQuestRelationsPkColumnsInput
     implements
-        Built<
-          GMainQuestRelationsPkColumnsInput,
-          GMainQuestRelationsPkColumnsInputBuilder
-        > {
+        Built<GMainQuestRelationsPkColumnsInput,
+            GMainQuestRelationsPkColumnsInputBuilder> {
   GMainQuestRelationsPkColumnsInput._();
 
-  factory GMainQuestRelationsPkColumnsInput([
-    void Function(GMainQuestRelationsPkColumnsInputBuilder b) updates,
-  ]) = _$GMainQuestRelationsPkColumnsInput;
+  factory GMainQuestRelationsPkColumnsInput(
+          [void Function(GMainQuestRelationsPkColumnsInputBuilder b) updates]) =
+      _$GMainQuestRelationsPkColumnsInput;
 
   String get childQuestId;
   String get parentQuestId;
   static Serializer<GMainQuestRelationsPkColumnsInput> get serializer =>
       _$gMainQuestRelationsPkColumnsInputSerializer;
 
-  Map<String, dynamic> toJson() =>
-      (_i1.serializers.serializeWith(
-            GMainQuestRelationsPkColumnsInput.serializer,
-            this,
-          )
-          as Map<String, dynamic>);
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GMainQuestRelationsPkColumnsInput.serializer,
+        this,
+      ) as Map<String, dynamic>);
 
   static GMainQuestRelationsPkColumnsInput? fromJson(
-    Map<String, dynamic> json,
-  ) => _i1.serializers.deserializeWith(
-    GMainQuestRelationsPkColumnsInput.serializer,
-    json,
-  );
+          Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GMainQuestRelationsPkColumnsInput.serializer,
+        json,
+      );
 }
 
 class GMainQuestRelationsSelectColumn extends EnumClass {
@@ -402,89 +394,81 @@ abstract class GMainQuestRelationsSetInput
         Built<GMainQuestRelationsSetInput, GMainQuestRelationsSetInputBuilder> {
   GMainQuestRelationsSetInput._();
 
-  factory GMainQuestRelationsSetInput([
-    void Function(GMainQuestRelationsSetInputBuilder b) updates,
-  ]) = _$GMainQuestRelationsSetInput;
+  factory GMainQuestRelationsSetInput(
+          [void Function(GMainQuestRelationsSetInputBuilder b) updates]) =
+      _$GMainQuestRelationsSetInput;
 
   String? get childQuestId;
   String? get parentQuestId;
   static Serializer<GMainQuestRelationsSetInput> get serializer =>
       _$gMainQuestRelationsSetInputSerializer;
 
-  Map<String, dynamic> toJson() =>
-      (_i1.serializers.serializeWith(
-            GMainQuestRelationsSetInput.serializer,
-            this,
-          )
-          as Map<String, dynamic>);
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GMainQuestRelationsSetInput.serializer,
+        this,
+      ) as Map<String, dynamic>);
 
-  static GMainQuestRelationsSetInput? fromJson(Map<String, dynamic> json) => _i1
-      .serializers
-      .deserializeWith(GMainQuestRelationsSetInput.serializer, json);
+  static GMainQuestRelationsSetInput? fromJson(Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GMainQuestRelationsSetInput.serializer,
+        json,
+      );
 }
 
 abstract class GMainQuestRelationsStreamCursorInput
     implements
-        Built<
-          GMainQuestRelationsStreamCursorInput,
-          GMainQuestRelationsStreamCursorInputBuilder
-        > {
+        Built<GMainQuestRelationsStreamCursorInput,
+            GMainQuestRelationsStreamCursorInputBuilder> {
   GMainQuestRelationsStreamCursorInput._();
 
-  factory GMainQuestRelationsStreamCursorInput([
-    void Function(GMainQuestRelationsStreamCursorInputBuilder b) updates,
-  ]) = _$GMainQuestRelationsStreamCursorInput;
+  factory GMainQuestRelationsStreamCursorInput(
+      [void Function(GMainQuestRelationsStreamCursorInputBuilder b)
+          updates]) = _$GMainQuestRelationsStreamCursorInput;
 
   GMainQuestRelationsStreamCursorValueInput get initialValue;
   GCursorOrdering? get ordering;
   static Serializer<GMainQuestRelationsStreamCursorInput> get serializer =>
       _$gMainQuestRelationsStreamCursorInputSerializer;
 
-  Map<String, dynamic> toJson() =>
-      (_i1.serializers.serializeWith(
-            GMainQuestRelationsStreamCursorInput.serializer,
-            this,
-          )
-          as Map<String, dynamic>);
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GMainQuestRelationsStreamCursorInput.serializer,
+        this,
+      ) as Map<String, dynamic>);
 
   static GMainQuestRelationsStreamCursorInput? fromJson(
-    Map<String, dynamic> json,
-  ) => _i1.serializers.deserializeWith(
-    GMainQuestRelationsStreamCursorInput.serializer,
-    json,
-  );
+          Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GMainQuestRelationsStreamCursorInput.serializer,
+        json,
+      );
 }
 
 abstract class GMainQuestRelationsStreamCursorValueInput
     implements
-        Built<
-          GMainQuestRelationsStreamCursorValueInput,
-          GMainQuestRelationsStreamCursorValueInputBuilder
-        > {
+        Built<GMainQuestRelationsStreamCursorValueInput,
+            GMainQuestRelationsStreamCursorValueInputBuilder> {
   GMainQuestRelationsStreamCursorValueInput._();
 
-  factory GMainQuestRelationsStreamCursorValueInput([
-    void Function(GMainQuestRelationsStreamCursorValueInputBuilder b) updates,
-  ]) = _$GMainQuestRelationsStreamCursorValueInput;
+  factory GMainQuestRelationsStreamCursorValueInput(
+      [void Function(GMainQuestRelationsStreamCursorValueInputBuilder b)
+          updates]) = _$GMainQuestRelationsStreamCursorValueInput;
 
   String? get childQuestId;
   String? get parentQuestId;
   static Serializer<GMainQuestRelationsStreamCursorValueInput> get serializer =>
       _$gMainQuestRelationsStreamCursorValueInputSerializer;
 
-  Map<String, dynamic> toJson() =>
-      (_i1.serializers.serializeWith(
-            GMainQuestRelationsStreamCursorValueInput.serializer,
-            this,
-          )
-          as Map<String, dynamic>);
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GMainQuestRelationsStreamCursorValueInput.serializer,
+        this,
+      ) as Map<String, dynamic>);
 
   static GMainQuestRelationsStreamCursorValueInput? fromJson(
-    Map<String, dynamic> json,
-  ) => _i1.serializers.deserializeWith(
-    GMainQuestRelationsStreamCursorValueInput.serializer,
-    json,
-  );
+          Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GMainQuestRelationsStreamCursorValueInput.serializer,
+        json,
+      );
 }
 
 class GMainQuestRelationsUpdateColumn extends EnumClass {
@@ -511,9 +495,9 @@ abstract class GMainQuestRelationsUpdates
         Built<GMainQuestRelationsUpdates, GMainQuestRelationsUpdatesBuilder> {
   GMainQuestRelationsUpdates._();
 
-  factory GMainQuestRelationsUpdates([
-    void Function(GMainQuestRelationsUpdatesBuilder b) updates,
-  ]) = _$GMainQuestRelationsUpdates;
+  factory GMainQuestRelationsUpdates(
+          [void Function(GMainQuestRelationsUpdatesBuilder b) updates]) =
+      _$GMainQuestRelationsUpdates;
 
   @BuiltValueField(wireName: '_set')
   GMainQuestRelationsSetInput? get G_set;
@@ -521,25 +505,25 @@ abstract class GMainQuestRelationsUpdates
   static Serializer<GMainQuestRelationsUpdates> get serializer =>
       _$gMainQuestRelationsUpdatesSerializer;
 
-  Map<String, dynamic> toJson() =>
-      (_i1.serializers.serializeWith(
-            GMainQuestRelationsUpdates.serializer,
-            this,
-          )
-          as Map<String, dynamic>);
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GMainQuestRelationsUpdates.serializer,
+        this,
+      ) as Map<String, dynamic>);
 
-  static GMainQuestRelationsUpdates? fromJson(Map<String, dynamic> json) => _i1
-      .serializers
-      .deserializeWith(GMainQuestRelationsUpdates.serializer, json);
+  static GMainQuestRelationsUpdates? fromJson(Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GMainQuestRelationsUpdates.serializer,
+        json,
+      );
 }
 
 abstract class GMainQuestsBoolExp
     implements Built<GMainQuestsBoolExp, GMainQuestsBoolExpBuilder> {
   GMainQuestsBoolExp._();
 
-  factory GMainQuestsBoolExp([
-    void Function(GMainQuestsBoolExpBuilder b) updates,
-  ]) = _$GMainQuestsBoolExp;
+  factory GMainQuestsBoolExp(
+          [void Function(GMainQuestsBoolExpBuilder b) updates]) =
+      _$GMainQuestsBoolExp;
 
   @BuiltValueField(wireName: '_and')
   BuiltList<GMainQuestsBoolExp>? get G_and;
@@ -563,12 +547,16 @@ abstract class GMainQuestsBoolExp
   static Serializer<GMainQuestsBoolExp> get serializer =>
       _$gMainQuestsBoolExpSerializer;
 
-  Map<String, dynamic> toJson() =>
-      (_i1.serializers.serializeWith(GMainQuestsBoolExp.serializer, this)
-          as Map<String, dynamic>);
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GMainQuestsBoolExp.serializer,
+        this,
+      ) as Map<String, dynamic>);
 
   static GMainQuestsBoolExp? fromJson(Map<String, dynamic> json) =>
-      _i1.serializers.deserializeWith(GMainQuestsBoolExp.serializer, json);
+      _i1.serializers.deserializeWith(
+        GMainQuestsBoolExp.serializer,
+        json,
+      );
 }
 
 class GMainQuestsConstraint extends EnumClass {
@@ -591,9 +579,9 @@ abstract class GMainQuestsInsertInput
     implements Built<GMainQuestsInsertInput, GMainQuestsInsertInputBuilder> {
   GMainQuestsInsertInput._();
 
-  factory GMainQuestsInsertInput([
-    void Function(GMainQuestsInsertInputBuilder b) updates,
-  ]) = _$GMainQuestsInsertInput;
+  factory GMainQuestsInsertInput(
+          [void Function(GMainQuestsInsertInputBuilder b) updates]) =
+      _$GMainQuestsInsertInput;
 
   DateTime? get begunAt;
   String? get categoryId;
@@ -611,21 +599,25 @@ abstract class GMainQuestsInsertInput
   static Serializer<GMainQuestsInsertInput> get serializer =>
       _$gMainQuestsInsertInputSerializer;
 
-  Map<String, dynamic> toJson() =>
-      (_i1.serializers.serializeWith(GMainQuestsInsertInput.serializer, this)
-          as Map<String, dynamic>);
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GMainQuestsInsertInput.serializer,
+        this,
+      ) as Map<String, dynamic>);
 
   static GMainQuestsInsertInput? fromJson(Map<String, dynamic> json) =>
-      _i1.serializers.deserializeWith(GMainQuestsInsertInput.serializer, json);
+      _i1.serializers.deserializeWith(
+        GMainQuestsInsertInput.serializer,
+        json,
+      );
 }
 
 abstract class GMainQuestsOnConflict
     implements Built<GMainQuestsOnConflict, GMainQuestsOnConflictBuilder> {
   GMainQuestsOnConflict._();
 
-  factory GMainQuestsOnConflict([
-    void Function(GMainQuestsOnConflictBuilder b) updates,
-  ]) = _$GMainQuestsOnConflict;
+  factory GMainQuestsOnConflict(
+          [void Function(GMainQuestsOnConflictBuilder b) updates]) =
+      _$GMainQuestsOnConflict;
 
   GMainQuestsConstraint get constraint;
   BuiltList<GMainQuestsUpdateColumn> get updateColumns;
@@ -633,21 +625,25 @@ abstract class GMainQuestsOnConflict
   static Serializer<GMainQuestsOnConflict> get serializer =>
       _$gMainQuestsOnConflictSerializer;
 
-  Map<String, dynamic> toJson() =>
-      (_i1.serializers.serializeWith(GMainQuestsOnConflict.serializer, this)
-          as Map<String, dynamic>);
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GMainQuestsOnConflict.serializer,
+        this,
+      ) as Map<String, dynamic>);
 
   static GMainQuestsOnConflict? fromJson(Map<String, dynamic> json) =>
-      _i1.serializers.deserializeWith(GMainQuestsOnConflict.serializer, json);
+      _i1.serializers.deserializeWith(
+        GMainQuestsOnConflict.serializer,
+        json,
+      );
 }
 
 abstract class GMainQuestsOrderBy
     implements Built<GMainQuestsOrderBy, GMainQuestsOrderByBuilder> {
   GMainQuestsOrderBy._();
 
-  factory GMainQuestsOrderBy([
-    void Function(GMainQuestsOrderByBuilder b) updates,
-  ]) = _$GMainQuestsOrderBy;
+  factory GMainQuestsOrderBy(
+          [void Function(GMainQuestsOrderByBuilder b) updates]) =
+      _$GMainQuestsOrderBy;
 
   GOrderBy? get begunAt;
   GOrderBy? get categoryId;
@@ -665,12 +661,16 @@ abstract class GMainQuestsOrderBy
   static Serializer<GMainQuestsOrderBy> get serializer =>
       _$gMainQuestsOrderBySerializer;
 
-  Map<String, dynamic> toJson() =>
-      (_i1.serializers.serializeWith(GMainQuestsOrderBy.serializer, this)
-          as Map<String, dynamic>);
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GMainQuestsOrderBy.serializer,
+        this,
+      ) as Map<String, dynamic>);
 
   static GMainQuestsOrderBy? fromJson(Map<String, dynamic> json) =>
-      _i1.serializers.deserializeWith(GMainQuestsOrderBy.serializer, json);
+      _i1.serializers.deserializeWith(
+        GMainQuestsOrderBy.serializer,
+        json,
+      );
 }
 
 abstract class GMainQuestsPkColumnsInput
@@ -678,21 +678,24 @@ abstract class GMainQuestsPkColumnsInput
         Built<GMainQuestsPkColumnsInput, GMainQuestsPkColumnsInputBuilder> {
   GMainQuestsPkColumnsInput._();
 
-  factory GMainQuestsPkColumnsInput([
-    void Function(GMainQuestsPkColumnsInputBuilder b) updates,
-  ]) = _$GMainQuestsPkColumnsInput;
+  factory GMainQuestsPkColumnsInput(
+          [void Function(GMainQuestsPkColumnsInputBuilder b) updates]) =
+      _$GMainQuestsPkColumnsInput;
 
   String get id;
   static Serializer<GMainQuestsPkColumnsInput> get serializer =>
       _$gMainQuestsPkColumnsInputSerializer;
 
-  Map<String, dynamic> toJson() =>
-      (_i1.serializers.serializeWith(GMainQuestsPkColumnsInput.serializer, this)
-          as Map<String, dynamic>);
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GMainQuestsPkColumnsInput.serializer,
+        this,
+      ) as Map<String, dynamic>);
 
-  static GMainQuestsPkColumnsInput? fromJson(Map<String, dynamic> json) => _i1
-      .serializers
-      .deserializeWith(GMainQuestsPkColumnsInput.serializer, json);
+  static GMainQuestsPkColumnsInput? fromJson(Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GMainQuestsPkColumnsInput.serializer,
+        json,
+      );
 }
 
 class GMainQuestsSelectColumn extends EnumClass {
@@ -746,9 +749,9 @@ abstract class GMainQuestsSetInput
     implements Built<GMainQuestsSetInput, GMainQuestsSetInputBuilder> {
   GMainQuestsSetInput._();
 
-  factory GMainQuestsSetInput([
-    void Function(GMainQuestsSetInputBuilder b) updates,
-  ]) = _$GMainQuestsSetInput;
+  factory GMainQuestsSetInput(
+          [void Function(GMainQuestsSetInputBuilder b) updates]) =
+      _$GMainQuestsSetInput;
 
   DateTime? get begunAt;
   String? get categoryId;
@@ -766,37 +769,37 @@ abstract class GMainQuestsSetInput
   static Serializer<GMainQuestsSetInput> get serializer =>
       _$gMainQuestsSetInputSerializer;
 
-  Map<String, dynamic> toJson() =>
-      (_i1.serializers.serializeWith(GMainQuestsSetInput.serializer, this)
-          as Map<String, dynamic>);
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GMainQuestsSetInput.serializer,
+        this,
+      ) as Map<String, dynamic>);
 
   static GMainQuestsSetInput? fromJson(Map<String, dynamic> json) =>
-      _i1.serializers.deserializeWith(GMainQuestsSetInput.serializer, json);
+      _i1.serializers.deserializeWith(
+        GMainQuestsSetInput.serializer,
+        json,
+      );
 }
 
 abstract class GMainQuestsStreamCursorInput
     implements
-        Built<
-          GMainQuestsStreamCursorInput,
-          GMainQuestsStreamCursorInputBuilder
-        > {
+        Built<GMainQuestsStreamCursorInput,
+            GMainQuestsStreamCursorInputBuilder> {
   GMainQuestsStreamCursorInput._();
 
-  factory GMainQuestsStreamCursorInput([
-    void Function(GMainQuestsStreamCursorInputBuilder b) updates,
-  ]) = _$GMainQuestsStreamCursorInput;
+  factory GMainQuestsStreamCursorInput(
+          [void Function(GMainQuestsStreamCursorInputBuilder b) updates]) =
+      _$GMainQuestsStreamCursorInput;
 
   GMainQuestsStreamCursorValueInput get initialValue;
   GCursorOrdering? get ordering;
   static Serializer<GMainQuestsStreamCursorInput> get serializer =>
       _$gMainQuestsStreamCursorInputSerializer;
 
-  Map<String, dynamic> toJson() =>
-      (_i1.serializers.serializeWith(
-            GMainQuestsStreamCursorInput.serializer,
-            this,
-          )
-          as Map<String, dynamic>);
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GMainQuestsStreamCursorInput.serializer,
+        this,
+      ) as Map<String, dynamic>);
 
   static GMainQuestsStreamCursorInput? fromJson(Map<String, dynamic> json) =>
       _i1.serializers.deserializeWith(
@@ -807,15 +810,13 @@ abstract class GMainQuestsStreamCursorInput
 
 abstract class GMainQuestsStreamCursorValueInput
     implements
-        Built<
-          GMainQuestsStreamCursorValueInput,
-          GMainQuestsStreamCursorValueInputBuilder
-        > {
+        Built<GMainQuestsStreamCursorValueInput,
+            GMainQuestsStreamCursorValueInputBuilder> {
   GMainQuestsStreamCursorValueInput._();
 
-  factory GMainQuestsStreamCursorValueInput([
-    void Function(GMainQuestsStreamCursorValueInputBuilder b) updates,
-  ]) = _$GMainQuestsStreamCursorValueInput;
+  factory GMainQuestsStreamCursorValueInput(
+          [void Function(GMainQuestsStreamCursorValueInputBuilder b) updates]) =
+      _$GMainQuestsStreamCursorValueInput;
 
   DateTime? get begunAt;
   String? get categoryId;
@@ -833,19 +834,17 @@ abstract class GMainQuestsStreamCursorValueInput
   static Serializer<GMainQuestsStreamCursorValueInput> get serializer =>
       _$gMainQuestsStreamCursorValueInputSerializer;
 
-  Map<String, dynamic> toJson() =>
-      (_i1.serializers.serializeWith(
-            GMainQuestsStreamCursorValueInput.serializer,
-            this,
-          )
-          as Map<String, dynamic>);
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GMainQuestsStreamCursorValueInput.serializer,
+        this,
+      ) as Map<String, dynamic>);
 
   static GMainQuestsStreamCursorValueInput? fromJson(
-    Map<String, dynamic> json,
-  ) => _i1.serializers.deserializeWith(
-    GMainQuestsStreamCursorValueInput.serializer,
-    json,
-  );
+          Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GMainQuestsStreamCursorValueInput.serializer,
+        json,
+      );
 }
 
 class GMainQuestsUpdateColumn extends EnumClass {
@@ -899,9 +898,9 @@ abstract class GMainQuestsUpdates
     implements Built<GMainQuestsUpdates, GMainQuestsUpdatesBuilder> {
   GMainQuestsUpdates._();
 
-  factory GMainQuestsUpdates([
-    void Function(GMainQuestsUpdatesBuilder b) updates,
-  ]) = _$GMainQuestsUpdates;
+  factory GMainQuestsUpdates(
+          [void Function(GMainQuestsUpdatesBuilder b) updates]) =
+      _$GMainQuestsUpdates;
 
   @BuiltValueField(wireName: '_set')
   GMainQuestsSetInput? get G_set;
@@ -909,12 +908,16 @@ abstract class GMainQuestsUpdates
   static Serializer<GMainQuestsUpdates> get serializer =>
       _$gMainQuestsUpdatesSerializer;
 
-  Map<String, dynamic> toJson() =>
-      (_i1.serializers.serializeWith(GMainQuestsUpdates.serializer, this)
-          as Map<String, dynamic>);
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GMainQuestsUpdates.serializer,
+        this,
+      ) as Map<String, dynamic>);
 
   static GMainQuestsUpdates? fromJson(Map<String, dynamic> json) =>
-      _i1.serializers.deserializeWith(GMainQuestsUpdates.serializer, json);
+      _i1.serializers.deserializeWith(
+        GMainQuestsUpdates.serializer,
+        json,
+      );
 }
 
 abstract class GNewsBoolExp
@@ -943,12 +946,16 @@ abstract class GNewsBoolExp
   GTimestamptzComparisonExp? get updatedAt;
   static Serializer<GNewsBoolExp> get serializer => _$gNewsBoolExpSerializer;
 
-  Map<String, dynamic> toJson() =>
-      (_i1.serializers.serializeWith(GNewsBoolExp.serializer, this)
-          as Map<String, dynamic>);
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GNewsBoolExp.serializer,
+        this,
+      ) as Map<String, dynamic>);
 
   static GNewsBoolExp? fromJson(Map<String, dynamic> json) =>
-      _i1.serializers.deserializeWith(GNewsBoolExp.serializer, json);
+      _i1.serializers.deserializeWith(
+        GNewsBoolExp.serializer,
+        json,
+      );
 }
 
 abstract class GNewsOrderBy
@@ -971,12 +978,16 @@ abstract class GNewsOrderBy
   GOrderBy? get updatedAt;
   static Serializer<GNewsOrderBy> get serializer => _$gNewsOrderBySerializer;
 
-  Map<String, dynamic> toJson() =>
-      (_i1.serializers.serializeWith(GNewsOrderBy.serializer, this)
-          as Map<String, dynamic>);
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GNewsOrderBy.serializer,
+        this,
+      ) as Map<String, dynamic>);
 
   static GNewsOrderBy? fromJson(Map<String, dynamic> json) =>
-      _i1.serializers.deserializeWith(GNewsOrderBy.serializer, json);
+      _i1.serializers.deserializeWith(
+        GNewsOrderBy.serializer,
+        json,
+      );
 }
 
 class GNewsSelectColumn extends EnumClass {
@@ -1016,21 +1027,25 @@ abstract class GNewsStreamCursorInput
     implements Built<GNewsStreamCursorInput, GNewsStreamCursorInputBuilder> {
   GNewsStreamCursorInput._();
 
-  factory GNewsStreamCursorInput([
-    void Function(GNewsStreamCursorInputBuilder b) updates,
-  ]) = _$GNewsStreamCursorInput;
+  factory GNewsStreamCursorInput(
+          [void Function(GNewsStreamCursorInputBuilder b) updates]) =
+      _$GNewsStreamCursorInput;
 
   GNewsStreamCursorValueInput get initialValue;
   GCursorOrdering? get ordering;
   static Serializer<GNewsStreamCursorInput> get serializer =>
       _$gNewsStreamCursorInputSerializer;
 
-  Map<String, dynamic> toJson() =>
-      (_i1.serializers.serializeWith(GNewsStreamCursorInput.serializer, this)
-          as Map<String, dynamic>);
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GNewsStreamCursorInput.serializer,
+        this,
+      ) as Map<String, dynamic>);
 
   static GNewsStreamCursorInput? fromJson(Map<String, dynamic> json) =>
-      _i1.serializers.deserializeWith(GNewsStreamCursorInput.serializer, json);
+      _i1.serializers.deserializeWith(
+        GNewsStreamCursorInput.serializer,
+        json,
+      );
 }
 
 abstract class GNewsStreamCursorValueInput
@@ -1038,9 +1053,9 @@ abstract class GNewsStreamCursorValueInput
         Built<GNewsStreamCursorValueInput, GNewsStreamCursorValueInputBuilder> {
   GNewsStreamCursorValueInput._();
 
-  factory GNewsStreamCursorValueInput([
-    void Function(GNewsStreamCursorValueInputBuilder b) updates,
-  ]) = _$GNewsStreamCursorValueInput;
+  factory GNewsStreamCursorValueInput(
+          [void Function(GNewsStreamCursorValueInputBuilder b) updates]) =
+      _$GNewsStreamCursorValueInput;
 
   String? get content;
   String? get coverImageUrl;
@@ -1055,25 +1070,25 @@ abstract class GNewsStreamCursorValueInput
   static Serializer<GNewsStreamCursorValueInput> get serializer =>
       _$gNewsStreamCursorValueInputSerializer;
 
-  Map<String, dynamic> toJson() =>
-      (_i1.serializers.serializeWith(
-            GNewsStreamCursorValueInput.serializer,
-            this,
-          )
-          as Map<String, dynamic>);
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GNewsStreamCursorValueInput.serializer,
+        this,
+      ) as Map<String, dynamic>);
 
-  static GNewsStreamCursorValueInput? fromJson(Map<String, dynamic> json) => _i1
-      .serializers
-      .deserializeWith(GNewsStreamCursorValueInput.serializer, json);
+  static GNewsStreamCursorValueInput? fromJson(Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GNewsStreamCursorValueInput.serializer,
+        json,
+      );
 }
 
 abstract class GNotificationsBoolExp
     implements Built<GNotificationsBoolExp, GNotificationsBoolExpBuilder> {
   GNotificationsBoolExp._();
 
-  factory GNotificationsBoolExp([
-    void Function(GNotificationsBoolExpBuilder b) updates,
-  ]) = _$GNotificationsBoolExp;
+  factory GNotificationsBoolExp(
+          [void Function(GNotificationsBoolExpBuilder b) updates]) =
+      _$GNotificationsBoolExp;
 
   @BuiltValueField(wireName: '_and')
   BuiltList<GNotificationsBoolExp>? get G_and;
@@ -1094,21 +1109,25 @@ abstract class GNotificationsBoolExp
   static Serializer<GNotificationsBoolExp> get serializer =>
       _$gNotificationsBoolExpSerializer;
 
-  Map<String, dynamic> toJson() =>
-      (_i1.serializers.serializeWith(GNotificationsBoolExp.serializer, this)
-          as Map<String, dynamic>);
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GNotificationsBoolExp.serializer,
+        this,
+      ) as Map<String, dynamic>);
 
   static GNotificationsBoolExp? fromJson(Map<String, dynamic> json) =>
-      _i1.serializers.deserializeWith(GNotificationsBoolExp.serializer, json);
+      _i1.serializers.deserializeWith(
+        GNotificationsBoolExp.serializer,
+        json,
+      );
 }
 
 abstract class GNotificationsOrderBy
     implements Built<GNotificationsOrderBy, GNotificationsOrderByBuilder> {
   GNotificationsOrderBy._();
 
-  factory GNotificationsOrderBy([
-    void Function(GNotificationsOrderByBuilder b) updates,
-  ]) = _$GNotificationsOrderBy;
+  factory GNotificationsOrderBy(
+          [void Function(GNotificationsOrderByBuilder b) updates]) =
+      _$GNotificationsOrderBy;
 
   GOrderBy? get content;
   GOrderBy? get coverImageUrl;
@@ -1123,12 +1142,16 @@ abstract class GNotificationsOrderBy
   static Serializer<GNotificationsOrderBy> get serializer =>
       _$gNotificationsOrderBySerializer;
 
-  Map<String, dynamic> toJson() =>
-      (_i1.serializers.serializeWith(GNotificationsOrderBy.serializer, this)
-          as Map<String, dynamic>);
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GNotificationsOrderBy.serializer,
+        this,
+      ) as Map<String, dynamic>);
 
   static GNotificationsOrderBy? fromJson(Map<String, dynamic> json) =>
-      _i1.serializers.deserializeWith(GNotificationsOrderBy.serializer, json);
+      _i1.serializers.deserializeWith(
+        GNotificationsOrderBy.serializer,
+        json,
+      );
 }
 
 class GNotificationsSelectColumn extends EnumClass {
@@ -1175,27 +1198,23 @@ class GNotificationsSelectColumn extends EnumClass {
 
 abstract class GNotificationsStreamCursorInput
     implements
-        Built<
-          GNotificationsStreamCursorInput,
-          GNotificationsStreamCursorInputBuilder
-        > {
+        Built<GNotificationsStreamCursorInput,
+            GNotificationsStreamCursorInputBuilder> {
   GNotificationsStreamCursorInput._();
 
-  factory GNotificationsStreamCursorInput([
-    void Function(GNotificationsStreamCursorInputBuilder b) updates,
-  ]) = _$GNotificationsStreamCursorInput;
+  factory GNotificationsStreamCursorInput(
+          [void Function(GNotificationsStreamCursorInputBuilder b) updates]) =
+      _$GNotificationsStreamCursorInput;
 
   GNotificationsStreamCursorValueInput get initialValue;
   GCursorOrdering? get ordering;
   static Serializer<GNotificationsStreamCursorInput> get serializer =>
       _$gNotificationsStreamCursorInputSerializer;
 
-  Map<String, dynamic> toJson() =>
-      (_i1.serializers.serializeWith(
-            GNotificationsStreamCursorInput.serializer,
-            this,
-          )
-          as Map<String, dynamic>);
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GNotificationsStreamCursorInput.serializer,
+        this,
+      ) as Map<String, dynamic>);
 
   static GNotificationsStreamCursorInput? fromJson(Map<String, dynamic> json) =>
       _i1.serializers.deserializeWith(
@@ -1206,15 +1225,13 @@ abstract class GNotificationsStreamCursorInput
 
 abstract class GNotificationsStreamCursorValueInput
     implements
-        Built<
-          GNotificationsStreamCursorValueInput,
-          GNotificationsStreamCursorValueInputBuilder
-        > {
+        Built<GNotificationsStreamCursorValueInput,
+            GNotificationsStreamCursorValueInputBuilder> {
   GNotificationsStreamCursorValueInput._();
 
-  factory GNotificationsStreamCursorValueInput([
-    void Function(GNotificationsStreamCursorValueInputBuilder b) updates,
-  ]) = _$GNotificationsStreamCursorValueInput;
+  factory GNotificationsStreamCursorValueInput(
+      [void Function(GNotificationsStreamCursorValueInputBuilder b)
+          updates]) = _$GNotificationsStreamCursorValueInput;
 
   String? get content;
   String? get coverImageUrl;
@@ -1229,19 +1246,17 @@ abstract class GNotificationsStreamCursorValueInput
   static Serializer<GNotificationsStreamCursorValueInput> get serializer =>
       _$gNotificationsStreamCursorValueInputSerializer;
 
-  Map<String, dynamic> toJson() =>
-      (_i1.serializers.serializeWith(
-            GNotificationsStreamCursorValueInput.serializer,
-            this,
-          )
-          as Map<String, dynamic>);
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GNotificationsStreamCursorValueInput.serializer,
+        this,
+      ) as Map<String, dynamic>);
 
   static GNotificationsStreamCursorValueInput? fromJson(
-    Map<String, dynamic> json,
-  ) => _i1.serializers.deserializeWith(
-    GNotificationsStreamCursorValueInput.serializer,
-    json,
-  );
+          Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GNotificationsStreamCursorValueInput.serializer,
+        json,
+      );
 }
 
 class GOrderBy extends EnumClass {
@@ -1270,9 +1285,9 @@ abstract class GQuestCategoriesBoolExp
     implements Built<GQuestCategoriesBoolExp, GQuestCategoriesBoolExpBuilder> {
   GQuestCategoriesBoolExp._();
 
-  factory GQuestCategoriesBoolExp([
-    void Function(GQuestCategoriesBoolExpBuilder b) updates,
-  ]) = _$GQuestCategoriesBoolExp;
+  factory GQuestCategoriesBoolExp(
+          [void Function(GQuestCategoriesBoolExpBuilder b) updates]) =
+      _$GQuestCategoriesBoolExp;
 
   @BuiltValueField(wireName: '_and')
   BuiltList<GQuestCategoriesBoolExp>? get G_and;
@@ -1289,21 +1304,25 @@ abstract class GQuestCategoriesBoolExp
   static Serializer<GQuestCategoriesBoolExp> get serializer =>
       _$gQuestCategoriesBoolExpSerializer;
 
-  Map<String, dynamic> toJson() =>
-      (_i1.serializers.serializeWith(GQuestCategoriesBoolExp.serializer, this)
-          as Map<String, dynamic>);
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GQuestCategoriesBoolExp.serializer,
+        this,
+      ) as Map<String, dynamic>);
 
   static GQuestCategoriesBoolExp? fromJson(Map<String, dynamic> json) =>
-      _i1.serializers.deserializeWith(GQuestCategoriesBoolExp.serializer, json);
+      _i1.serializers.deserializeWith(
+        GQuestCategoriesBoolExp.serializer,
+        json,
+      );
 }
 
 abstract class GQuestCategoriesOrderBy
     implements Built<GQuestCategoriesOrderBy, GQuestCategoriesOrderByBuilder> {
   GQuestCategoriesOrderBy._();
 
-  factory GQuestCategoriesOrderBy([
-    void Function(GQuestCategoriesOrderByBuilder b) updates,
-  ]) = _$GQuestCategoriesOrderBy;
+  factory GQuestCategoriesOrderBy(
+          [void Function(GQuestCategoriesOrderByBuilder b) updates]) =
+      _$GQuestCategoriesOrderBy;
 
   GOrderBy? get createdAt;
   GOrderBy? get description;
@@ -1314,12 +1333,16 @@ abstract class GQuestCategoriesOrderBy
   static Serializer<GQuestCategoriesOrderBy> get serializer =>
       _$gQuestCategoriesOrderBySerializer;
 
-  Map<String, dynamic> toJson() =>
-      (_i1.serializers.serializeWith(GQuestCategoriesOrderBy.serializer, this)
-          as Map<String, dynamic>);
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GQuestCategoriesOrderBy.serializer,
+        this,
+      ) as Map<String, dynamic>);
 
   static GQuestCategoriesOrderBy? fromJson(Map<String, dynamic> json) =>
-      _i1.serializers.deserializeWith(GQuestCategoriesOrderBy.serializer, json);
+      _i1.serializers.deserializeWith(
+        GQuestCategoriesOrderBy.serializer,
+        json,
+      );
 }
 
 class GQuestCategoriesSelectColumn extends EnumClass {
@@ -1356,47 +1379,41 @@ class GQuestCategoriesSelectColumn extends EnumClass {
 
 abstract class GQuestCategoriesStreamCursorInput
     implements
-        Built<
-          GQuestCategoriesStreamCursorInput,
-          GQuestCategoriesStreamCursorInputBuilder
-        > {
+        Built<GQuestCategoriesStreamCursorInput,
+            GQuestCategoriesStreamCursorInputBuilder> {
   GQuestCategoriesStreamCursorInput._();
 
-  factory GQuestCategoriesStreamCursorInput([
-    void Function(GQuestCategoriesStreamCursorInputBuilder b) updates,
-  ]) = _$GQuestCategoriesStreamCursorInput;
+  factory GQuestCategoriesStreamCursorInput(
+          [void Function(GQuestCategoriesStreamCursorInputBuilder b) updates]) =
+      _$GQuestCategoriesStreamCursorInput;
 
   GQuestCategoriesStreamCursorValueInput get initialValue;
   GCursorOrdering? get ordering;
   static Serializer<GQuestCategoriesStreamCursorInput> get serializer =>
       _$gQuestCategoriesStreamCursorInputSerializer;
 
-  Map<String, dynamic> toJson() =>
-      (_i1.serializers.serializeWith(
-            GQuestCategoriesStreamCursorInput.serializer,
-            this,
-          )
-          as Map<String, dynamic>);
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GQuestCategoriesStreamCursorInput.serializer,
+        this,
+      ) as Map<String, dynamic>);
 
   static GQuestCategoriesStreamCursorInput? fromJson(
-    Map<String, dynamic> json,
-  ) => _i1.serializers.deserializeWith(
-    GQuestCategoriesStreamCursorInput.serializer,
-    json,
-  );
+          Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GQuestCategoriesStreamCursorInput.serializer,
+        json,
+      );
 }
 
 abstract class GQuestCategoriesStreamCursorValueInput
     implements
-        Built<
-          GQuestCategoriesStreamCursorValueInput,
-          GQuestCategoriesStreamCursorValueInputBuilder
-        > {
+        Built<GQuestCategoriesStreamCursorValueInput,
+            GQuestCategoriesStreamCursorValueInputBuilder> {
   GQuestCategoriesStreamCursorValueInput._();
 
-  factory GQuestCategoriesStreamCursorValueInput([
-    void Function(GQuestCategoriesStreamCursorValueInputBuilder b) updates,
-  ]) = _$GQuestCategoriesStreamCursorValueInput;
+  factory GQuestCategoriesStreamCursorValueInput(
+      [void Function(GQuestCategoriesStreamCursorValueInputBuilder b)
+          updates]) = _$GQuestCategoriesStreamCursorValueInput;
 
   DateTime? get createdAt;
   String? get description;
@@ -1407,28 +1424,26 @@ abstract class GQuestCategoriesStreamCursorValueInput
   static Serializer<GQuestCategoriesStreamCursorValueInput> get serializer =>
       _$gQuestCategoriesStreamCursorValueInputSerializer;
 
-  Map<String, dynamic> toJson() =>
-      (_i1.serializers.serializeWith(
-            GQuestCategoriesStreamCursorValueInput.serializer,
-            this,
-          )
-          as Map<String, dynamic>);
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GQuestCategoriesStreamCursorValueInput.serializer,
+        this,
+      ) as Map<String, dynamic>);
 
   static GQuestCategoriesStreamCursorValueInput? fromJson(
-    Map<String, dynamic> json,
-  ) => _i1.serializers.deserializeWith(
-    GQuestCategoriesStreamCursorValueInput.serializer,
-    json,
-  );
+          Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GQuestCategoriesStreamCursorValueInput.serializer,
+        json,
+      );
 }
 
 abstract class GQuestStatusBoolExp
     implements Built<GQuestStatusBoolExp, GQuestStatusBoolExpBuilder> {
   GQuestStatusBoolExp._();
 
-  factory GQuestStatusBoolExp([
-    void Function(GQuestStatusBoolExpBuilder b) updates,
-  ]) = _$GQuestStatusBoolExp;
+  factory GQuestStatusBoolExp(
+          [void Function(GQuestStatusBoolExpBuilder b) updates]) =
+      _$GQuestStatusBoolExp;
 
   @BuiltValueField(wireName: '_and')
   BuiltList<GQuestStatusBoolExp>? get G_and;
@@ -1440,12 +1455,16 @@ abstract class GQuestStatusBoolExp
   static Serializer<GQuestStatusBoolExp> get serializer =>
       _$gQuestStatusBoolExpSerializer;
 
-  Map<String, dynamic> toJson() =>
-      (_i1.serializers.serializeWith(GQuestStatusBoolExp.serializer, this)
-          as Map<String, dynamic>);
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GQuestStatusBoolExp.serializer,
+        this,
+      ) as Map<String, dynamic>);
 
   static GQuestStatusBoolExp? fromJson(Map<String, dynamic> json) =>
-      _i1.serializers.deserializeWith(GQuestStatusBoolExp.serializer, json);
+      _i1.serializers.deserializeWith(
+        GQuestStatusBoolExp.serializer,
+        json,
+      );
 }
 
 class GQuestStatusEnum extends EnumClass {
@@ -1474,15 +1493,13 @@ class GQuestStatusEnum extends EnumClass {
 
 abstract class GQuestStatusEnumComparisonExp
     implements
-        Built<
-          GQuestStatusEnumComparisonExp,
-          GQuestStatusEnumComparisonExpBuilder
-        > {
+        Built<GQuestStatusEnumComparisonExp,
+            GQuestStatusEnumComparisonExpBuilder> {
   GQuestStatusEnumComparisonExp._();
 
-  factory GQuestStatusEnumComparisonExp([
-    void Function(GQuestStatusEnumComparisonExpBuilder b) updates,
-  ]) = _$GQuestStatusEnumComparisonExp;
+  factory GQuestStatusEnumComparisonExp(
+          [void Function(GQuestStatusEnumComparisonExpBuilder b) updates]) =
+      _$GQuestStatusEnumComparisonExp;
 
   @BuiltValueField(wireName: '_eq')
   GQuestStatusEnum? get G_eq;
@@ -1497,12 +1514,10 @@ abstract class GQuestStatusEnumComparisonExp
   static Serializer<GQuestStatusEnumComparisonExp> get serializer =>
       _$gQuestStatusEnumComparisonExpSerializer;
 
-  Map<String, dynamic> toJson() =>
-      (_i1.serializers.serializeWith(
-            GQuestStatusEnumComparisonExp.serializer,
-            this,
-          )
-          as Map<String, dynamic>);
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GQuestStatusEnumComparisonExp.serializer,
+        this,
+      ) as Map<String, dynamic>);
 
   static GQuestStatusEnumComparisonExp? fromJson(Map<String, dynamic> json) =>
       _i1.serializers.deserializeWith(
@@ -1515,20 +1530,24 @@ abstract class GQuestStatusOrderBy
     implements Built<GQuestStatusOrderBy, GQuestStatusOrderByBuilder> {
   GQuestStatusOrderBy._();
 
-  factory GQuestStatusOrderBy([
-    void Function(GQuestStatusOrderByBuilder b) updates,
-  ]) = _$GQuestStatusOrderBy;
+  factory GQuestStatusOrderBy(
+          [void Function(GQuestStatusOrderByBuilder b) updates]) =
+      _$GQuestStatusOrderBy;
 
   GOrderBy? get value;
   static Serializer<GQuestStatusOrderBy> get serializer =>
       _$gQuestStatusOrderBySerializer;
 
-  Map<String, dynamic> toJson() =>
-      (_i1.serializers.serializeWith(GQuestStatusOrderBy.serializer, this)
-          as Map<String, dynamic>);
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GQuestStatusOrderBy.serializer,
+        this,
+      ) as Map<String, dynamic>);
 
   static GQuestStatusOrderBy? fromJson(Map<String, dynamic> json) =>
-      _i1.serializers.deserializeWith(GQuestStatusOrderBy.serializer, json);
+      _i1.serializers.deserializeWith(
+        GQuestStatusOrderBy.serializer,
+        json,
+      );
 }
 
 class GQuestStatusSelectColumn extends EnumClass {
@@ -1548,27 +1567,23 @@ class GQuestStatusSelectColumn extends EnumClass {
 
 abstract class GQuestStatusStreamCursorInput
     implements
-        Built<
-          GQuestStatusStreamCursorInput,
-          GQuestStatusStreamCursorInputBuilder
-        > {
+        Built<GQuestStatusStreamCursorInput,
+            GQuestStatusStreamCursorInputBuilder> {
   GQuestStatusStreamCursorInput._();
 
-  factory GQuestStatusStreamCursorInput([
-    void Function(GQuestStatusStreamCursorInputBuilder b) updates,
-  ]) = _$GQuestStatusStreamCursorInput;
+  factory GQuestStatusStreamCursorInput(
+          [void Function(GQuestStatusStreamCursorInputBuilder b) updates]) =
+      _$GQuestStatusStreamCursorInput;
 
   GQuestStatusStreamCursorValueInput get initialValue;
   GCursorOrdering? get ordering;
   static Serializer<GQuestStatusStreamCursorInput> get serializer =>
       _$gQuestStatusStreamCursorInputSerializer;
 
-  Map<String, dynamic> toJson() =>
-      (_i1.serializers.serializeWith(
-            GQuestStatusStreamCursorInput.serializer,
-            this,
-          )
-          as Map<String, dynamic>);
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GQuestStatusStreamCursorInput.serializer,
+        this,
+      ) as Map<String, dynamic>);
 
   static GQuestStatusStreamCursorInput? fromJson(Map<String, dynamic> json) =>
       _i1.serializers.deserializeWith(
@@ -1579,33 +1594,29 @@ abstract class GQuestStatusStreamCursorInput
 
 abstract class GQuestStatusStreamCursorValueInput
     implements
-        Built<
-          GQuestStatusStreamCursorValueInput,
-          GQuestStatusStreamCursorValueInputBuilder
-        > {
+        Built<GQuestStatusStreamCursorValueInput,
+            GQuestStatusStreamCursorValueInputBuilder> {
   GQuestStatusStreamCursorValueInput._();
 
-  factory GQuestStatusStreamCursorValueInput([
-    void Function(GQuestStatusStreamCursorValueInputBuilder b) updates,
-  ]) = _$GQuestStatusStreamCursorValueInput;
+  factory GQuestStatusStreamCursorValueInput(
+      [void Function(GQuestStatusStreamCursorValueInputBuilder b)
+          updates]) = _$GQuestStatusStreamCursorValueInput;
 
   String? get value;
   static Serializer<GQuestStatusStreamCursorValueInput> get serializer =>
       _$gQuestStatusStreamCursorValueInputSerializer;
 
-  Map<String, dynamic> toJson() =>
-      (_i1.serializers.serializeWith(
-            GQuestStatusStreamCursorValueInput.serializer,
-            this,
-          )
-          as Map<String, dynamic>);
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GQuestStatusStreamCursorValueInput.serializer,
+        this,
+      ) as Map<String, dynamic>);
 
   static GQuestStatusStreamCursorValueInput? fromJson(
-    Map<String, dynamic> json,
-  ) => _i1.serializers.deserializeWith(
-    GQuestStatusStreamCursorValueInput.serializer,
-    json,
-  );
+          Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GQuestStatusStreamCursorValueInput.serializer,
+        json,
+      );
 }
 
 abstract class GSeosBoolExp
@@ -1629,12 +1640,16 @@ abstract class GSeosBoolExp
   GTimestamptzComparisonExp? get updatedAt;
   static Serializer<GSeosBoolExp> get serializer => _$gSeosBoolExpSerializer;
 
-  Map<String, dynamic> toJson() =>
-      (_i1.serializers.serializeWith(GSeosBoolExp.serializer, this)
-          as Map<String, dynamic>);
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GSeosBoolExp.serializer,
+        this,
+      ) as Map<String, dynamic>);
 
   static GSeosBoolExp? fromJson(Map<String, dynamic> json) =>
-      _i1.serializers.deserializeWith(GSeosBoolExp.serializer, json);
+      _i1.serializers.deserializeWith(
+        GSeosBoolExp.serializer,
+        json,
+      );
 }
 
 abstract class GSeosOrderBy
@@ -1652,12 +1667,16 @@ abstract class GSeosOrderBy
   GOrderBy? get updatedAt;
   static Serializer<GSeosOrderBy> get serializer => _$gSeosOrderBySerializer;
 
-  Map<String, dynamic> toJson() =>
-      (_i1.serializers.serializeWith(GSeosOrderBy.serializer, this)
-          as Map<String, dynamic>);
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GSeosOrderBy.serializer,
+        this,
+      ) as Map<String, dynamic>);
 
   static GSeosOrderBy? fromJson(Map<String, dynamic> json) =>
-      _i1.serializers.deserializeWith(GSeosOrderBy.serializer, json);
+      _i1.serializers.deserializeWith(
+        GSeosOrderBy.serializer,
+        json,
+      );
 }
 
 class GSeosSelectColumn extends EnumClass {
@@ -1688,21 +1707,25 @@ abstract class GSeosStreamCursorInput
     implements Built<GSeosStreamCursorInput, GSeosStreamCursorInputBuilder> {
   GSeosStreamCursorInput._();
 
-  factory GSeosStreamCursorInput([
-    void Function(GSeosStreamCursorInputBuilder b) updates,
-  ]) = _$GSeosStreamCursorInput;
+  factory GSeosStreamCursorInput(
+          [void Function(GSeosStreamCursorInputBuilder b) updates]) =
+      _$GSeosStreamCursorInput;
 
   GSeosStreamCursorValueInput get initialValue;
   GCursorOrdering? get ordering;
   static Serializer<GSeosStreamCursorInput> get serializer =>
       _$gSeosStreamCursorInputSerializer;
 
-  Map<String, dynamic> toJson() =>
-      (_i1.serializers.serializeWith(GSeosStreamCursorInput.serializer, this)
-          as Map<String, dynamic>);
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GSeosStreamCursorInput.serializer,
+        this,
+      ) as Map<String, dynamic>);
 
   static GSeosStreamCursorInput? fromJson(Map<String, dynamic> json) =>
-      _i1.serializers.deserializeWith(GSeosStreamCursorInput.serializer, json);
+      _i1.serializers.deserializeWith(
+        GSeosStreamCursorInput.serializer,
+        json,
+      );
 }
 
 abstract class GSeosStreamCursorValueInput
@@ -1710,9 +1733,9 @@ abstract class GSeosStreamCursorValueInput
         Built<GSeosStreamCursorValueInput, GSeosStreamCursorValueInputBuilder> {
   GSeosStreamCursorValueInput._();
 
-  factory GSeosStreamCursorValueInput([
-    void Function(GSeosStreamCursorValueInputBuilder b) updates,
-  ]) = _$GSeosStreamCursorValueInput;
+  factory GSeosStreamCursorValueInput(
+          [void Function(GSeosStreamCursorValueInputBuilder b) updates]) =
+      _$GSeosStreamCursorValueInput;
 
   DateTime? get createdAt;
   String? get description;
@@ -1723,25 +1746,25 @@ abstract class GSeosStreamCursorValueInput
   static Serializer<GSeosStreamCursorValueInput> get serializer =>
       _$gSeosStreamCursorValueInputSerializer;
 
-  Map<String, dynamic> toJson() =>
-      (_i1.serializers.serializeWith(
-            GSeosStreamCursorValueInput.serializer,
-            this,
-          )
-          as Map<String, dynamic>);
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GSeosStreamCursorValueInput.serializer,
+        this,
+      ) as Map<String, dynamic>);
 
-  static GSeosStreamCursorValueInput? fromJson(Map<String, dynamic> json) => _i1
-      .serializers
-      .deserializeWith(GSeosStreamCursorValueInput.serializer, json);
+  static GSeosStreamCursorValueInput? fromJson(Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GSeosStreamCursorValueInput.serializer,
+        json,
+      );
 }
 
 abstract class GStringComparisonExp
     implements Built<GStringComparisonExp, GStringComparisonExpBuilder> {
   GStringComparisonExp._();
 
-  factory GStringComparisonExp([
-    void Function(GStringComparisonExpBuilder b) updates,
-  ]) = _$GStringComparisonExp;
+  factory GStringComparisonExp(
+          [void Function(GStringComparisonExpBuilder b) updates]) =
+      _$GStringComparisonExp;
 
   @BuiltValueField(wireName: '_eq')
   String? get G_eq;
@@ -1784,12 +1807,16 @@ abstract class GStringComparisonExp
   static Serializer<GStringComparisonExp> get serializer =>
       _$gStringComparisonExpSerializer;
 
-  Map<String, dynamic> toJson() =>
-      (_i1.serializers.serializeWith(GStringComparisonExp.serializer, this)
-          as Map<String, dynamic>);
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GStringComparisonExp.serializer,
+        this,
+      ) as Map<String, dynamic>);
 
   static GStringComparisonExp? fromJson(Map<String, dynamic> json) =>
-      _i1.serializers.deserializeWith(GStringComparisonExp.serializer, json);
+      _i1.serializers.deserializeWith(
+        GStringComparisonExp.serializer,
+        json,
+      );
 }
 
 abstract class GTagsBoolExp
@@ -1812,12 +1839,16 @@ abstract class GTagsBoolExp
   GTimestamptzComparisonExp? get updatedAt;
   static Serializer<GTagsBoolExp> get serializer => _$gTagsBoolExpSerializer;
 
-  Map<String, dynamic> toJson() =>
-      (_i1.serializers.serializeWith(GTagsBoolExp.serializer, this)
-          as Map<String, dynamic>);
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GTagsBoolExp.serializer,
+        this,
+      ) as Map<String, dynamic>);
 
   static GTagsBoolExp? fromJson(Map<String, dynamic> json) =>
-      _i1.serializers.deserializeWith(GTagsBoolExp.serializer, json);
+      _i1.serializers.deserializeWith(
+        GTagsBoolExp.serializer,
+        json,
+      );
 }
 
 abstract class GTagsOrderBy
@@ -1834,12 +1865,16 @@ abstract class GTagsOrderBy
   GOrderBy? get updatedAt;
   static Serializer<GTagsOrderBy> get serializer => _$gTagsOrderBySerializer;
 
-  Map<String, dynamic> toJson() =>
-      (_i1.serializers.serializeWith(GTagsOrderBy.serializer, this)
-          as Map<String, dynamic>);
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GTagsOrderBy.serializer,
+        this,
+      ) as Map<String, dynamic>);
 
   static GTagsOrderBy? fromJson(Map<String, dynamic> json) =>
-      _i1.serializers.deserializeWith(GTagsOrderBy.serializer, json);
+      _i1.serializers.deserializeWith(
+        GTagsOrderBy.serializer,
+        json,
+      );
 }
 
 class GTagsSelectColumn extends EnumClass {
@@ -1868,21 +1903,25 @@ abstract class GTagsStreamCursorInput
     implements Built<GTagsStreamCursorInput, GTagsStreamCursorInputBuilder> {
   GTagsStreamCursorInput._();
 
-  factory GTagsStreamCursorInput([
-    void Function(GTagsStreamCursorInputBuilder b) updates,
-  ]) = _$GTagsStreamCursorInput;
+  factory GTagsStreamCursorInput(
+          [void Function(GTagsStreamCursorInputBuilder b) updates]) =
+      _$GTagsStreamCursorInput;
 
   GTagsStreamCursorValueInput get initialValue;
   GCursorOrdering? get ordering;
   static Serializer<GTagsStreamCursorInput> get serializer =>
       _$gTagsStreamCursorInputSerializer;
 
-  Map<String, dynamic> toJson() =>
-      (_i1.serializers.serializeWith(GTagsStreamCursorInput.serializer, this)
-          as Map<String, dynamic>);
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GTagsStreamCursorInput.serializer,
+        this,
+      ) as Map<String, dynamic>);
 
   static GTagsStreamCursorInput? fromJson(Map<String, dynamic> json) =>
-      _i1.serializers.deserializeWith(GTagsStreamCursorInput.serializer, json);
+      _i1.serializers.deserializeWith(
+        GTagsStreamCursorInput.serializer,
+        json,
+      );
 }
 
 abstract class GTagsStreamCursorValueInput
@@ -1890,9 +1929,9 @@ abstract class GTagsStreamCursorValueInput
         Built<GTagsStreamCursorValueInput, GTagsStreamCursorValueInputBuilder> {
   GTagsStreamCursorValueInput._();
 
-  factory GTagsStreamCursorValueInput([
-    void Function(GTagsStreamCursorValueInputBuilder b) updates,
-  ]) = _$GTagsStreamCursorValueInput;
+  factory GTagsStreamCursorValueInput(
+          [void Function(GTagsStreamCursorValueInputBuilder b) updates]) =
+      _$GTagsStreamCursorValueInput;
 
   DateTime? get createdAt;
   String? get description;
@@ -1902,16 +1941,16 @@ abstract class GTagsStreamCursorValueInput
   static Serializer<GTagsStreamCursorValueInput> get serializer =>
       _$gTagsStreamCursorValueInputSerializer;
 
-  Map<String, dynamic> toJson() =>
-      (_i1.serializers.serializeWith(
-            GTagsStreamCursorValueInput.serializer,
-            this,
-          )
-          as Map<String, dynamic>);
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GTagsStreamCursorValueInput.serializer,
+        this,
+      ) as Map<String, dynamic>);
 
-  static GTagsStreamCursorValueInput? fromJson(Map<String, dynamic> json) => _i1
-      .serializers
-      .deserializeWith(GTagsStreamCursorValueInput.serializer, json);
+  static GTagsStreamCursorValueInput? fromJson(Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GTagsStreamCursorValueInput.serializer,
+        json,
+      );
 }
 
 abstract class GTimestamptzComparisonExp
@@ -1919,9 +1958,9 @@ abstract class GTimestamptzComparisonExp
         Built<GTimestamptzComparisonExp, GTimestamptzComparisonExpBuilder> {
   GTimestamptzComparisonExp._();
 
-  factory GTimestamptzComparisonExp([
-    void Function(GTimestamptzComparisonExpBuilder b) updates,
-  ]) = _$GTimestamptzComparisonExp;
+  factory GTimestamptzComparisonExp(
+          [void Function(GTimestamptzComparisonExpBuilder b) updates]) =
+      _$GTimestamptzComparisonExp;
 
   @BuiltValueField(wireName: '_eq')
   DateTime? get G_eq;
@@ -1944,13 +1983,16 @@ abstract class GTimestamptzComparisonExp
   static Serializer<GTimestamptzComparisonExp> get serializer =>
       _$gTimestamptzComparisonExpSerializer;
 
-  Map<String, dynamic> toJson() =>
-      (_i1.serializers.serializeWith(GTimestamptzComparisonExp.serializer, this)
-          as Map<String, dynamic>);
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GTimestamptzComparisonExp.serializer,
+        this,
+      ) as Map<String, dynamic>);
 
-  static GTimestamptzComparisonExp? fromJson(Map<String, dynamic> json) => _i1
-      .serializers
-      .deserializeWith(GTimestamptzComparisonExp.serializer, json);
+  static GTimestamptzComparisonExp? fromJson(Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GTimestamptzComparisonExp.serializer,
+        json,
+      );
 }
 
 abstract class GUserAchievementsBoolExp
@@ -1958,9 +2000,9 @@ abstract class GUserAchievementsBoolExp
         Built<GUserAchievementsBoolExp, GUserAchievementsBoolExpBuilder> {
   GUserAchievementsBoolExp._();
 
-  factory GUserAchievementsBoolExp([
-    void Function(GUserAchievementsBoolExpBuilder b) updates,
-  ]) = _$GUserAchievementsBoolExp;
+  factory GUserAchievementsBoolExp(
+          [void Function(GUserAchievementsBoolExpBuilder b) updates]) =
+      _$GUserAchievementsBoolExp;
 
   @BuiltValueField(wireName: '_and')
   BuiltList<GUserAchievementsBoolExp>? get G_and;
@@ -1973,13 +2015,16 @@ abstract class GUserAchievementsBoolExp
   static Serializer<GUserAchievementsBoolExp> get serializer =>
       _$gUserAchievementsBoolExpSerializer;
 
-  Map<String, dynamic> toJson() =>
-      (_i1.serializers.serializeWith(GUserAchievementsBoolExp.serializer, this)
-          as Map<String, dynamic>);
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GUserAchievementsBoolExp.serializer,
+        this,
+      ) as Map<String, dynamic>);
 
-  static GUserAchievementsBoolExp? fromJson(Map<String, dynamic> json) => _i1
-      .serializers
-      .deserializeWith(GUserAchievementsBoolExp.serializer, json);
+  static GUserAchievementsBoolExp? fromJson(Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GUserAchievementsBoolExp.serializer,
+        json,
+      );
 }
 
 abstract class GUserAchievementsOrderBy
@@ -1987,22 +2032,25 @@ abstract class GUserAchievementsOrderBy
         Built<GUserAchievementsOrderBy, GUserAchievementsOrderByBuilder> {
   GUserAchievementsOrderBy._();
 
-  factory GUserAchievementsOrderBy([
-    void Function(GUserAchievementsOrderByBuilder b) updates,
-  ]) = _$GUserAchievementsOrderBy;
+  factory GUserAchievementsOrderBy(
+          [void Function(GUserAchievementsOrderByBuilder b) updates]) =
+      _$GUserAchievementsOrderBy;
 
   GOrderBy? get achievementId;
   GOrderBy? get userId;
   static Serializer<GUserAchievementsOrderBy> get serializer =>
       _$gUserAchievementsOrderBySerializer;
 
-  Map<String, dynamic> toJson() =>
-      (_i1.serializers.serializeWith(GUserAchievementsOrderBy.serializer, this)
-          as Map<String, dynamic>);
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GUserAchievementsOrderBy.serializer,
+        this,
+      ) as Map<String, dynamic>);
 
-  static GUserAchievementsOrderBy? fromJson(Map<String, dynamic> json) => _i1
-      .serializers
-      .deserializeWith(GUserAchievementsOrderBy.serializer, json);
+  static GUserAchievementsOrderBy? fromJson(Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GUserAchievementsOrderBy.serializer,
+        json,
+      );
 }
 
 class GUserAchievementsSelectColumn extends EnumClass {
@@ -2026,66 +2074,58 @@ class GUserAchievementsSelectColumn extends EnumClass {
 
 abstract class GUserAchievementsStreamCursorInput
     implements
-        Built<
-          GUserAchievementsStreamCursorInput,
-          GUserAchievementsStreamCursorInputBuilder
-        > {
+        Built<GUserAchievementsStreamCursorInput,
+            GUserAchievementsStreamCursorInputBuilder> {
   GUserAchievementsStreamCursorInput._();
 
-  factory GUserAchievementsStreamCursorInput([
-    void Function(GUserAchievementsStreamCursorInputBuilder b) updates,
-  ]) = _$GUserAchievementsStreamCursorInput;
+  factory GUserAchievementsStreamCursorInput(
+      [void Function(GUserAchievementsStreamCursorInputBuilder b)
+          updates]) = _$GUserAchievementsStreamCursorInput;
 
   GUserAchievementsStreamCursorValueInput get initialValue;
   GCursorOrdering? get ordering;
   static Serializer<GUserAchievementsStreamCursorInput> get serializer =>
       _$gUserAchievementsStreamCursorInputSerializer;
 
-  Map<String, dynamic> toJson() =>
-      (_i1.serializers.serializeWith(
-            GUserAchievementsStreamCursorInput.serializer,
-            this,
-          )
-          as Map<String, dynamic>);
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GUserAchievementsStreamCursorInput.serializer,
+        this,
+      ) as Map<String, dynamic>);
 
   static GUserAchievementsStreamCursorInput? fromJson(
-    Map<String, dynamic> json,
-  ) => _i1.serializers.deserializeWith(
-    GUserAchievementsStreamCursorInput.serializer,
-    json,
-  );
+          Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GUserAchievementsStreamCursorInput.serializer,
+        json,
+      );
 }
 
 abstract class GUserAchievementsStreamCursorValueInput
     implements
-        Built<
-          GUserAchievementsStreamCursorValueInput,
-          GUserAchievementsStreamCursorValueInputBuilder
-        > {
+        Built<GUserAchievementsStreamCursorValueInput,
+            GUserAchievementsStreamCursorValueInputBuilder> {
   GUserAchievementsStreamCursorValueInput._();
 
-  factory GUserAchievementsStreamCursorValueInput([
-    void Function(GUserAchievementsStreamCursorValueInputBuilder b) updates,
-  ]) = _$GUserAchievementsStreamCursorValueInput;
+  factory GUserAchievementsStreamCursorValueInput(
+      [void Function(GUserAchievementsStreamCursorValueInputBuilder b)
+          updates]) = _$GUserAchievementsStreamCursorValueInput;
 
   String? get achievementId;
   String? get userId;
   static Serializer<GUserAchievementsStreamCursorValueInput> get serializer =>
       _$gUserAchievementsStreamCursorValueInputSerializer;
 
-  Map<String, dynamic> toJson() =>
-      (_i1.serializers.serializeWith(
-            GUserAchievementsStreamCursorValueInput.serializer,
-            this,
-          )
-          as Map<String, dynamic>);
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GUserAchievementsStreamCursorValueInput.serializer,
+        this,
+      ) as Map<String, dynamic>);
 
   static GUserAchievementsStreamCursorValueInput? fromJson(
-    Map<String, dynamic> json,
-  ) => _i1.serializers.deserializeWith(
-    GUserAchievementsStreamCursorValueInput.serializer,
-    json,
-  );
+          Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GUserAchievementsStreamCursorValueInput.serializer,
+        json,
+      );
 }
 
 abstract class GUsersBoolExp
@@ -2112,12 +2152,16 @@ abstract class GUsersBoolExp
   GStringComparisonExp? get website;
   static Serializer<GUsersBoolExp> get serializer => _$gUsersBoolExpSerializer;
 
-  Map<String, dynamic> toJson() =>
-      (_i1.serializers.serializeWith(GUsersBoolExp.serializer, this)
-          as Map<String, dynamic>);
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GUsersBoolExp.serializer,
+        this,
+      ) as Map<String, dynamic>);
 
   static GUsersBoolExp? fromJson(Map<String, dynamic> json) =>
-      _i1.serializers.deserializeWith(GUsersBoolExp.serializer, json);
+      _i1.serializers.deserializeWith(
+        GUsersBoolExp.serializer,
+        json,
+      );
 }
 
 abstract class GUsersOrderBy
@@ -2138,12 +2182,16 @@ abstract class GUsersOrderBy
   GOrderBy? get website;
   static Serializer<GUsersOrderBy> get serializer => _$gUsersOrderBySerializer;
 
-  Map<String, dynamic> toJson() =>
-      (_i1.serializers.serializeWith(GUsersOrderBy.serializer, this)
-          as Map<String, dynamic>);
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GUsersOrderBy.serializer,
+        this,
+      ) as Map<String, dynamic>);
 
   static GUsersOrderBy? fromJson(Map<String, dynamic> json) =>
-      _i1.serializers.deserializeWith(GUsersOrderBy.serializer, json);
+      _i1.serializers.deserializeWith(
+        GUsersOrderBy.serializer,
+        json,
+      );
 }
 
 class GUsersSelectColumn extends EnumClass {
@@ -2180,34 +2228,36 @@ abstract class GUsersStreamCursorInput
     implements Built<GUsersStreamCursorInput, GUsersStreamCursorInputBuilder> {
   GUsersStreamCursorInput._();
 
-  factory GUsersStreamCursorInput([
-    void Function(GUsersStreamCursorInputBuilder b) updates,
-  ]) = _$GUsersStreamCursorInput;
+  factory GUsersStreamCursorInput(
+          [void Function(GUsersStreamCursorInputBuilder b) updates]) =
+      _$GUsersStreamCursorInput;
 
   GUsersStreamCursorValueInput get initialValue;
   GCursorOrdering? get ordering;
   static Serializer<GUsersStreamCursorInput> get serializer =>
       _$gUsersStreamCursorInputSerializer;
 
-  Map<String, dynamic> toJson() =>
-      (_i1.serializers.serializeWith(GUsersStreamCursorInput.serializer, this)
-          as Map<String, dynamic>);
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GUsersStreamCursorInput.serializer,
+        this,
+      ) as Map<String, dynamic>);
 
   static GUsersStreamCursorInput? fromJson(Map<String, dynamic> json) =>
-      _i1.serializers.deserializeWith(GUsersStreamCursorInput.serializer, json);
+      _i1.serializers.deserializeWith(
+        GUsersStreamCursorInput.serializer,
+        json,
+      );
 }
 
 abstract class GUsersStreamCursorValueInput
     implements
-        Built<
-          GUsersStreamCursorValueInput,
-          GUsersStreamCursorValueInputBuilder
-        > {
+        Built<GUsersStreamCursorValueInput,
+            GUsersStreamCursorValueInputBuilder> {
   GUsersStreamCursorValueInput._();
 
-  factory GUsersStreamCursorValueInput([
-    void Function(GUsersStreamCursorValueInputBuilder b) updates,
-  ]) = _$GUsersStreamCursorValueInput;
+  factory GUsersStreamCursorValueInput(
+          [void Function(GUsersStreamCursorValueInputBuilder b) updates]) =
+      _$GUsersStreamCursorValueInput;
 
   DateTime? get createdAt;
   String? get email;
@@ -2221,12 +2271,10 @@ abstract class GUsersStreamCursorValueInput
   static Serializer<GUsersStreamCursorValueInput> get serializer =>
       _$gUsersStreamCursorValueInputSerializer;
 
-  Map<String, dynamic> toJson() =>
-      (_i1.serializers.serializeWith(
-            GUsersStreamCursorValueInput.serializer,
-            this,
-          )
-          as Map<String, dynamic>);
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GUsersStreamCursorValueInput.serializer,
+        this,
+      ) as Map<String, dynamic>);
 
   static GUsersStreamCursorValueInput? fromJson(Map<String, dynamic> json) =>
       _i1.serializers.deserializeWith(
@@ -2239,9 +2287,9 @@ abstract class GUuidComparisonExp
     implements Built<GUuidComparisonExp, GUuidComparisonExpBuilder> {
   GUuidComparisonExp._();
 
-  factory GUuidComparisonExp([
-    void Function(GUuidComparisonExpBuilder b) updates,
-  ]) = _$GUuidComparisonExp;
+  factory GUuidComparisonExp(
+          [void Function(GUuidComparisonExpBuilder b) updates]) =
+      _$GUuidComparisonExp;
 
   @BuiltValueField(wireName: '_eq')
   String? get G_eq;
@@ -2264,12 +2312,16 @@ abstract class GUuidComparisonExp
   static Serializer<GUuidComparisonExp> get serializer =>
       _$gUuidComparisonExpSerializer;
 
-  Map<String, dynamic> toJson() =>
-      (_i1.serializers.serializeWith(GUuidComparisonExp.serializer, this)
-          as Map<String, dynamic>);
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GUuidComparisonExp.serializer,
+        this,
+      ) as Map<String, dynamic>);
 
   static GUuidComparisonExp? fromJson(Map<String, dynamic> json) =>
-      _i1.serializers.deserializeWith(GUuidComparisonExp.serializer, json);
+      _i1.serializers.deserializeWith(
+        GUuidComparisonExp.serializer,
+        json,
+      );
 }
 
 const Map<String, Set<String>> possibleTypesMap = {};

--- a/app/backend/lib/graphql/__generated__/schema.schema.gql.g.dart
+++ b/app/backend/lib/graphql/__generated__/schema.schema.gql.g.dart
@@ -36,12 +36,12 @@ GAchievementsSelectColumn _$gAchievementsSelectColumnValueOf(String name) {
 
 final BuiltSet<GAchievementsSelectColumn> _$gAchievementsSelectColumnValues =
     new BuiltSet<GAchievementsSelectColumn>(const <GAchievementsSelectColumn>[
-      _$gAchievementsSelectColumncreatedAt,
-      _$gAchievementsSelectColumndescription,
-      _$gAchievementsSelectColumnid,
-      _$gAchievementsSelectColumnGname,
-      _$gAchievementsSelectColumnupdatedAt,
-    ]);
+  _$gAchievementsSelectColumncreatedAt,
+  _$gAchievementsSelectColumndescription,
+  _$gAchievementsSelectColumnid,
+  _$gAchievementsSelectColumnGname,
+  _$gAchievementsSelectColumnupdatedAt,
+]);
 
 const GCursorOrdering _$gCursorOrderingASC = const GCursorOrdering._('ASC');
 const GCursorOrdering _$gCursorOrderingDESC = const GCursorOrdering._('DESC');
@@ -59,17 +59,16 @@ GCursorOrdering _$gCursorOrderingValueOf(String name) {
 
 final BuiltSet<GCursorOrdering> _$gCursorOrderingValues =
     new BuiltSet<GCursorOrdering>(const <GCursorOrdering>[
-      _$gCursorOrderingASC,
-      _$gCursorOrderingDESC,
-    ]);
+  _$gCursorOrderingASC,
+  _$gCursorOrderingDESC,
+]);
 
 const GMainQuestRelationsConstraint
-_$gMainQuestRelationsConstraintmain_quest_relations_pkey =
+    _$gMainQuestRelationsConstraintmain_quest_relations_pkey =
     const GMainQuestRelationsConstraint._('main_quest_relations_pkey');
 
 GMainQuestRelationsConstraint _$gMainQuestRelationsConstraintValueOf(
-  String name,
-) {
+    String name) {
   switch (name) {
     case 'main_quest_relations_pkey':
       return _$gMainQuestRelationsConstraintmain_quest_relations_pkey;
@@ -79,23 +78,20 @@ GMainQuestRelationsConstraint _$gMainQuestRelationsConstraintValueOf(
 }
 
 final BuiltSet<GMainQuestRelationsConstraint>
-_$gMainQuestRelationsConstraintValues =
-    new BuiltSet<GMainQuestRelationsConstraint>(
-      const <GMainQuestRelationsConstraint>[
-        _$gMainQuestRelationsConstraintmain_quest_relations_pkey,
-      ],
-    );
+    _$gMainQuestRelationsConstraintValues = new BuiltSet<
+        GMainQuestRelationsConstraint>(const <GMainQuestRelationsConstraint>[
+  _$gMainQuestRelationsConstraintmain_quest_relations_pkey,
+]);
 
 const GMainQuestRelationsSelectColumn
-_$gMainQuestRelationsSelectColumnchildQuestId =
+    _$gMainQuestRelationsSelectColumnchildQuestId =
     const GMainQuestRelationsSelectColumn._('childQuestId');
 const GMainQuestRelationsSelectColumn
-_$gMainQuestRelationsSelectColumnparentQuestId =
+    _$gMainQuestRelationsSelectColumnparentQuestId =
     const GMainQuestRelationsSelectColumn._('parentQuestId');
 
 GMainQuestRelationsSelectColumn _$gMainQuestRelationsSelectColumnValueOf(
-  String name,
-) {
+    String name) {
   switch (name) {
     case 'childQuestId':
       return _$gMainQuestRelationsSelectColumnchildQuestId;
@@ -107,24 +103,21 @@ GMainQuestRelationsSelectColumn _$gMainQuestRelationsSelectColumnValueOf(
 }
 
 final BuiltSet<GMainQuestRelationsSelectColumn>
-_$gMainQuestRelationsSelectColumnValues =
-    new BuiltSet<GMainQuestRelationsSelectColumn>(
-      const <GMainQuestRelationsSelectColumn>[
-        _$gMainQuestRelationsSelectColumnchildQuestId,
-        _$gMainQuestRelationsSelectColumnparentQuestId,
-      ],
-    );
+    _$gMainQuestRelationsSelectColumnValues = new BuiltSet<
+        GMainQuestRelationsSelectColumn>(const <GMainQuestRelationsSelectColumn>[
+  _$gMainQuestRelationsSelectColumnchildQuestId,
+  _$gMainQuestRelationsSelectColumnparentQuestId,
+]);
 
 const GMainQuestRelationsUpdateColumn
-_$gMainQuestRelationsUpdateColumnchildQuestId =
+    _$gMainQuestRelationsUpdateColumnchildQuestId =
     const GMainQuestRelationsUpdateColumn._('childQuestId');
 const GMainQuestRelationsUpdateColumn
-_$gMainQuestRelationsUpdateColumnparentQuestId =
+    _$gMainQuestRelationsUpdateColumnparentQuestId =
     const GMainQuestRelationsUpdateColumn._('parentQuestId');
 
 GMainQuestRelationsUpdateColumn _$gMainQuestRelationsUpdateColumnValueOf(
-  String name,
-) {
+    String name) {
   switch (name) {
     case 'childQuestId':
       return _$gMainQuestRelationsUpdateColumnchildQuestId;
@@ -136,13 +129,11 @@ GMainQuestRelationsUpdateColumn _$gMainQuestRelationsUpdateColumnValueOf(
 }
 
 final BuiltSet<GMainQuestRelationsUpdateColumn>
-_$gMainQuestRelationsUpdateColumnValues =
-    new BuiltSet<GMainQuestRelationsUpdateColumn>(
-      const <GMainQuestRelationsUpdateColumn>[
-        _$gMainQuestRelationsUpdateColumnchildQuestId,
-        _$gMainQuestRelationsUpdateColumnparentQuestId,
-      ],
-    );
+    _$gMainQuestRelationsUpdateColumnValues = new BuiltSet<
+        GMainQuestRelationsUpdateColumn>(const <GMainQuestRelationsUpdateColumn>[
+  _$gMainQuestRelationsUpdateColumnchildQuestId,
+  _$gMainQuestRelationsUpdateColumnparentQuestId,
+]);
 
 const GMainQuestsConstraint _$gMainQuestsConstraintmain_quests_pkey =
     const GMainQuestsConstraint._('main_quests_pkey');
@@ -158,8 +149,8 @@ GMainQuestsConstraint _$gMainQuestsConstraintValueOf(String name) {
 
 final BuiltSet<GMainQuestsConstraint> _$gMainQuestsConstraintValues =
     new BuiltSet<GMainQuestsConstraint>(const <GMainQuestsConstraint>[
-      _$gMainQuestsConstraintmain_quests_pkey,
-    ]);
+  _$gMainQuestsConstraintmain_quests_pkey,
+]);
 
 const GMainQuestsSelectColumn _$gMainQuestsSelectColumnbegunAt =
     const GMainQuestsSelectColumn._('begunAt');
@@ -223,20 +214,20 @@ GMainQuestsSelectColumn _$gMainQuestsSelectColumnValueOf(String name) {
 
 final BuiltSet<GMainQuestsSelectColumn> _$gMainQuestsSelectColumnValues =
     new BuiltSet<GMainQuestsSelectColumn>(const <GMainQuestsSelectColumn>[
-      _$gMainQuestsSelectColumnbegunAt,
-      _$gMainQuestsSelectColumncategoryId,
-      _$gMainQuestsSelectColumncoverImageUrl,
-      _$gMainQuestsSelectColumncreatedAt,
-      _$gMainQuestsSelectColumndeletedAt,
-      _$gMainQuestsSelectColumndescription,
-      _$gMainQuestsSelectColumnendedAt,
-      _$gMainQuestsSelectColumnid,
-      _$gMainQuestsSelectColumnnote,
-      _$gMainQuestsSelectColumnstatus,
-      _$gMainQuestsSelectColumntitle,
-      _$gMainQuestsSelectColumnupdatedAt,
-      _$gMainQuestsSelectColumnuserId,
-    ]);
+  _$gMainQuestsSelectColumnbegunAt,
+  _$gMainQuestsSelectColumncategoryId,
+  _$gMainQuestsSelectColumncoverImageUrl,
+  _$gMainQuestsSelectColumncreatedAt,
+  _$gMainQuestsSelectColumndeletedAt,
+  _$gMainQuestsSelectColumndescription,
+  _$gMainQuestsSelectColumnendedAt,
+  _$gMainQuestsSelectColumnid,
+  _$gMainQuestsSelectColumnnote,
+  _$gMainQuestsSelectColumnstatus,
+  _$gMainQuestsSelectColumntitle,
+  _$gMainQuestsSelectColumnupdatedAt,
+  _$gMainQuestsSelectColumnuserId,
+]);
 
 const GMainQuestsUpdateColumn _$gMainQuestsUpdateColumnbegunAt =
     const GMainQuestsUpdateColumn._('begunAt');
@@ -300,43 +291,38 @@ GMainQuestsUpdateColumn _$gMainQuestsUpdateColumnValueOf(String name) {
 
 final BuiltSet<GMainQuestsUpdateColumn> _$gMainQuestsUpdateColumnValues =
     new BuiltSet<GMainQuestsUpdateColumn>(const <GMainQuestsUpdateColumn>[
-      _$gMainQuestsUpdateColumnbegunAt,
-      _$gMainQuestsUpdateColumncategoryId,
-      _$gMainQuestsUpdateColumncoverImageUrl,
-      _$gMainQuestsUpdateColumncreatedAt,
-      _$gMainQuestsUpdateColumndeletedAt,
-      _$gMainQuestsUpdateColumndescription,
-      _$gMainQuestsUpdateColumnendedAt,
-      _$gMainQuestsUpdateColumnid,
-      _$gMainQuestsUpdateColumnnote,
-      _$gMainQuestsUpdateColumnstatus,
-      _$gMainQuestsUpdateColumntitle,
-      _$gMainQuestsUpdateColumnupdatedAt,
-      _$gMainQuestsUpdateColumnuserId,
-    ]);
+  _$gMainQuestsUpdateColumnbegunAt,
+  _$gMainQuestsUpdateColumncategoryId,
+  _$gMainQuestsUpdateColumncoverImageUrl,
+  _$gMainQuestsUpdateColumncreatedAt,
+  _$gMainQuestsUpdateColumndeletedAt,
+  _$gMainQuestsUpdateColumndescription,
+  _$gMainQuestsUpdateColumnendedAt,
+  _$gMainQuestsUpdateColumnid,
+  _$gMainQuestsUpdateColumnnote,
+  _$gMainQuestsUpdateColumnstatus,
+  _$gMainQuestsUpdateColumntitle,
+  _$gMainQuestsUpdateColumnupdatedAt,
+  _$gMainQuestsUpdateColumnuserId,
+]);
 
-const GNewsSelectColumn _$gNewsSelectColumncontent = const GNewsSelectColumn._(
-  'content',
-);
+const GNewsSelectColumn _$gNewsSelectColumncontent =
+    const GNewsSelectColumn._('content');
 const GNewsSelectColumn _$gNewsSelectColumncoverImageUrl =
     const GNewsSelectColumn._('coverImageUrl');
 const GNewsSelectColumn _$gNewsSelectColumncreatedAt =
     const GNewsSelectColumn._('createdAt');
-const GNewsSelectColumn _$gNewsSelectColumnexcerpt = const GNewsSelectColumn._(
-  'excerpt',
-);
+const GNewsSelectColumn _$gNewsSelectColumnexcerpt =
+    const GNewsSelectColumn._('excerpt');
 const GNewsSelectColumn _$gNewsSelectColumnid = const GNewsSelectColumn._('id');
 const GNewsSelectColumn _$gNewsSelectColumnpublishedAt =
     const GNewsSelectColumn._('publishedAt');
-const GNewsSelectColumn _$gNewsSelectColumnseoId = const GNewsSelectColumn._(
-  'seoId',
-);
-const GNewsSelectColumn _$gNewsSelectColumnslug = const GNewsSelectColumn._(
-  'slug',
-);
-const GNewsSelectColumn _$gNewsSelectColumntitle = const GNewsSelectColumn._(
-  'title',
-);
+const GNewsSelectColumn _$gNewsSelectColumnseoId =
+    const GNewsSelectColumn._('seoId');
+const GNewsSelectColumn _$gNewsSelectColumnslug =
+    const GNewsSelectColumn._('slug');
+const GNewsSelectColumn _$gNewsSelectColumntitle =
+    const GNewsSelectColumn._('title');
 const GNewsSelectColumn _$gNewsSelectColumnupdatedAt =
     const GNewsSelectColumn._('updatedAt');
 
@@ -369,17 +355,17 @@ GNewsSelectColumn _$gNewsSelectColumnValueOf(String name) {
 
 final BuiltSet<GNewsSelectColumn> _$gNewsSelectColumnValues =
     new BuiltSet<GNewsSelectColumn>(const <GNewsSelectColumn>[
-      _$gNewsSelectColumncontent,
-      _$gNewsSelectColumncoverImageUrl,
-      _$gNewsSelectColumncreatedAt,
-      _$gNewsSelectColumnexcerpt,
-      _$gNewsSelectColumnid,
-      _$gNewsSelectColumnpublishedAt,
-      _$gNewsSelectColumnseoId,
-      _$gNewsSelectColumnslug,
-      _$gNewsSelectColumntitle,
-      _$gNewsSelectColumnupdatedAt,
-    ]);
+  _$gNewsSelectColumncontent,
+  _$gNewsSelectColumncoverImageUrl,
+  _$gNewsSelectColumncreatedAt,
+  _$gNewsSelectColumnexcerpt,
+  _$gNewsSelectColumnid,
+  _$gNewsSelectColumnpublishedAt,
+  _$gNewsSelectColumnseoId,
+  _$gNewsSelectColumnslug,
+  _$gNewsSelectColumntitle,
+  _$gNewsSelectColumnupdatedAt,
+]);
 
 const GNotificationsSelectColumn _$gNotificationsSelectColumncontent =
     const GNotificationsSelectColumn._('content');
@@ -431,25 +417,24 @@ GNotificationsSelectColumn _$gNotificationsSelectColumnValueOf(String name) {
 
 final BuiltSet<GNotificationsSelectColumn> _$gNotificationsSelectColumnValues =
     new BuiltSet<GNotificationsSelectColumn>(const <GNotificationsSelectColumn>[
-      _$gNotificationsSelectColumncontent,
-      _$gNotificationsSelectColumncoverImageUrl,
-      _$gNotificationsSelectColumncreatedAt,
-      _$gNotificationsSelectColumnexcerpt,
-      _$gNotificationsSelectColumnfirstOpenedAt,
-      _$gNotificationsSelectColumnid,
-      _$gNotificationsSelectColumnpublishedAt,
-      _$gNotificationsSelectColumntitle,
-      _$gNotificationsSelectColumnupdatedAt,
-      _$gNotificationsSelectColumnuserId,
-    ]);
+  _$gNotificationsSelectColumncontent,
+  _$gNotificationsSelectColumncoverImageUrl,
+  _$gNotificationsSelectColumncreatedAt,
+  _$gNotificationsSelectColumnexcerpt,
+  _$gNotificationsSelectColumnfirstOpenedAt,
+  _$gNotificationsSelectColumnid,
+  _$gNotificationsSelectColumnpublishedAt,
+  _$gNotificationsSelectColumntitle,
+  _$gNotificationsSelectColumnupdatedAt,
+  _$gNotificationsSelectColumnuserId,
+]);
 
 const GOrderBy _$gOrderByASC = const GOrderBy._('ASC');
 const GOrderBy _$gOrderByASC_NULLS_FIRST = const GOrderBy._('ASC_NULLS_FIRST');
 const GOrderBy _$gOrderByASC_NULLS_LAST = const GOrderBy._('ASC_NULLS_LAST');
 const GOrderBy _$gOrderByDESC = const GOrderBy._('DESC');
-const GOrderBy _$gOrderByDESC_NULLS_FIRST = const GOrderBy._(
-  'DESC_NULLS_FIRST',
-);
+const GOrderBy _$gOrderByDESC_NULLS_FIRST =
+    const GOrderBy._('DESC_NULLS_FIRST');
 const GOrderBy _$gOrderByDESC_NULLS_LAST = const GOrderBy._('DESC_NULLS_LAST');
 
 GOrderBy _$gOrderByValueOf(String name) {
@@ -473,13 +458,13 @@ GOrderBy _$gOrderByValueOf(String name) {
 
 final BuiltSet<GOrderBy> _$gOrderByValues =
     new BuiltSet<GOrderBy>(const <GOrderBy>[
-      _$gOrderByASC,
-      _$gOrderByASC_NULLS_FIRST,
-      _$gOrderByASC_NULLS_LAST,
-      _$gOrderByDESC,
-      _$gOrderByDESC_NULLS_FIRST,
-      _$gOrderByDESC_NULLS_LAST,
-    ]);
+  _$gOrderByASC,
+  _$gOrderByASC_NULLS_FIRST,
+  _$gOrderByASC_NULLS_LAST,
+  _$gOrderByDESC,
+  _$gOrderByDESC_NULLS_FIRST,
+  _$gOrderByDESC_NULLS_LAST,
+]);
 
 const GQuestCategoriesSelectColumn _$gQuestCategoriesSelectColumncreatedAt =
     const GQuestCategoriesSelectColumn._('createdAt');
@@ -495,8 +480,7 @@ const GQuestCategoriesSelectColumn _$gQuestCategoriesSelectColumnupdatedAt =
     const GQuestCategoriesSelectColumn._('updatedAt');
 
 GQuestCategoriesSelectColumn _$gQuestCategoriesSelectColumnValueOf(
-  String name,
-) {
+    String name) {
   switch (name) {
     case 'createdAt':
       return _$gQuestCategoriesSelectColumncreatedAt;
@@ -516,36 +500,28 @@ GQuestCategoriesSelectColumn _$gQuestCategoriesSelectColumnValueOf(
 }
 
 final BuiltSet<GQuestCategoriesSelectColumn>
-_$gQuestCategoriesSelectColumnValues =
-    new BuiltSet<GQuestCategoriesSelectColumn>(
-      const <GQuestCategoriesSelectColumn>[
-        _$gQuestCategoriesSelectColumncreatedAt,
-        _$gQuestCategoriesSelectColumndescription,
-        _$gQuestCategoriesSelectColumnid,
-        _$gQuestCategoriesSelectColumnGname,
-        _$gQuestCategoriesSelectColumnsortNumber,
-        _$gQuestCategoriesSelectColumnupdatedAt,
-      ],
-    );
+    _$gQuestCategoriesSelectColumnValues = new BuiltSet<
+        GQuestCategoriesSelectColumn>(const <GQuestCategoriesSelectColumn>[
+  _$gQuestCategoriesSelectColumncreatedAt,
+  _$gQuestCategoriesSelectColumndescription,
+  _$gQuestCategoriesSelectColumnid,
+  _$gQuestCategoriesSelectColumnGname,
+  _$gQuestCategoriesSelectColumnsortNumber,
+  _$gQuestCategoriesSelectColumnupdatedAt,
+]);
 
-const GQuestStatusEnum _$gQuestStatusEnumABORT = const GQuestStatusEnum._(
-  'ABORT',
-);
-const GQuestStatusEnum _$gQuestStatusEnumBACKLOG = const GQuestStatusEnum._(
-  'BACKLOG',
-);
-const GQuestStatusEnum _$gQuestStatusEnumCOMPLETED = const GQuestStatusEnum._(
-  'COMPLETED',
-);
-const GQuestStatusEnum _$gQuestStatusEnumIN_PROGRESS = const GQuestStatusEnum._(
-  'IN_PROGRESS',
-);
-const GQuestStatusEnum _$gQuestStatusEnumREADY = const GQuestStatusEnum._(
-  'READY',
-);
-const GQuestStatusEnum _$gQuestStatusEnumSUSPEND = const GQuestStatusEnum._(
-  'SUSPEND',
-);
+const GQuestStatusEnum _$gQuestStatusEnumABORT =
+    const GQuestStatusEnum._('ABORT');
+const GQuestStatusEnum _$gQuestStatusEnumBACKLOG =
+    const GQuestStatusEnum._('BACKLOG');
+const GQuestStatusEnum _$gQuestStatusEnumCOMPLETED =
+    const GQuestStatusEnum._('COMPLETED');
+const GQuestStatusEnum _$gQuestStatusEnumIN_PROGRESS =
+    const GQuestStatusEnum._('IN_PROGRESS');
+const GQuestStatusEnum _$gQuestStatusEnumREADY =
+    const GQuestStatusEnum._('READY');
+const GQuestStatusEnum _$gQuestStatusEnumSUSPEND =
+    const GQuestStatusEnum._('SUSPEND');
 
 GQuestStatusEnum _$gQuestStatusEnumValueOf(String name) {
   switch (name) {
@@ -568,13 +544,13 @@ GQuestStatusEnum _$gQuestStatusEnumValueOf(String name) {
 
 final BuiltSet<GQuestStatusEnum> _$gQuestStatusEnumValues =
     new BuiltSet<GQuestStatusEnum>(const <GQuestStatusEnum>[
-      _$gQuestStatusEnumABORT,
-      _$gQuestStatusEnumBACKLOG,
-      _$gQuestStatusEnumCOMPLETED,
-      _$gQuestStatusEnumIN_PROGRESS,
-      _$gQuestStatusEnumREADY,
-      _$gQuestStatusEnumSUSPEND,
-    ]);
+  _$gQuestStatusEnumABORT,
+  _$gQuestStatusEnumBACKLOG,
+  _$gQuestStatusEnumCOMPLETED,
+  _$gQuestStatusEnumIN_PROGRESS,
+  _$gQuestStatusEnumREADY,
+  _$gQuestStatusEnumSUSPEND,
+]);
 
 const GQuestStatusSelectColumn _$gQuestStatusSelectColumnvalue =
     const GQuestStatusSelectColumn._('value');
@@ -590,8 +566,8 @@ GQuestStatusSelectColumn _$gQuestStatusSelectColumnValueOf(String name) {
 
 final BuiltSet<GQuestStatusSelectColumn> _$gQuestStatusSelectColumnValues =
     new BuiltSet<GQuestStatusSelectColumn>(const <GQuestStatusSelectColumn>[
-      _$gQuestStatusSelectColumnvalue,
-    ]);
+  _$gQuestStatusSelectColumnvalue,
+]);
 
 const GSeosSelectColumn _$gSeosSelectColumncreatedAt =
     const GSeosSelectColumn._('createdAt');
@@ -600,9 +576,8 @@ const GSeosSelectColumn _$gSeosSelectColumndescription =
 const GSeosSelectColumn _$gSeosSelectColumnid = const GSeosSelectColumn._('id');
 const GSeosSelectColumn _$gSeosSelectColumnogImageUrl =
     const GSeosSelectColumn._('ogImageUrl');
-const GSeosSelectColumn _$gSeosSelectColumntitle = const GSeosSelectColumn._(
-  'title',
-);
+const GSeosSelectColumn _$gSeosSelectColumntitle =
+    const GSeosSelectColumn._('title');
 const GSeosSelectColumn _$gSeosSelectColumnupdatedAt =
     const GSeosSelectColumn._('updatedAt');
 
@@ -627,22 +602,21 @@ GSeosSelectColumn _$gSeosSelectColumnValueOf(String name) {
 
 final BuiltSet<GSeosSelectColumn> _$gSeosSelectColumnValues =
     new BuiltSet<GSeosSelectColumn>(const <GSeosSelectColumn>[
-      _$gSeosSelectColumncreatedAt,
-      _$gSeosSelectColumndescription,
-      _$gSeosSelectColumnid,
-      _$gSeosSelectColumnogImageUrl,
-      _$gSeosSelectColumntitle,
-      _$gSeosSelectColumnupdatedAt,
-    ]);
+  _$gSeosSelectColumncreatedAt,
+  _$gSeosSelectColumndescription,
+  _$gSeosSelectColumnid,
+  _$gSeosSelectColumnogImageUrl,
+  _$gSeosSelectColumntitle,
+  _$gSeosSelectColumnupdatedAt,
+]);
 
 const GTagsSelectColumn _$gTagsSelectColumncreatedAt =
     const GTagsSelectColumn._('createdAt');
 const GTagsSelectColumn _$gTagsSelectColumndescription =
     const GTagsSelectColumn._('description');
 const GTagsSelectColumn _$gTagsSelectColumnid = const GTagsSelectColumn._('id');
-const GTagsSelectColumn _$gTagsSelectColumntag = const GTagsSelectColumn._(
-  'tag',
-);
+const GTagsSelectColumn _$gTagsSelectColumntag =
+    const GTagsSelectColumn._('tag');
 const GTagsSelectColumn _$gTagsSelectColumnupdatedAt =
     const GTagsSelectColumn._('updatedAt');
 
@@ -665,22 +639,21 @@ GTagsSelectColumn _$gTagsSelectColumnValueOf(String name) {
 
 final BuiltSet<GTagsSelectColumn> _$gTagsSelectColumnValues =
     new BuiltSet<GTagsSelectColumn>(const <GTagsSelectColumn>[
-      _$gTagsSelectColumncreatedAt,
-      _$gTagsSelectColumndescription,
-      _$gTagsSelectColumnid,
-      _$gTagsSelectColumntag,
-      _$gTagsSelectColumnupdatedAt,
-    ]);
+  _$gTagsSelectColumncreatedAt,
+  _$gTagsSelectColumndescription,
+  _$gTagsSelectColumnid,
+  _$gTagsSelectColumntag,
+  _$gTagsSelectColumnupdatedAt,
+]);
 
 const GUserAchievementsSelectColumn
-_$gUserAchievementsSelectColumnachievementId =
+    _$gUserAchievementsSelectColumnachievementId =
     const GUserAchievementsSelectColumn._('achievementId');
 const GUserAchievementsSelectColumn _$gUserAchievementsSelectColumnuserId =
     const GUserAchievementsSelectColumn._('userId');
 
 GUserAchievementsSelectColumn _$gUserAchievementsSelectColumnValueOf(
-  String name,
-) {
+    String name) {
   switch (name) {
     case 'achievementId':
       return _$gUserAchievementsSelectColumnachievementId;
@@ -692,22 +665,18 @@ GUserAchievementsSelectColumn _$gUserAchievementsSelectColumnValueOf(
 }
 
 final BuiltSet<GUserAchievementsSelectColumn>
-_$gUserAchievementsSelectColumnValues =
-    new BuiltSet<GUserAchievementsSelectColumn>(
-      const <GUserAchievementsSelectColumn>[
-        _$gUserAchievementsSelectColumnachievementId,
-        _$gUserAchievementsSelectColumnuserId,
-      ],
-    );
+    _$gUserAchievementsSelectColumnValues = new BuiltSet<
+        GUserAchievementsSelectColumn>(const <GUserAchievementsSelectColumn>[
+  _$gUserAchievementsSelectColumnachievementId,
+  _$gUserAchievementsSelectColumnuserId,
+]);
 
 const GUsersSelectColumn _$gUsersSelectColumncreatedAt =
     const GUsersSelectColumn._('createdAt');
-const GUsersSelectColumn _$gUsersSelectColumnemail = const GUsersSelectColumn._(
-  'email',
-);
-const GUsersSelectColumn _$gUsersSelectColumnid = const GUsersSelectColumn._(
-  'id',
-);
+const GUsersSelectColumn _$gUsersSelectColumnemail =
+    const GUsersSelectColumn._('email');
+const GUsersSelectColumn _$gUsersSelectColumnid =
+    const GUsersSelectColumn._('id');
 const GUsersSelectColumn _$gUsersSelectColumnlastSeen =
     const GUsersSelectColumn._('lastSeen');
 const GUsersSelectColumn _$gUsersSelectColumnnickname =
@@ -748,16 +717,16 @@ GUsersSelectColumn _$gUsersSelectColumnValueOf(String name) {
 
 final BuiltSet<GUsersSelectColumn> _$gUsersSelectColumnValues =
     new BuiltSet<GUsersSelectColumn>(const <GUsersSelectColumn>[
-      _$gUsersSelectColumncreatedAt,
-      _$gUsersSelectColumnemail,
-      _$gUsersSelectColumnid,
-      _$gUsersSelectColumnlastSeen,
-      _$gUsersSelectColumnnickname,
-      _$gUsersSelectColumnpicture,
-      _$gUsersSelectColumnupdatedAt,
-      _$gUsersSelectColumnusername,
-      _$gUsersSelectColumnwebsite,
-    ]);
+  _$gUsersSelectColumncreatedAt,
+  _$gUsersSelectColumnemail,
+  _$gUsersSelectColumnid,
+  _$gUsersSelectColumnlastSeen,
+  _$gUsersSelectColumnnickname,
+  _$gUsersSelectColumnpicture,
+  _$gUsersSelectColumnupdatedAt,
+  _$gUsersSelectColumnusername,
+  _$gUsersSelectColumnwebsite,
+]);
 
 Serializer<GAchievementsBoolExp> _$gAchievementsBoolExpSerializer =
     new _$GAchievementsBoolExpSerializer();
@@ -766,10 +735,10 @@ Serializer<GAchievementsOrderBy> _$gAchievementsOrderBySerializer =
 Serializer<GAchievementsSelectColumn> _$gAchievementsSelectColumnSerializer =
     new _$GAchievementsSelectColumnSerializer();
 Serializer<GAchievementsStreamCursorInput>
-_$gAchievementsStreamCursorInputSerializer =
+    _$gAchievementsStreamCursorInputSerializer =
     new _$GAchievementsStreamCursorInputSerializer();
 Serializer<GAchievementsStreamCursorValueInput>
-_$gAchievementsStreamCursorValueInputSerializer =
+    _$gAchievementsStreamCursorValueInputSerializer =
     new _$GAchievementsStreamCursorValueInputSerializer();
 Serializer<GCursorOrdering> _$gCursorOrderingSerializer =
     new _$GCursorOrderingSerializer();
@@ -778,33 +747,33 @@ Serializer<GIntComparisonExp> _$gIntComparisonExpSerializer =
 Serializer<GMainQuestRelationsBoolExp> _$gMainQuestRelationsBoolExpSerializer =
     new _$GMainQuestRelationsBoolExpSerializer();
 Serializer<GMainQuestRelationsConstraint>
-_$gMainQuestRelationsConstraintSerializer =
+    _$gMainQuestRelationsConstraintSerializer =
     new _$GMainQuestRelationsConstraintSerializer();
 Serializer<GMainQuestRelationsInsertInput>
-_$gMainQuestRelationsInsertInputSerializer =
+    _$gMainQuestRelationsInsertInputSerializer =
     new _$GMainQuestRelationsInsertInputSerializer();
 Serializer<GMainQuestRelationsOnConflict>
-_$gMainQuestRelationsOnConflictSerializer =
+    _$gMainQuestRelationsOnConflictSerializer =
     new _$GMainQuestRelationsOnConflictSerializer();
 Serializer<GMainQuestRelationsOrderBy> _$gMainQuestRelationsOrderBySerializer =
     new _$GMainQuestRelationsOrderBySerializer();
 Serializer<GMainQuestRelationsPkColumnsInput>
-_$gMainQuestRelationsPkColumnsInputSerializer =
+    _$gMainQuestRelationsPkColumnsInputSerializer =
     new _$GMainQuestRelationsPkColumnsInputSerializer();
 Serializer<GMainQuestRelationsSelectColumn>
-_$gMainQuestRelationsSelectColumnSerializer =
+    _$gMainQuestRelationsSelectColumnSerializer =
     new _$GMainQuestRelationsSelectColumnSerializer();
 Serializer<GMainQuestRelationsSetInput>
-_$gMainQuestRelationsSetInputSerializer =
+    _$gMainQuestRelationsSetInputSerializer =
     new _$GMainQuestRelationsSetInputSerializer();
 Serializer<GMainQuestRelationsStreamCursorInput>
-_$gMainQuestRelationsStreamCursorInputSerializer =
+    _$gMainQuestRelationsStreamCursorInputSerializer =
     new _$GMainQuestRelationsStreamCursorInputSerializer();
 Serializer<GMainQuestRelationsStreamCursorValueInput>
-_$gMainQuestRelationsStreamCursorValueInputSerializer =
+    _$gMainQuestRelationsStreamCursorValueInputSerializer =
     new _$GMainQuestRelationsStreamCursorValueInputSerializer();
 Serializer<GMainQuestRelationsUpdateColumn>
-_$gMainQuestRelationsUpdateColumnSerializer =
+    _$gMainQuestRelationsUpdateColumnSerializer =
     new _$GMainQuestRelationsUpdateColumnSerializer();
 Serializer<GMainQuestRelationsUpdates> _$gMainQuestRelationsUpdatesSerializer =
     new _$GMainQuestRelationsUpdatesSerializer();
@@ -825,10 +794,10 @@ Serializer<GMainQuestsSelectColumn> _$gMainQuestsSelectColumnSerializer =
 Serializer<GMainQuestsSetInput> _$gMainQuestsSetInputSerializer =
     new _$GMainQuestsSetInputSerializer();
 Serializer<GMainQuestsStreamCursorInput>
-_$gMainQuestsStreamCursorInputSerializer =
+    _$gMainQuestsStreamCursorInputSerializer =
     new _$GMainQuestsStreamCursorInputSerializer();
 Serializer<GMainQuestsStreamCursorValueInput>
-_$gMainQuestsStreamCursorValueInputSerializer =
+    _$gMainQuestsStreamCursorValueInputSerializer =
     new _$GMainQuestsStreamCursorValueInputSerializer();
 Serializer<GMainQuestsUpdateColumn> _$gMainQuestsUpdateColumnSerializer =
     new _$GMainQuestsUpdateColumnSerializer();
@@ -843,7 +812,7 @@ Serializer<GNewsSelectColumn> _$gNewsSelectColumnSerializer =
 Serializer<GNewsStreamCursorInput> _$gNewsStreamCursorInputSerializer =
     new _$GNewsStreamCursorInputSerializer();
 Serializer<GNewsStreamCursorValueInput>
-_$gNewsStreamCursorValueInputSerializer =
+    _$gNewsStreamCursorValueInputSerializer =
     new _$GNewsStreamCursorValueInputSerializer();
 Serializer<GNotificationsBoolExp> _$gNotificationsBoolExpSerializer =
     new _$GNotificationsBoolExpSerializer();
@@ -852,10 +821,10 @@ Serializer<GNotificationsOrderBy> _$gNotificationsOrderBySerializer =
 Serializer<GNotificationsSelectColumn> _$gNotificationsSelectColumnSerializer =
     new _$GNotificationsSelectColumnSerializer();
 Serializer<GNotificationsStreamCursorInput>
-_$gNotificationsStreamCursorInputSerializer =
+    _$gNotificationsStreamCursorInputSerializer =
     new _$GNotificationsStreamCursorInputSerializer();
 Serializer<GNotificationsStreamCursorValueInput>
-_$gNotificationsStreamCursorValueInputSerializer =
+    _$gNotificationsStreamCursorValueInputSerializer =
     new _$GNotificationsStreamCursorValueInputSerializer();
 Serializer<GOrderBy> _$gOrderBySerializer = new _$GOrderBySerializer();
 Serializer<GQuestCategoriesBoolExp> _$gQuestCategoriesBoolExpSerializer =
@@ -863,30 +832,30 @@ Serializer<GQuestCategoriesBoolExp> _$gQuestCategoriesBoolExpSerializer =
 Serializer<GQuestCategoriesOrderBy> _$gQuestCategoriesOrderBySerializer =
     new _$GQuestCategoriesOrderBySerializer();
 Serializer<GQuestCategoriesSelectColumn>
-_$gQuestCategoriesSelectColumnSerializer =
+    _$gQuestCategoriesSelectColumnSerializer =
     new _$GQuestCategoriesSelectColumnSerializer();
 Serializer<GQuestCategoriesStreamCursorInput>
-_$gQuestCategoriesStreamCursorInputSerializer =
+    _$gQuestCategoriesStreamCursorInputSerializer =
     new _$GQuestCategoriesStreamCursorInputSerializer();
 Serializer<GQuestCategoriesStreamCursorValueInput>
-_$gQuestCategoriesStreamCursorValueInputSerializer =
+    _$gQuestCategoriesStreamCursorValueInputSerializer =
     new _$GQuestCategoriesStreamCursorValueInputSerializer();
 Serializer<GQuestStatusBoolExp> _$gQuestStatusBoolExpSerializer =
     new _$GQuestStatusBoolExpSerializer();
 Serializer<GQuestStatusEnum> _$gQuestStatusEnumSerializer =
     new _$GQuestStatusEnumSerializer();
 Serializer<GQuestStatusEnumComparisonExp>
-_$gQuestStatusEnumComparisonExpSerializer =
+    _$gQuestStatusEnumComparisonExpSerializer =
     new _$GQuestStatusEnumComparisonExpSerializer();
 Serializer<GQuestStatusOrderBy> _$gQuestStatusOrderBySerializer =
     new _$GQuestStatusOrderBySerializer();
 Serializer<GQuestStatusSelectColumn> _$gQuestStatusSelectColumnSerializer =
     new _$GQuestStatusSelectColumnSerializer();
 Serializer<GQuestStatusStreamCursorInput>
-_$gQuestStatusStreamCursorInputSerializer =
+    _$gQuestStatusStreamCursorInputSerializer =
     new _$GQuestStatusStreamCursorInputSerializer();
 Serializer<GQuestStatusStreamCursorValueInput>
-_$gQuestStatusStreamCursorValueInputSerializer =
+    _$gQuestStatusStreamCursorValueInputSerializer =
     new _$GQuestStatusStreamCursorValueInputSerializer();
 Serializer<GSeosBoolExp> _$gSeosBoolExpSerializer =
     new _$GSeosBoolExpSerializer();
@@ -897,7 +866,7 @@ Serializer<GSeosSelectColumn> _$gSeosSelectColumnSerializer =
 Serializer<GSeosStreamCursorInput> _$gSeosStreamCursorInputSerializer =
     new _$GSeosStreamCursorInputSerializer();
 Serializer<GSeosStreamCursorValueInput>
-_$gSeosStreamCursorValueInputSerializer =
+    _$gSeosStreamCursorValueInputSerializer =
     new _$GSeosStreamCursorValueInputSerializer();
 Serializer<GStringComparisonExp> _$gStringComparisonExpSerializer =
     new _$GStringComparisonExpSerializer();
@@ -910,7 +879,7 @@ Serializer<GTagsSelectColumn> _$gTagsSelectColumnSerializer =
 Serializer<GTagsStreamCursorInput> _$gTagsStreamCursorInputSerializer =
     new _$GTagsStreamCursorInputSerializer();
 Serializer<GTagsStreamCursorValueInput>
-_$gTagsStreamCursorValueInputSerializer =
+    _$gTagsStreamCursorValueInputSerializer =
     new _$GTagsStreamCursorValueInputSerializer();
 Serializer<GTimestamptzComparisonExp> _$gTimestamptzComparisonExpSerializer =
     new _$GTimestamptzComparisonExpSerializer();
@@ -919,13 +888,13 @@ Serializer<GUserAchievementsBoolExp> _$gUserAchievementsBoolExpSerializer =
 Serializer<GUserAchievementsOrderBy> _$gUserAchievementsOrderBySerializer =
     new _$GUserAchievementsOrderBySerializer();
 Serializer<GUserAchievementsSelectColumn>
-_$gUserAchievementsSelectColumnSerializer =
+    _$gUserAchievementsSelectColumnSerializer =
     new _$GUserAchievementsSelectColumnSerializer();
 Serializer<GUserAchievementsStreamCursorInput>
-_$gUserAchievementsStreamCursorInputSerializer =
+    _$gUserAchievementsStreamCursorInputSerializer =
     new _$GUserAchievementsStreamCursorInputSerializer();
 Serializer<GUserAchievementsStreamCursorValueInput>
-_$gUserAchievementsStreamCursorValueInputSerializer =
+    _$gUserAchievementsStreamCursorValueInputSerializer =
     new _$GUserAchievementsStreamCursorValueInputSerializer();
 Serializer<GUsersBoolExp> _$gUsersBoolExpSerializer =
     new _$GUsersBoolExpSerializer();
@@ -936,7 +905,7 @@ Serializer<GUsersSelectColumn> _$gUsersSelectColumnSerializer =
 Serializer<GUsersStreamCursorInput> _$gUsersStreamCursorInputSerializer =
     new _$GUsersStreamCursorInputSerializer();
 Serializer<GUsersStreamCursorValueInput>
-_$gUsersStreamCursorValueInputSerializer =
+    _$gUsersStreamCursorValueInputSerializer =
     new _$GUsersStreamCursorValueInputSerializer();
 Serializer<GUuidComparisonExp> _$gUuidComparisonExpSerializer =
     new _$GUuidComparisonExpSerializer();
@@ -946,120 +915,82 @@ class _$GAchievementsBoolExpSerializer
   @override
   final Iterable<Type> types = const [
     GAchievementsBoolExp,
-    _$GAchievementsBoolExp,
+    _$GAchievementsBoolExp
   ];
   @override
   final String wireName = 'GAchievementsBoolExp';
 
   @override
   Iterable<Object?> serialize(
-    Serializers serializers,
-    GAchievementsBoolExp object, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, GAchievementsBoolExp object,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[];
     Object? value;
     value = object.G_and;
     if (value != null) {
       result
         ..add('_and')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(BuiltList, const [
-              const FullType(GAchievementsBoolExp),
-            ]),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(
+                BuiltList, const [const FullType(GAchievementsBoolExp)])));
     }
     value = object.G_not;
     if (value != null) {
       result
         ..add('_not')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GAchievementsBoolExp),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GAchievementsBoolExp)));
     }
     value = object.G_or;
     if (value != null) {
       result
         ..add('_or')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(BuiltList, const [
-              const FullType(GAchievementsBoolExp),
-            ]),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(
+                BuiltList, const [const FullType(GAchievementsBoolExp)])));
     }
     value = object.createdAt;
     if (value != null) {
       result
         ..add('createdAt')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GTimestamptzComparisonExp),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GTimestamptzComparisonExp)));
     }
     value = object.description;
     if (value != null) {
       result
         ..add('description')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GStringComparisonExp),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GStringComparisonExp)));
     }
     value = object.id;
     if (value != null) {
       result
         ..add('id')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GUuidComparisonExp),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GUuidComparisonExp)));
     }
     value = object.name;
     if (value != null) {
       result
         ..add('name')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GStringComparisonExp),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GStringComparisonExp)));
     }
     value = object.updatedAt;
     if (value != null) {
       result
         ..add('updatedAt')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GTimestamptzComparisonExp),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GTimestamptzComparisonExp)));
     }
     return result;
   }
 
   @override
   GAchievementsBoolExp deserialize(
-    Serializers serializers,
-    Iterable<Object?> serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = new GAchievementsBoolExpBuilder();
 
     final iterator = serialized.iterator;
@@ -1069,80 +1000,46 @@ class _$GAchievementsBoolExpSerializer
       final Object? value = iterator.current;
       switch (key) {
         case '_and':
-          result.G_and.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(BuiltList, const [
-                    const FullType(GAchievementsBoolExp),
-                  ]),
-                )!
-                as BuiltList<Object?>,
-          );
+          result.G_and.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(
+                      BuiltList, const [const FullType(GAchievementsBoolExp)]))!
+              as BuiltList<Object?>);
           break;
         case '_not':
-          result.G_not.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(GAchievementsBoolExp),
-                )!
-                as GAchievementsBoolExp,
-          );
+          result.G_not.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(GAchievementsBoolExp))!
+              as GAchievementsBoolExp);
           break;
         case '_or':
-          result.G_or.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(BuiltList, const [
-                    const FullType(GAchievementsBoolExp),
-                  ]),
-                )!
-                as BuiltList<Object?>,
-          );
+          result.G_or.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(
+                      BuiltList, const [const FullType(GAchievementsBoolExp)]))!
+              as BuiltList<Object?>);
           break;
         case 'createdAt':
-          result.createdAt.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(GTimestamptzComparisonExp),
-                )!
-                as GTimestamptzComparisonExp,
-          );
+          result.createdAt.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(GTimestamptzComparisonExp))!
+              as GTimestamptzComparisonExp);
           break;
         case 'description':
-          result.description.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(GStringComparisonExp),
-                )!
-                as GStringComparisonExp,
-          );
+          result.description.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(GStringComparisonExp))!
+              as GStringComparisonExp);
           break;
         case 'id':
-          result.id.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(GUuidComparisonExp),
-                )!
-                as GUuidComparisonExp,
-          );
+          result.id.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(GUuidComparisonExp))!
+              as GUuidComparisonExp);
           break;
         case 'name':
-          result.name.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(GStringComparisonExp),
-                )!
-                as GStringComparisonExp,
-          );
+          result.name.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(GStringComparisonExp))!
+              as GStringComparisonExp);
           break;
         case 'updatedAt':
-          result.updatedAt.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(GTimestamptzComparisonExp),
-                )!
-                as GTimestamptzComparisonExp,
-          );
+          result.updatedAt.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(GTimestamptzComparisonExp))!
+              as GTimestamptzComparisonExp);
           break;
       }
     }
@@ -1156,68 +1053,59 @@ class _$GAchievementsOrderBySerializer
   @override
   final Iterable<Type> types = const [
     GAchievementsOrderBy,
-    _$GAchievementsOrderBy,
+    _$GAchievementsOrderBy
   ];
   @override
   final String wireName = 'GAchievementsOrderBy';
 
   @override
   Iterable<Object?> serialize(
-    Serializers serializers,
-    GAchievementsOrderBy object, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, GAchievementsOrderBy object,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[];
     Object? value;
     value = object.createdAt;
     if (value != null) {
       result
         ..add('createdAt')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(GOrderBy)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GOrderBy)));
     }
     value = object.description;
     if (value != null) {
       result
         ..add('description')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(GOrderBy)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GOrderBy)));
     }
     value = object.id;
     if (value != null) {
       result
         ..add('id')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(GOrderBy)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GOrderBy)));
     }
     value = object.name;
     if (value != null) {
       result
         ..add('name')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(GOrderBy)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GOrderBy)));
     }
     value = object.updatedAt;
     if (value != null) {
       result
         ..add('updatedAt')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(GOrderBy)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GOrderBy)));
     }
     return result;
   }
 
   @override
   GAchievementsOrderBy deserialize(
-    Serializers serializers,
-    Iterable<Object?> serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = new GAchievementsOrderByBuilder();
 
     final iterator = serialized.iterator;
@@ -1227,44 +1115,24 @@ class _$GAchievementsOrderBySerializer
       final Object? value = iterator.current;
       switch (key) {
         case 'createdAt':
-          result.createdAt =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(GOrderBy),
-                  )
-                  as GOrderBy?;
+          result.createdAt = serializers.deserialize(value,
+              specifiedType: const FullType(GOrderBy)) as GOrderBy?;
           break;
         case 'description':
-          result.description =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(GOrderBy),
-                  )
-                  as GOrderBy?;
+          result.description = serializers.deserialize(value,
+              specifiedType: const FullType(GOrderBy)) as GOrderBy?;
           break;
         case 'id':
-          result.id =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(GOrderBy),
-                  )
-                  as GOrderBy?;
+          result.id = serializers.deserialize(value,
+              specifiedType: const FullType(GOrderBy)) as GOrderBy?;
           break;
         case 'name':
-          result.name =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(GOrderBy),
-                  )
-                  as GOrderBy?;
+          result.name = serializers.deserialize(value,
+              specifiedType: const FullType(GOrderBy)) as GOrderBy?;
           break;
         case 'updatedAt':
-          result.updatedAt =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(GOrderBy),
-                  )
-                  as GOrderBy?;
+          result.updatedAt = serializers.deserialize(value,
+              specifiedType: const FullType(GOrderBy)) as GOrderBy?;
           break;
       }
     }
@@ -1288,20 +1156,16 @@ class _$GAchievementsSelectColumnSerializer
   final String wireName = 'GAchievementsSelectColumn';
 
   @override
-  Object serialize(
-    Serializers serializers,
-    GAchievementsSelectColumn object, {
-    FullType specifiedType = FullType.unspecified,
-  }) => _toWire[object.name] ?? object.name;
+  Object serialize(Serializers serializers, GAchievementsSelectColumn object,
+          {FullType specifiedType = FullType.unspecified}) =>
+      _toWire[object.name] ?? object.name;
 
   @override
   GAchievementsSelectColumn deserialize(
-    Serializers serializers,
-    Object serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) => GAchievementsSelectColumn.valueOf(
-    _fromWire[serialized] ?? (serialized is String ? serialized : ''),
-  );
+          Serializers serializers, Object serialized,
+          {FullType specifiedType = FullType.unspecified}) =>
+      GAchievementsSelectColumn.valueOf(
+          _fromWire[serialized] ?? (serialized is String ? serialized : ''));
 }
 
 class _$GAchievementsStreamCursorInputSerializer
@@ -1309,45 +1173,35 @@ class _$GAchievementsStreamCursorInputSerializer
   @override
   final Iterable<Type> types = const [
     GAchievementsStreamCursorInput,
-    _$GAchievementsStreamCursorInput,
+    _$GAchievementsStreamCursorInput
   ];
   @override
   final String wireName = 'GAchievementsStreamCursorInput';
 
   @override
   Iterable<Object?> serialize(
-    Serializers serializers,
-    GAchievementsStreamCursorInput object, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, GAchievementsStreamCursorInput object,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[
       'initialValue',
-      serializers.serialize(
-        object.initialValue,
-        specifiedType: const FullType(GAchievementsStreamCursorValueInput),
-      ),
+      serializers.serialize(object.initialValue,
+          specifiedType: const FullType(GAchievementsStreamCursorValueInput)),
     ];
     Object? value;
     value = object.ordering;
     if (value != null) {
       result
         ..add('ordering')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GCursorOrdering),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GCursorOrdering)));
     }
     return result;
   }
 
   @override
   GAchievementsStreamCursorInput deserialize(
-    Serializers serializers,
-    Iterable<Object?> serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = new GAchievementsStreamCursorInputBuilder();
 
     final iterator = serialized.iterator;
@@ -1357,23 +1211,15 @@ class _$GAchievementsStreamCursorInputSerializer
       final Object? value = iterator.current;
       switch (key) {
         case 'initialValue':
-          result.initialValue.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(
-                    GAchievementsStreamCursorValueInput,
-                  ),
-                )!
-                as GAchievementsStreamCursorValueInput,
-          );
+          result.initialValue.replace(serializers.deserialize(value,
+                  specifiedType:
+                      const FullType(GAchievementsStreamCursorValueInput))!
+              as GAchievementsStreamCursorValueInput);
           break;
         case 'ordering':
-          result.ordering =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(GCursorOrdering),
-                  )
-                  as GCursorOrdering?;
+          result.ordering = serializers.deserialize(value,
+                  specifiedType: const FullType(GCursorOrdering))
+              as GCursorOrdering?;
           break;
       }
     }
@@ -1387,68 +1233,59 @@ class _$GAchievementsStreamCursorValueInputSerializer
   @override
   final Iterable<Type> types = const [
     GAchievementsStreamCursorValueInput,
-    _$GAchievementsStreamCursorValueInput,
+    _$GAchievementsStreamCursorValueInput
   ];
   @override
   final String wireName = 'GAchievementsStreamCursorValueInput';
 
   @override
   Iterable<Object?> serialize(
-    Serializers serializers,
-    GAchievementsStreamCursorValueInput object, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, GAchievementsStreamCursorValueInput object,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[];
     Object? value;
     value = object.createdAt;
     if (value != null) {
       result
         ..add('createdAt')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(DateTime)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(DateTime)));
     }
     value = object.description;
     if (value != null) {
       result
         ..add('description')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(String)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
     }
     value = object.id;
     if (value != null) {
       result
         ..add('id')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(String)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
     }
     value = object.name;
     if (value != null) {
       result
         ..add('name')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(String)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
     }
     value = object.updatedAt;
     if (value != null) {
       result
         ..add('updatedAt')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(DateTime)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(DateTime)));
     }
     return result;
   }
 
   @override
   GAchievementsStreamCursorValueInput deserialize(
-    Serializers serializers,
-    Iterable<Object?> serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = new GAchievementsStreamCursorValueInputBuilder();
 
     final iterator = serialized.iterator;
@@ -1458,44 +1295,24 @@ class _$GAchievementsStreamCursorValueInputSerializer
       final Object? value = iterator.current;
       switch (key) {
         case 'createdAt':
-          result.createdAt =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(DateTime),
-                  )
-                  as DateTime?;
+          result.createdAt = serializers.deserialize(value,
+              specifiedType: const FullType(DateTime)) as DateTime?;
           break;
         case 'description':
-          result.description =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )
-                  as String?;
+          result.description = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
           break;
         case 'id':
-          result.id =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )
-                  as String?;
+          result.id = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
           break;
         case 'name':
-          result.name =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )
-                  as String?;
+          result.name = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
           break;
         case 'updatedAt':
-          result.updatedAt =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(DateTime),
-                  )
-                  as DateTime?;
+          result.updatedAt = serializers.deserialize(value,
+              specifiedType: const FullType(DateTime)) as DateTime?;
           break;
       }
     }
@@ -1512,18 +1329,14 @@ class _$GCursorOrderingSerializer
   final String wireName = 'GCursorOrdering';
 
   @override
-  Object serialize(
-    Serializers serializers,
-    GCursorOrdering object, {
-    FullType specifiedType = FullType.unspecified,
-  }) => object.name;
+  Object serialize(Serializers serializers, GCursorOrdering object,
+          {FullType specifiedType = FullType.unspecified}) =>
+      object.name;
 
   @override
-  GCursorOrdering deserialize(
-    Serializers serializers,
-    Object serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) => GCursorOrdering.valueOf(serialized as String);
+  GCursorOrdering deserialize(Serializers serializers, Object serialized,
+          {FullType specifiedType = FullType.unspecified}) =>
+      GCursorOrdering.valueOf(serialized as String);
 }
 
 class _$GIntComparisonExpSerializer
@@ -1534,11 +1347,8 @@ class _$GIntComparisonExpSerializer
   final String wireName = 'GIntComparisonExp';
 
   @override
-  Iterable<Object?> serialize(
-    Serializers serializers,
-    GIntComparisonExp object, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+  Iterable<Object?> serialize(Serializers serializers, GIntComparisonExp object,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[];
     Object? value;
     value = object.G_eq;
@@ -1563,22 +1373,16 @@ class _$GIntComparisonExpSerializer
     if (value != null) {
       result
         ..add('_in')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(BuiltList, const [
-              const FullType(int),
-            ]),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType:
+                const FullType(BuiltList, const [const FullType(int)])));
     }
     value = object.G_isNull;
     if (value != null) {
       result
         ..add('_isNull')
         ..add(
-          serializers.serialize(value, specifiedType: const FullType(bool)),
-        );
+            serializers.serialize(value, specifiedType: const FullType(bool)));
     }
     value = object.G_lt;
     if (value != null) {
@@ -1602,24 +1406,17 @@ class _$GIntComparisonExpSerializer
     if (value != null) {
       result
         ..add('_nin')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(BuiltList, const [
-              const FullType(int),
-            ]),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType:
+                const FullType(BuiltList, const [const FullType(int)])));
     }
     return result;
   }
 
   @override
   GIntComparisonExp deserialize(
-    Serializers serializers,
-    Iterable<Object?> serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = new GIntComparisonExpBuilder();
 
     final iterator = serialized.iterator;
@@ -1629,64 +1426,44 @@ class _$GIntComparisonExpSerializer
       final Object? value = iterator.current;
       switch (key) {
         case '_eq':
-          result.G_eq =
-              serializers.deserialize(value, specifiedType: const FullType(int))
-                  as int?;
+          result.G_eq = serializers.deserialize(value,
+              specifiedType: const FullType(int)) as int?;
           break;
         case '_gt':
-          result.G_gt =
-              serializers.deserialize(value, specifiedType: const FullType(int))
-                  as int?;
+          result.G_gt = serializers.deserialize(value,
+              specifiedType: const FullType(int)) as int?;
           break;
         case '_gte':
-          result.G_gte =
-              serializers.deserialize(value, specifiedType: const FullType(int))
-                  as int?;
+          result.G_gte = serializers.deserialize(value,
+              specifiedType: const FullType(int)) as int?;
           break;
         case '_in':
-          result.G_in.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(BuiltList, const [
-                    const FullType(int),
-                  ]),
-                )!
-                as BuiltList<Object?>,
-          );
+          result.G_in.replace(serializers.deserialize(value,
+                  specifiedType:
+                      const FullType(BuiltList, const [const FullType(int)]))!
+              as BuiltList<Object?>);
           break;
         case '_isNull':
-          result.G_isNull =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(bool),
-                  )
-                  as bool?;
+          result.G_isNull = serializers.deserialize(value,
+              specifiedType: const FullType(bool)) as bool?;
           break;
         case '_lt':
-          result.G_lt =
-              serializers.deserialize(value, specifiedType: const FullType(int))
-                  as int?;
+          result.G_lt = serializers.deserialize(value,
+              specifiedType: const FullType(int)) as int?;
           break;
         case '_lte':
-          result.G_lte =
-              serializers.deserialize(value, specifiedType: const FullType(int))
-                  as int?;
+          result.G_lte = serializers.deserialize(value,
+              specifiedType: const FullType(int)) as int?;
           break;
         case '_neq':
-          result.G_neq =
-              serializers.deserialize(value, specifiedType: const FullType(int))
-                  as int?;
+          result.G_neq = serializers.deserialize(value,
+              specifiedType: const FullType(int)) as int?;
           break;
         case '_nin':
-          result.G_nin.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(BuiltList, const [
-                    const FullType(int),
-                  ]),
-                )!
-                as BuiltList<Object?>,
-          );
+          result.G_nin.replace(serializers.deserialize(value,
+                  specifiedType:
+                      const FullType(BuiltList, const [const FullType(int)]))!
+              as BuiltList<Object?>);
           break;
       }
     }
@@ -1700,87 +1477,61 @@ class _$GMainQuestRelationsBoolExpSerializer
   @override
   final Iterable<Type> types = const [
     GMainQuestRelationsBoolExp,
-    _$GMainQuestRelationsBoolExp,
+    _$GMainQuestRelationsBoolExp
   ];
   @override
   final String wireName = 'GMainQuestRelationsBoolExp';
 
   @override
   Iterable<Object?> serialize(
-    Serializers serializers,
-    GMainQuestRelationsBoolExp object, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, GMainQuestRelationsBoolExp object,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[];
     Object? value;
     value = object.G_and;
     if (value != null) {
       result
         ..add('_and')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(BuiltList, const [
-              const FullType(GMainQuestRelationsBoolExp),
-            ]),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(BuiltList,
+                const [const FullType(GMainQuestRelationsBoolExp)])));
     }
     value = object.G_not;
     if (value != null) {
       result
         ..add('_not')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GMainQuestRelationsBoolExp),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GMainQuestRelationsBoolExp)));
     }
     value = object.G_or;
     if (value != null) {
       result
         ..add('_or')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(BuiltList, const [
-              const FullType(GMainQuestRelationsBoolExp),
-            ]),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(BuiltList,
+                const [const FullType(GMainQuestRelationsBoolExp)])));
     }
     value = object.childQuestId;
     if (value != null) {
       result
         ..add('childQuestId')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GUuidComparisonExp),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GUuidComparisonExp)));
     }
     value = object.parentQuestId;
     if (value != null) {
       result
         ..add('parentQuestId')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GUuidComparisonExp),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GUuidComparisonExp)));
     }
     return result;
   }
 
   @override
   GMainQuestRelationsBoolExp deserialize(
-    Serializers serializers,
-    Iterable<Object?> serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = new GMainQuestRelationsBoolExpBuilder();
 
     final iterator = serialized.iterator;
@@ -1790,53 +1541,31 @@ class _$GMainQuestRelationsBoolExpSerializer
       final Object? value = iterator.current;
       switch (key) {
         case '_and':
-          result.G_and.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(BuiltList, const [
-                    const FullType(GMainQuestRelationsBoolExp),
-                  ]),
-                )!
-                as BuiltList<Object?>,
-          );
+          result.G_and.replace(serializers.deserialize(value,
+              specifiedType: const FullType(BuiltList, const [
+                const FullType(GMainQuestRelationsBoolExp)
+              ]))! as BuiltList<Object?>);
           break;
         case '_not':
-          result.G_not.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(GMainQuestRelationsBoolExp),
-                )!
-                as GMainQuestRelationsBoolExp,
-          );
+          result.G_not.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(GMainQuestRelationsBoolExp))!
+              as GMainQuestRelationsBoolExp);
           break;
         case '_or':
-          result.G_or.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(BuiltList, const [
-                    const FullType(GMainQuestRelationsBoolExp),
-                  ]),
-                )!
-                as BuiltList<Object?>,
-          );
+          result.G_or.replace(serializers.deserialize(value,
+              specifiedType: const FullType(BuiltList, const [
+                const FullType(GMainQuestRelationsBoolExp)
+              ]))! as BuiltList<Object?>);
           break;
         case 'childQuestId':
-          result.childQuestId.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(GUuidComparisonExp),
-                )!
-                as GUuidComparisonExp,
-          );
+          result.childQuestId.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(GUuidComparisonExp))!
+              as GUuidComparisonExp);
           break;
         case 'parentQuestId':
-          result.parentQuestId.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(GUuidComparisonExp),
-                )!
-                as GUuidComparisonExp,
-          );
+          result.parentQuestId.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(GUuidComparisonExp))!
+              as GUuidComparisonExp);
           break;
       }
     }
@@ -1854,17 +1583,15 @@ class _$GMainQuestRelationsConstraintSerializer
 
   @override
   Object serialize(
-    Serializers serializers,
-    GMainQuestRelationsConstraint object, {
-    FullType specifiedType = FullType.unspecified,
-  }) => object.name;
+          Serializers serializers, GMainQuestRelationsConstraint object,
+          {FullType specifiedType = FullType.unspecified}) =>
+      object.name;
 
   @override
   GMainQuestRelationsConstraint deserialize(
-    Serializers serializers,
-    Object serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) => GMainQuestRelationsConstraint.valueOf(serialized as String);
+          Serializers serializers, Object serialized,
+          {FullType specifiedType = FullType.unspecified}) =>
+      GMainQuestRelationsConstraint.valueOf(serialized as String);
 }
 
 class _$GMainQuestRelationsInsertInputSerializer
@@ -1872,44 +1599,38 @@ class _$GMainQuestRelationsInsertInputSerializer
   @override
   final Iterable<Type> types = const [
     GMainQuestRelationsInsertInput,
-    _$GMainQuestRelationsInsertInput,
+    _$GMainQuestRelationsInsertInput
   ];
   @override
   final String wireName = 'GMainQuestRelationsInsertInput';
 
   @override
   Iterable<Object?> serialize(
-    Serializers serializers,
-    GMainQuestRelationsInsertInput object, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, GMainQuestRelationsInsertInput object,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[];
     Object? value;
     value = object.childQuestId;
     if (value != null) {
       result
         ..add('childQuestId')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(String)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
     }
     value = object.parentQuestId;
     if (value != null) {
       result
         ..add('parentQuestId')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(String)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
     }
     return result;
   }
 
   @override
   GMainQuestRelationsInsertInput deserialize(
-    Serializers serializers,
-    Iterable<Object?> serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = new GMainQuestRelationsInsertInputBuilder();
 
     final iterator = serialized.iterator;
@@ -1919,20 +1640,12 @@ class _$GMainQuestRelationsInsertInputSerializer
       final Object? value = iterator.current;
       switch (key) {
         case 'childQuestId':
-          result.childQuestId =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )
-                  as String?;
+          result.childQuestId = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
           break;
         case 'parentQuestId':
-          result.parentQuestId =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )
-                  as String?;
+          result.parentQuestId = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
           break;
       }
     }
@@ -1946,52 +1659,39 @@ class _$GMainQuestRelationsOnConflictSerializer
   @override
   final Iterable<Type> types = const [
     GMainQuestRelationsOnConflict,
-    _$GMainQuestRelationsOnConflict,
+    _$GMainQuestRelationsOnConflict
   ];
   @override
   final String wireName = 'GMainQuestRelationsOnConflict';
 
   @override
   Iterable<Object?> serialize(
-    Serializers serializers,
-    GMainQuestRelationsOnConflict object, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, GMainQuestRelationsOnConflict object,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[
       'constraint',
-      serializers.serialize(
-        object.constraint,
-        specifiedType: const FullType(GMainQuestRelationsConstraint),
-      ),
+      serializers.serialize(object.constraint,
+          specifiedType: const FullType(GMainQuestRelationsConstraint)),
       'updateColumns',
-      serializers.serialize(
-        object.updateColumns,
-        specifiedType: const FullType(BuiltList, const [
-          const FullType(GMainQuestRelationsUpdateColumn),
-        ]),
-      ),
+      serializers.serialize(object.updateColumns,
+          specifiedType: const FullType(BuiltList,
+              const [const FullType(GMainQuestRelationsUpdateColumn)])),
     ];
     Object? value;
     value = object.where;
     if (value != null) {
       result
         ..add('where')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GMainQuestRelationsBoolExp),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GMainQuestRelationsBoolExp)));
     }
     return result;
   }
 
   @override
   GMainQuestRelationsOnConflict deserialize(
-    Serializers serializers,
-    Iterable<Object?> serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = new GMainQuestRelationsOnConflictBuilder();
 
     final iterator = serialized.iterator;
@@ -2001,34 +1701,20 @@ class _$GMainQuestRelationsOnConflictSerializer
       final Object? value = iterator.current;
       switch (key) {
         case 'constraint':
-          result.constraint =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(
-                      GMainQuestRelationsConstraint,
-                    ),
-                  )!
-                  as GMainQuestRelationsConstraint;
+          result.constraint = serializers.deserialize(value,
+                  specifiedType: const FullType(GMainQuestRelationsConstraint))!
+              as GMainQuestRelationsConstraint;
           break;
         case 'updateColumns':
-          result.updateColumns.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(BuiltList, const [
-                    const FullType(GMainQuestRelationsUpdateColumn),
-                  ]),
-                )!
-                as BuiltList<Object?>,
-          );
+          result.updateColumns.replace(serializers.deserialize(value,
+              specifiedType: const FullType(BuiltList, const [
+                const FullType(GMainQuestRelationsUpdateColumn)
+              ]))! as BuiltList<Object?>);
           break;
         case 'where':
-          result.where.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(GMainQuestRelationsBoolExp),
-                )!
-                as GMainQuestRelationsBoolExp,
-          );
+          result.where.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(GMainQuestRelationsBoolExp))!
+              as GMainQuestRelationsBoolExp);
           break;
       }
     }
@@ -2042,44 +1728,38 @@ class _$GMainQuestRelationsOrderBySerializer
   @override
   final Iterable<Type> types = const [
     GMainQuestRelationsOrderBy,
-    _$GMainQuestRelationsOrderBy,
+    _$GMainQuestRelationsOrderBy
   ];
   @override
   final String wireName = 'GMainQuestRelationsOrderBy';
 
   @override
   Iterable<Object?> serialize(
-    Serializers serializers,
-    GMainQuestRelationsOrderBy object, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, GMainQuestRelationsOrderBy object,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[];
     Object? value;
     value = object.childQuestId;
     if (value != null) {
       result
         ..add('childQuestId')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(GOrderBy)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GOrderBy)));
     }
     value = object.parentQuestId;
     if (value != null) {
       result
         ..add('parentQuestId')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(GOrderBy)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GOrderBy)));
     }
     return result;
   }
 
   @override
   GMainQuestRelationsOrderBy deserialize(
-    Serializers serializers,
-    Iterable<Object?> serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = new GMainQuestRelationsOrderByBuilder();
 
     final iterator = serialized.iterator;
@@ -2089,20 +1769,12 @@ class _$GMainQuestRelationsOrderBySerializer
       final Object? value = iterator.current;
       switch (key) {
         case 'childQuestId':
-          result.childQuestId =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(GOrderBy),
-                  )
-                  as GOrderBy?;
+          result.childQuestId = serializers.deserialize(value,
+              specifiedType: const FullType(GOrderBy)) as GOrderBy?;
           break;
         case 'parentQuestId':
-          result.parentQuestId =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(GOrderBy),
-                  )
-                  as GOrderBy?;
+          result.parentQuestId = serializers.deserialize(value,
+              specifiedType: const FullType(GOrderBy)) as GOrderBy?;
           break;
       }
     }
@@ -2116,28 +1788,22 @@ class _$GMainQuestRelationsPkColumnsInputSerializer
   @override
   final Iterable<Type> types = const [
     GMainQuestRelationsPkColumnsInput,
-    _$GMainQuestRelationsPkColumnsInput,
+    _$GMainQuestRelationsPkColumnsInput
   ];
   @override
   final String wireName = 'GMainQuestRelationsPkColumnsInput';
 
   @override
   Iterable<Object?> serialize(
-    Serializers serializers,
-    GMainQuestRelationsPkColumnsInput object, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, GMainQuestRelationsPkColumnsInput object,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[
       'childQuestId',
-      serializers.serialize(
-        object.childQuestId,
-        specifiedType: const FullType(String),
-      ),
+      serializers.serialize(object.childQuestId,
+          specifiedType: const FullType(String)),
       'parentQuestId',
-      serializers.serialize(
-        object.parentQuestId,
-        specifiedType: const FullType(String),
-      ),
+      serializers.serialize(object.parentQuestId,
+          specifiedType: const FullType(String)),
     ];
 
     return result;
@@ -2145,10 +1811,8 @@ class _$GMainQuestRelationsPkColumnsInputSerializer
 
   @override
   GMainQuestRelationsPkColumnsInput deserialize(
-    Serializers serializers,
-    Iterable<Object?> serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = new GMainQuestRelationsPkColumnsInputBuilder();
 
     final iterator = serialized.iterator;
@@ -2158,20 +1822,12 @@ class _$GMainQuestRelationsPkColumnsInputSerializer
       final Object? value = iterator.current;
       switch (key) {
         case 'childQuestId':
-          result.childQuestId =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )!
-                  as String;
+          result.childQuestId = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
           break;
         case 'parentQuestId':
-          result.parentQuestId =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )!
-                  as String;
+          result.parentQuestId = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
           break;
       }
     }
@@ -2189,17 +1845,15 @@ class _$GMainQuestRelationsSelectColumnSerializer
 
   @override
   Object serialize(
-    Serializers serializers,
-    GMainQuestRelationsSelectColumn object, {
-    FullType specifiedType = FullType.unspecified,
-  }) => object.name;
+          Serializers serializers, GMainQuestRelationsSelectColumn object,
+          {FullType specifiedType = FullType.unspecified}) =>
+      object.name;
 
   @override
   GMainQuestRelationsSelectColumn deserialize(
-    Serializers serializers,
-    Object serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) => GMainQuestRelationsSelectColumn.valueOf(serialized as String);
+          Serializers serializers, Object serialized,
+          {FullType specifiedType = FullType.unspecified}) =>
+      GMainQuestRelationsSelectColumn.valueOf(serialized as String);
 }
 
 class _$GMainQuestRelationsSetInputSerializer
@@ -2207,44 +1861,38 @@ class _$GMainQuestRelationsSetInputSerializer
   @override
   final Iterable<Type> types = const [
     GMainQuestRelationsSetInput,
-    _$GMainQuestRelationsSetInput,
+    _$GMainQuestRelationsSetInput
   ];
   @override
   final String wireName = 'GMainQuestRelationsSetInput';
 
   @override
   Iterable<Object?> serialize(
-    Serializers serializers,
-    GMainQuestRelationsSetInput object, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, GMainQuestRelationsSetInput object,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[];
     Object? value;
     value = object.childQuestId;
     if (value != null) {
       result
         ..add('childQuestId')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(String)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
     }
     value = object.parentQuestId;
     if (value != null) {
       result
         ..add('parentQuestId')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(String)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
     }
     return result;
   }
 
   @override
   GMainQuestRelationsSetInput deserialize(
-    Serializers serializers,
-    Iterable<Object?> serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = new GMainQuestRelationsSetInputBuilder();
 
     final iterator = serialized.iterator;
@@ -2254,20 +1902,12 @@ class _$GMainQuestRelationsSetInputSerializer
       final Object? value = iterator.current;
       switch (key) {
         case 'childQuestId':
-          result.childQuestId =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )
-                  as String?;
+          result.childQuestId = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
           break;
         case 'parentQuestId':
-          result.parentQuestId =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )
-                  as String?;
+          result.parentQuestId = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
           break;
       }
     }
@@ -2281,47 +1921,36 @@ class _$GMainQuestRelationsStreamCursorInputSerializer
   @override
   final Iterable<Type> types = const [
     GMainQuestRelationsStreamCursorInput,
-    _$GMainQuestRelationsStreamCursorInput,
+    _$GMainQuestRelationsStreamCursorInput
   ];
   @override
   final String wireName = 'GMainQuestRelationsStreamCursorInput';
 
   @override
   Iterable<Object?> serialize(
-    Serializers serializers,
-    GMainQuestRelationsStreamCursorInput object, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, GMainQuestRelationsStreamCursorInput object,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[
       'initialValue',
-      serializers.serialize(
-        object.initialValue,
-        specifiedType: const FullType(
-          GMainQuestRelationsStreamCursorValueInput,
-        ),
-      ),
+      serializers.serialize(object.initialValue,
+          specifiedType:
+              const FullType(GMainQuestRelationsStreamCursorValueInput)),
     ];
     Object? value;
     value = object.ordering;
     if (value != null) {
       result
         ..add('ordering')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GCursorOrdering),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GCursorOrdering)));
     }
     return result;
   }
 
   @override
   GMainQuestRelationsStreamCursorInput deserialize(
-    Serializers serializers,
-    Iterable<Object?> serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = new GMainQuestRelationsStreamCursorInputBuilder();
 
     final iterator = serialized.iterator;
@@ -2331,23 +1960,15 @@ class _$GMainQuestRelationsStreamCursorInputSerializer
       final Object? value = iterator.current;
       switch (key) {
         case 'initialValue':
-          result.initialValue.replace(
-            serializers.deserialize(
-                  value,
+          result.initialValue.replace(serializers.deserialize(value,
                   specifiedType: const FullType(
-                    GMainQuestRelationsStreamCursorValueInput,
-                  ),
-                )!
-                as GMainQuestRelationsStreamCursorValueInput,
-          );
+                      GMainQuestRelationsStreamCursorValueInput))!
+              as GMainQuestRelationsStreamCursorValueInput);
           break;
         case 'ordering':
-          result.ordering =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(GCursorOrdering),
-                  )
-                  as GCursorOrdering?;
+          result.ordering = serializers.deserialize(value,
+                  specifiedType: const FullType(GCursorOrdering))
+              as GCursorOrdering?;
           break;
       }
     }
@@ -2361,44 +1982,38 @@ class _$GMainQuestRelationsStreamCursorValueInputSerializer
   @override
   final Iterable<Type> types = const [
     GMainQuestRelationsStreamCursorValueInput,
-    _$GMainQuestRelationsStreamCursorValueInput,
+    _$GMainQuestRelationsStreamCursorValueInput
   ];
   @override
   final String wireName = 'GMainQuestRelationsStreamCursorValueInput';
 
   @override
   Iterable<Object?> serialize(
-    Serializers serializers,
-    GMainQuestRelationsStreamCursorValueInput object, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, GMainQuestRelationsStreamCursorValueInput object,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[];
     Object? value;
     value = object.childQuestId;
     if (value != null) {
       result
         ..add('childQuestId')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(String)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
     }
     value = object.parentQuestId;
     if (value != null) {
       result
         ..add('parentQuestId')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(String)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
     }
     return result;
   }
 
   @override
   GMainQuestRelationsStreamCursorValueInput deserialize(
-    Serializers serializers,
-    Iterable<Object?> serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = new GMainQuestRelationsStreamCursorValueInputBuilder();
 
     final iterator = serialized.iterator;
@@ -2408,20 +2023,12 @@ class _$GMainQuestRelationsStreamCursorValueInputSerializer
       final Object? value = iterator.current;
       switch (key) {
         case 'childQuestId':
-          result.childQuestId =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )
-                  as String?;
+          result.childQuestId = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
           break;
         case 'parentQuestId':
-          result.parentQuestId =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )
-                  as String?;
+          result.parentQuestId = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
           break;
       }
     }
@@ -2439,17 +2046,15 @@ class _$GMainQuestRelationsUpdateColumnSerializer
 
   @override
   Object serialize(
-    Serializers serializers,
-    GMainQuestRelationsUpdateColumn object, {
-    FullType specifiedType = FullType.unspecified,
-  }) => object.name;
+          Serializers serializers, GMainQuestRelationsUpdateColumn object,
+          {FullType specifiedType = FullType.unspecified}) =>
+      object.name;
 
   @override
   GMainQuestRelationsUpdateColumn deserialize(
-    Serializers serializers,
-    Object serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) => GMainQuestRelationsUpdateColumn.valueOf(serialized as String);
+          Serializers serializers, Object serialized,
+          {FullType specifiedType = FullType.unspecified}) =>
+      GMainQuestRelationsUpdateColumn.valueOf(serialized as String);
 }
 
 class _$GMainQuestRelationsUpdatesSerializer
@@ -2457,45 +2062,35 @@ class _$GMainQuestRelationsUpdatesSerializer
   @override
   final Iterable<Type> types = const [
     GMainQuestRelationsUpdates,
-    _$GMainQuestRelationsUpdates,
+    _$GMainQuestRelationsUpdates
   ];
   @override
   final String wireName = 'GMainQuestRelationsUpdates';
 
   @override
   Iterable<Object?> serialize(
-    Serializers serializers,
-    GMainQuestRelationsUpdates object, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, GMainQuestRelationsUpdates object,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[
       'where',
-      serializers.serialize(
-        object.where,
-        specifiedType: const FullType(GMainQuestRelationsBoolExp),
-      ),
+      serializers.serialize(object.where,
+          specifiedType: const FullType(GMainQuestRelationsBoolExp)),
     ];
     Object? value;
     value = object.G_set;
     if (value != null) {
       result
         ..add('_set')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GMainQuestRelationsSetInput),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GMainQuestRelationsSetInput)));
     }
     return result;
   }
 
   @override
   GMainQuestRelationsUpdates deserialize(
-    Serializers serializers,
-    Iterable<Object?> serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = new GMainQuestRelationsUpdatesBuilder();
 
     final iterator = serialized.iterator;
@@ -2505,22 +2100,14 @@ class _$GMainQuestRelationsUpdatesSerializer
       final Object? value = iterator.current;
       switch (key) {
         case '_set':
-          result.G_set.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(GMainQuestRelationsSetInput),
-                )!
-                as GMainQuestRelationsSetInput,
-          );
+          result.G_set.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(GMainQuestRelationsSetInput))!
+              as GMainQuestRelationsSetInput);
           break;
         case 'where':
-          result.where.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(GMainQuestRelationsBoolExp),
-                )!
-                as GMainQuestRelationsBoolExp,
-          );
+          result.where.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(GMainQuestRelationsBoolExp))!
+              as GMainQuestRelationsBoolExp);
           break;
       }
     }
@@ -2538,201 +2125,131 @@ class _$GMainQuestsBoolExpSerializer
 
   @override
   Iterable<Object?> serialize(
-    Serializers serializers,
-    GMainQuestsBoolExp object, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, GMainQuestsBoolExp object,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[];
     Object? value;
     value = object.G_and;
     if (value != null) {
       result
         ..add('_and')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(BuiltList, const [
-              const FullType(GMainQuestsBoolExp),
-            ]),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(
+                BuiltList, const [const FullType(GMainQuestsBoolExp)])));
     }
     value = object.G_not;
     if (value != null) {
       result
         ..add('_not')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GMainQuestsBoolExp),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GMainQuestsBoolExp)));
     }
     value = object.G_or;
     if (value != null) {
       result
         ..add('_or')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(BuiltList, const [
-              const FullType(GMainQuestsBoolExp),
-            ]),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(
+                BuiltList, const [const FullType(GMainQuestsBoolExp)])));
     }
     value = object.begunAt;
     if (value != null) {
       result
         ..add('begunAt')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GTimestamptzComparisonExp),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GTimestamptzComparisonExp)));
     }
     value = object.categoryId;
     if (value != null) {
       result
         ..add('categoryId')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GUuidComparisonExp),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GUuidComparisonExp)));
     }
     value = object.coverImageUrl;
     if (value != null) {
       result
         ..add('coverImageUrl')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GStringComparisonExp),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GStringComparisonExp)));
     }
     value = object.createdAt;
     if (value != null) {
       result
         ..add('createdAt')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GTimestamptzComparisonExp),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GTimestamptzComparisonExp)));
     }
     value = object.deletedAt;
     if (value != null) {
       result
         ..add('deletedAt')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GTimestamptzComparisonExp),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GTimestamptzComparisonExp)));
     }
     value = object.description;
     if (value != null) {
       result
         ..add('description')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GStringComparisonExp),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GStringComparisonExp)));
     }
     value = object.endedAt;
     if (value != null) {
       result
         ..add('endedAt')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GTimestamptzComparisonExp),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GTimestamptzComparisonExp)));
     }
     value = object.id;
     if (value != null) {
       result
         ..add('id')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GUuidComparisonExp),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GUuidComparisonExp)));
     }
     value = object.note;
     if (value != null) {
       result
         ..add('note')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GStringComparisonExp),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GStringComparisonExp)));
     }
     value = object.status;
     if (value != null) {
       result
         ..add('status')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GQuestStatusEnumComparisonExp),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GQuestStatusEnumComparisonExp)));
     }
     value = object.title;
     if (value != null) {
       result
         ..add('title')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GStringComparisonExp),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GStringComparisonExp)));
     }
     value = object.updatedAt;
     if (value != null) {
       result
         ..add('updatedAt')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GTimestamptzComparisonExp),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GTimestamptzComparisonExp)));
     }
     value = object.userId;
     if (value != null) {
       result
         ..add('userId')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GStringComparisonExp),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GStringComparisonExp)));
     }
     return result;
   }
 
   @override
   GMainQuestsBoolExp deserialize(
-    Serializers serializers,
-    Iterable<Object?> serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = new GMainQuestsBoolExpBuilder();
 
     final iterator = serialized.iterator;
@@ -2742,152 +2259,86 @@ class _$GMainQuestsBoolExpSerializer
       final Object? value = iterator.current;
       switch (key) {
         case '_and':
-          result.G_and.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(BuiltList, const [
-                    const FullType(GMainQuestsBoolExp),
-                  ]),
-                )!
-                as BuiltList<Object?>,
-          );
+          result.G_and.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(
+                      BuiltList, const [const FullType(GMainQuestsBoolExp)]))!
+              as BuiltList<Object?>);
           break;
         case '_not':
-          result.G_not.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(GMainQuestsBoolExp),
-                )!
-                as GMainQuestsBoolExp,
-          );
+          result.G_not.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(GMainQuestsBoolExp))!
+              as GMainQuestsBoolExp);
           break;
         case '_or':
-          result.G_or.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(BuiltList, const [
-                    const FullType(GMainQuestsBoolExp),
-                  ]),
-                )!
-                as BuiltList<Object?>,
-          );
+          result.G_or.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(
+                      BuiltList, const [const FullType(GMainQuestsBoolExp)]))!
+              as BuiltList<Object?>);
           break;
         case 'begunAt':
-          result.begunAt.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(GTimestamptzComparisonExp),
-                )!
-                as GTimestamptzComparisonExp,
-          );
+          result.begunAt.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(GTimestamptzComparisonExp))!
+              as GTimestamptzComparisonExp);
           break;
         case 'categoryId':
-          result.categoryId.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(GUuidComparisonExp),
-                )!
-                as GUuidComparisonExp,
-          );
+          result.categoryId.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(GUuidComparisonExp))!
+              as GUuidComparisonExp);
           break;
         case 'coverImageUrl':
-          result.coverImageUrl.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(GStringComparisonExp),
-                )!
-                as GStringComparisonExp,
-          );
+          result.coverImageUrl.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(GStringComparisonExp))!
+              as GStringComparisonExp);
           break;
         case 'createdAt':
-          result.createdAt.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(GTimestamptzComparisonExp),
-                )!
-                as GTimestamptzComparisonExp,
-          );
+          result.createdAt.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(GTimestamptzComparisonExp))!
+              as GTimestamptzComparisonExp);
           break;
         case 'deletedAt':
-          result.deletedAt.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(GTimestamptzComparisonExp),
-                )!
-                as GTimestamptzComparisonExp,
-          );
+          result.deletedAt.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(GTimestamptzComparisonExp))!
+              as GTimestamptzComparisonExp);
           break;
         case 'description':
-          result.description.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(GStringComparisonExp),
-                )!
-                as GStringComparisonExp,
-          );
+          result.description.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(GStringComparisonExp))!
+              as GStringComparisonExp);
           break;
         case 'endedAt':
-          result.endedAt.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(GTimestamptzComparisonExp),
-                )!
-                as GTimestamptzComparisonExp,
-          );
+          result.endedAt.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(GTimestamptzComparisonExp))!
+              as GTimestamptzComparisonExp);
           break;
         case 'id':
-          result.id.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(GUuidComparisonExp),
-                )!
-                as GUuidComparisonExp,
-          );
+          result.id.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(GUuidComparisonExp))!
+              as GUuidComparisonExp);
           break;
         case 'note':
-          result.note.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(GStringComparisonExp),
-                )!
-                as GStringComparisonExp,
-          );
+          result.note.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(GStringComparisonExp))!
+              as GStringComparisonExp);
           break;
         case 'status':
-          result.status.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(GQuestStatusEnumComparisonExp),
-                )!
-                as GQuestStatusEnumComparisonExp,
-          );
+          result.status.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(GQuestStatusEnumComparisonExp))!
+              as GQuestStatusEnumComparisonExp);
           break;
         case 'title':
-          result.title.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(GStringComparisonExp),
-                )!
-                as GStringComparisonExp,
-          );
+          result.title.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(GStringComparisonExp))!
+              as GStringComparisonExp);
           break;
         case 'updatedAt':
-          result.updatedAt.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(GTimestamptzComparisonExp),
-                )!
-                as GTimestamptzComparisonExp,
-          );
+          result.updatedAt.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(GTimestamptzComparisonExp))!
+              as GTimestamptzComparisonExp);
           break;
         case 'userId':
-          result.userId.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(GStringComparisonExp),
-                )!
-                as GStringComparisonExp,
-          );
+          result.userId.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(GStringComparisonExp))!
+              as GStringComparisonExp);
           break;
       }
     }
@@ -2904,18 +2355,14 @@ class _$GMainQuestsConstraintSerializer
   final String wireName = 'GMainQuestsConstraint';
 
   @override
-  Object serialize(
-    Serializers serializers,
-    GMainQuestsConstraint object, {
-    FullType specifiedType = FullType.unspecified,
-  }) => object.name;
+  Object serialize(Serializers serializers, GMainQuestsConstraint object,
+          {FullType specifiedType = FullType.unspecified}) =>
+      object.name;
 
   @override
-  GMainQuestsConstraint deserialize(
-    Serializers serializers,
-    Object serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) => GMainQuestsConstraint.valueOf(serialized as String);
+  GMainQuestsConstraint deserialize(Serializers serializers, Object serialized,
+          {FullType specifiedType = FullType.unspecified}) =>
+      GMainQuestsConstraint.valueOf(serialized as String);
 }
 
 class _$GMainQuestsInsertInputSerializer
@@ -2923,135 +2370,115 @@ class _$GMainQuestsInsertInputSerializer
   @override
   final Iterable<Type> types = const [
     GMainQuestsInsertInput,
-    _$GMainQuestsInsertInput,
+    _$GMainQuestsInsertInput
   ];
   @override
   final String wireName = 'GMainQuestsInsertInput';
 
   @override
   Iterable<Object?> serialize(
-    Serializers serializers,
-    GMainQuestsInsertInput object, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, GMainQuestsInsertInput object,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[];
     Object? value;
     value = object.begunAt;
     if (value != null) {
       result
         ..add('begunAt')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(DateTime)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(DateTime)));
     }
     value = object.categoryId;
     if (value != null) {
       result
         ..add('categoryId')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(String)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
     }
     value = object.coverImageUrl;
     if (value != null) {
       result
         ..add('coverImageUrl')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(String)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
     }
     value = object.createdAt;
     if (value != null) {
       result
         ..add('createdAt')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(DateTime)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(DateTime)));
     }
     value = object.deletedAt;
     if (value != null) {
       result
         ..add('deletedAt')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(DateTime)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(DateTime)));
     }
     value = object.description;
     if (value != null) {
       result
         ..add('description')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(String)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
     }
     value = object.endedAt;
     if (value != null) {
       result
         ..add('endedAt')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(DateTime)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(DateTime)));
     }
     value = object.id;
     if (value != null) {
       result
         ..add('id')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(String)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
     }
     value = object.note;
     if (value != null) {
       result
         ..add('note')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(String)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
     }
     value = object.status;
     if (value != null) {
       result
         ..add('status')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GQuestStatusEnum),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GQuestStatusEnum)));
     }
     value = object.title;
     if (value != null) {
       result
         ..add('title')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(String)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
     }
     value = object.updatedAt;
     if (value != null) {
       result
         ..add('updatedAt')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(DateTime)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(DateTime)));
     }
     value = object.userId;
     if (value != null) {
       result
         ..add('userId')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(String)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
     }
     return result;
   }
 
   @override
   GMainQuestsInsertInput deserialize(
-    Serializers serializers,
-    Iterable<Object?> serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = new GMainQuestsInsertInputBuilder();
 
     final iterator = serialized.iterator;
@@ -3061,108 +2488,57 @@ class _$GMainQuestsInsertInputSerializer
       final Object? value = iterator.current;
       switch (key) {
         case 'begunAt':
-          result.begunAt =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(DateTime),
-                  )
-                  as DateTime?;
+          result.begunAt = serializers.deserialize(value,
+              specifiedType: const FullType(DateTime)) as DateTime?;
           break;
         case 'categoryId':
-          result.categoryId =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )
-                  as String?;
+          result.categoryId = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
           break;
         case 'coverImageUrl':
-          result.coverImageUrl =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )
-                  as String?;
+          result.coverImageUrl = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
           break;
         case 'createdAt':
-          result.createdAt =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(DateTime),
-                  )
-                  as DateTime?;
+          result.createdAt = serializers.deserialize(value,
+              specifiedType: const FullType(DateTime)) as DateTime?;
           break;
         case 'deletedAt':
-          result.deletedAt =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(DateTime),
-                  )
-                  as DateTime?;
+          result.deletedAt = serializers.deserialize(value,
+              specifiedType: const FullType(DateTime)) as DateTime?;
           break;
         case 'description':
-          result.description =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )
-                  as String?;
+          result.description = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
           break;
         case 'endedAt':
-          result.endedAt =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(DateTime),
-                  )
-                  as DateTime?;
+          result.endedAt = serializers.deserialize(value,
+              specifiedType: const FullType(DateTime)) as DateTime?;
           break;
         case 'id':
-          result.id =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )
-                  as String?;
+          result.id = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
           break;
         case 'note':
-          result.note =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )
-                  as String?;
+          result.note = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
           break;
         case 'status':
-          result.status =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(GQuestStatusEnum),
-                  )
-                  as GQuestStatusEnum?;
+          result.status = serializers.deserialize(value,
+                  specifiedType: const FullType(GQuestStatusEnum))
+              as GQuestStatusEnum?;
           break;
         case 'title':
-          result.title =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )
-                  as String?;
+          result.title = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
           break;
         case 'updatedAt':
-          result.updatedAt =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(DateTime),
-                  )
-                  as DateTime?;
+          result.updatedAt = serializers.deserialize(value,
+              specifiedType: const FullType(DateTime)) as DateTime?;
           break;
         case 'userId':
-          result.userId =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )
-                  as String?;
+          result.userId = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
           break;
       }
     }
@@ -3176,52 +2552,39 @@ class _$GMainQuestsOnConflictSerializer
   @override
   final Iterable<Type> types = const [
     GMainQuestsOnConflict,
-    _$GMainQuestsOnConflict,
+    _$GMainQuestsOnConflict
   ];
   @override
   final String wireName = 'GMainQuestsOnConflict';
 
   @override
   Iterable<Object?> serialize(
-    Serializers serializers,
-    GMainQuestsOnConflict object, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, GMainQuestsOnConflict object,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[
       'constraint',
-      serializers.serialize(
-        object.constraint,
-        specifiedType: const FullType(GMainQuestsConstraint),
-      ),
+      serializers.serialize(object.constraint,
+          specifiedType: const FullType(GMainQuestsConstraint)),
       'updateColumns',
-      serializers.serialize(
-        object.updateColumns,
-        specifiedType: const FullType(BuiltList, const [
-          const FullType(GMainQuestsUpdateColumn),
-        ]),
-      ),
+      serializers.serialize(object.updateColumns,
+          specifiedType: const FullType(
+              BuiltList, const [const FullType(GMainQuestsUpdateColumn)])),
     ];
     Object? value;
     value = object.where;
     if (value != null) {
       result
         ..add('where')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GMainQuestsBoolExp),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GMainQuestsBoolExp)));
     }
     return result;
   }
 
   @override
   GMainQuestsOnConflict deserialize(
-    Serializers serializers,
-    Iterable<Object?> serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = new GMainQuestsOnConflictBuilder();
 
     final iterator = serialized.iterator;
@@ -3231,32 +2594,20 @@ class _$GMainQuestsOnConflictSerializer
       final Object? value = iterator.current;
       switch (key) {
         case 'constraint':
-          result.constraint =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(GMainQuestsConstraint),
-                  )!
-                  as GMainQuestsConstraint;
+          result.constraint = serializers.deserialize(value,
+                  specifiedType: const FullType(GMainQuestsConstraint))!
+              as GMainQuestsConstraint;
           break;
         case 'updateColumns':
-          result.updateColumns.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(BuiltList, const [
-                    const FullType(GMainQuestsUpdateColumn),
-                  ]),
-                )!
-                as BuiltList<Object?>,
-          );
+          result.updateColumns.replace(serializers.deserialize(value,
+              specifiedType: const FullType(BuiltList, const [
+                const FullType(GMainQuestsUpdateColumn)
+              ]))! as BuiltList<Object?>);
           break;
         case 'where':
-          result.where.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(GMainQuestsBoolExp),
-                )!
-                as GMainQuestsBoolExp,
-          );
+          result.where.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(GMainQuestsBoolExp))!
+              as GMainQuestsBoolExp);
           break;
       }
     }
@@ -3274,125 +2625,108 @@ class _$GMainQuestsOrderBySerializer
 
   @override
   Iterable<Object?> serialize(
-    Serializers serializers,
-    GMainQuestsOrderBy object, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, GMainQuestsOrderBy object,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[];
     Object? value;
     value = object.begunAt;
     if (value != null) {
       result
         ..add('begunAt')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(GOrderBy)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GOrderBy)));
     }
     value = object.categoryId;
     if (value != null) {
       result
         ..add('categoryId')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(GOrderBy)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GOrderBy)));
     }
     value = object.coverImageUrl;
     if (value != null) {
       result
         ..add('coverImageUrl')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(GOrderBy)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GOrderBy)));
     }
     value = object.createdAt;
     if (value != null) {
       result
         ..add('createdAt')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(GOrderBy)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GOrderBy)));
     }
     value = object.deletedAt;
     if (value != null) {
       result
         ..add('deletedAt')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(GOrderBy)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GOrderBy)));
     }
     value = object.description;
     if (value != null) {
       result
         ..add('description')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(GOrderBy)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GOrderBy)));
     }
     value = object.endedAt;
     if (value != null) {
       result
         ..add('endedAt')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(GOrderBy)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GOrderBy)));
     }
     value = object.id;
     if (value != null) {
       result
         ..add('id')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(GOrderBy)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GOrderBy)));
     }
     value = object.note;
     if (value != null) {
       result
         ..add('note')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(GOrderBy)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GOrderBy)));
     }
     value = object.status;
     if (value != null) {
       result
         ..add('status')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(GOrderBy)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GOrderBy)));
     }
     value = object.title;
     if (value != null) {
       result
         ..add('title')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(GOrderBy)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GOrderBy)));
     }
     value = object.updatedAt;
     if (value != null) {
       result
         ..add('updatedAt')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(GOrderBy)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GOrderBy)));
     }
     value = object.userId;
     if (value != null) {
       result
         ..add('userId')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(GOrderBy)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GOrderBy)));
     }
     return result;
   }
 
   @override
   GMainQuestsOrderBy deserialize(
-    Serializers serializers,
-    Iterable<Object?> serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = new GMainQuestsOrderByBuilder();
 
     final iterator = serialized.iterator;
@@ -3402,108 +2736,56 @@ class _$GMainQuestsOrderBySerializer
       final Object? value = iterator.current;
       switch (key) {
         case 'begunAt':
-          result.begunAt =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(GOrderBy),
-                  )
-                  as GOrderBy?;
+          result.begunAt = serializers.deserialize(value,
+              specifiedType: const FullType(GOrderBy)) as GOrderBy?;
           break;
         case 'categoryId':
-          result.categoryId =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(GOrderBy),
-                  )
-                  as GOrderBy?;
+          result.categoryId = serializers.deserialize(value,
+              specifiedType: const FullType(GOrderBy)) as GOrderBy?;
           break;
         case 'coverImageUrl':
-          result.coverImageUrl =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(GOrderBy),
-                  )
-                  as GOrderBy?;
+          result.coverImageUrl = serializers.deserialize(value,
+              specifiedType: const FullType(GOrderBy)) as GOrderBy?;
           break;
         case 'createdAt':
-          result.createdAt =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(GOrderBy),
-                  )
-                  as GOrderBy?;
+          result.createdAt = serializers.deserialize(value,
+              specifiedType: const FullType(GOrderBy)) as GOrderBy?;
           break;
         case 'deletedAt':
-          result.deletedAt =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(GOrderBy),
-                  )
-                  as GOrderBy?;
+          result.deletedAt = serializers.deserialize(value,
+              specifiedType: const FullType(GOrderBy)) as GOrderBy?;
           break;
         case 'description':
-          result.description =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(GOrderBy),
-                  )
-                  as GOrderBy?;
+          result.description = serializers.deserialize(value,
+              specifiedType: const FullType(GOrderBy)) as GOrderBy?;
           break;
         case 'endedAt':
-          result.endedAt =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(GOrderBy),
-                  )
-                  as GOrderBy?;
+          result.endedAt = serializers.deserialize(value,
+              specifiedType: const FullType(GOrderBy)) as GOrderBy?;
           break;
         case 'id':
-          result.id =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(GOrderBy),
-                  )
-                  as GOrderBy?;
+          result.id = serializers.deserialize(value,
+              specifiedType: const FullType(GOrderBy)) as GOrderBy?;
           break;
         case 'note':
-          result.note =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(GOrderBy),
-                  )
-                  as GOrderBy?;
+          result.note = serializers.deserialize(value,
+              specifiedType: const FullType(GOrderBy)) as GOrderBy?;
           break;
         case 'status':
-          result.status =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(GOrderBy),
-                  )
-                  as GOrderBy?;
+          result.status = serializers.deserialize(value,
+              specifiedType: const FullType(GOrderBy)) as GOrderBy?;
           break;
         case 'title':
-          result.title =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(GOrderBy),
-                  )
-                  as GOrderBy?;
+          result.title = serializers.deserialize(value,
+              specifiedType: const FullType(GOrderBy)) as GOrderBy?;
           break;
         case 'updatedAt':
-          result.updatedAt =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(GOrderBy),
-                  )
-                  as GOrderBy?;
+          result.updatedAt = serializers.deserialize(value,
+              specifiedType: const FullType(GOrderBy)) as GOrderBy?;
           break;
         case 'userId':
-          result.userId =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(GOrderBy),
-                  )
-                  as GOrderBy?;
+          result.userId = serializers.deserialize(value,
+              specifiedType: const FullType(GOrderBy)) as GOrderBy?;
           break;
       }
     }
@@ -3517,17 +2799,15 @@ class _$GMainQuestsPkColumnsInputSerializer
   @override
   final Iterable<Type> types = const [
     GMainQuestsPkColumnsInput,
-    _$GMainQuestsPkColumnsInput,
+    _$GMainQuestsPkColumnsInput
   ];
   @override
   final String wireName = 'GMainQuestsPkColumnsInput';
 
   @override
   Iterable<Object?> serialize(
-    Serializers serializers,
-    GMainQuestsPkColumnsInput object, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, GMainQuestsPkColumnsInput object,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[
       'id',
       serializers.serialize(object.id, specifiedType: const FullType(String)),
@@ -3538,10 +2818,8 @@ class _$GMainQuestsPkColumnsInputSerializer
 
   @override
   GMainQuestsPkColumnsInput deserialize(
-    Serializers serializers,
-    Iterable<Object?> serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = new GMainQuestsPkColumnsInputBuilder();
 
     final iterator = serialized.iterator;
@@ -3551,12 +2829,8 @@ class _$GMainQuestsPkColumnsInputSerializer
       final Object? value = iterator.current;
       switch (key) {
         case 'id':
-          result.id =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )!
-                  as String;
+          result.id = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
           break;
       }
     }
@@ -3573,18 +2847,15 @@ class _$GMainQuestsSelectColumnSerializer
   final String wireName = 'GMainQuestsSelectColumn';
 
   @override
-  Object serialize(
-    Serializers serializers,
-    GMainQuestsSelectColumn object, {
-    FullType specifiedType = FullType.unspecified,
-  }) => object.name;
+  Object serialize(Serializers serializers, GMainQuestsSelectColumn object,
+          {FullType specifiedType = FullType.unspecified}) =>
+      object.name;
 
   @override
   GMainQuestsSelectColumn deserialize(
-    Serializers serializers,
-    Object serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) => GMainQuestsSelectColumn.valueOf(serialized as String);
+          Serializers serializers, Object serialized,
+          {FullType specifiedType = FullType.unspecified}) =>
+      GMainQuestsSelectColumn.valueOf(serialized as String);
 }
 
 class _$GMainQuestsSetInputSerializer
@@ -3592,135 +2863,115 @@ class _$GMainQuestsSetInputSerializer
   @override
   final Iterable<Type> types = const [
     GMainQuestsSetInput,
-    _$GMainQuestsSetInput,
+    _$GMainQuestsSetInput
   ];
   @override
   final String wireName = 'GMainQuestsSetInput';
 
   @override
   Iterable<Object?> serialize(
-    Serializers serializers,
-    GMainQuestsSetInput object, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, GMainQuestsSetInput object,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[];
     Object? value;
     value = object.begunAt;
     if (value != null) {
       result
         ..add('begunAt')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(DateTime)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(DateTime)));
     }
     value = object.categoryId;
     if (value != null) {
       result
         ..add('categoryId')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(String)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
     }
     value = object.coverImageUrl;
     if (value != null) {
       result
         ..add('coverImageUrl')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(String)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
     }
     value = object.createdAt;
     if (value != null) {
       result
         ..add('createdAt')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(DateTime)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(DateTime)));
     }
     value = object.deletedAt;
     if (value != null) {
       result
         ..add('deletedAt')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(DateTime)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(DateTime)));
     }
     value = object.description;
     if (value != null) {
       result
         ..add('description')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(String)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
     }
     value = object.endedAt;
     if (value != null) {
       result
         ..add('endedAt')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(DateTime)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(DateTime)));
     }
     value = object.id;
     if (value != null) {
       result
         ..add('id')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(String)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
     }
     value = object.note;
     if (value != null) {
       result
         ..add('note')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(String)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
     }
     value = object.status;
     if (value != null) {
       result
         ..add('status')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GQuestStatusEnum),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GQuestStatusEnum)));
     }
     value = object.title;
     if (value != null) {
       result
         ..add('title')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(String)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
     }
     value = object.updatedAt;
     if (value != null) {
       result
         ..add('updatedAt')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(DateTime)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(DateTime)));
     }
     value = object.userId;
     if (value != null) {
       result
         ..add('userId')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(String)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
     }
     return result;
   }
 
   @override
   GMainQuestsSetInput deserialize(
-    Serializers serializers,
-    Iterable<Object?> serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = new GMainQuestsSetInputBuilder();
 
     final iterator = serialized.iterator;
@@ -3730,108 +2981,57 @@ class _$GMainQuestsSetInputSerializer
       final Object? value = iterator.current;
       switch (key) {
         case 'begunAt':
-          result.begunAt =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(DateTime),
-                  )
-                  as DateTime?;
+          result.begunAt = serializers.deserialize(value,
+              specifiedType: const FullType(DateTime)) as DateTime?;
           break;
         case 'categoryId':
-          result.categoryId =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )
-                  as String?;
+          result.categoryId = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
           break;
         case 'coverImageUrl':
-          result.coverImageUrl =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )
-                  as String?;
+          result.coverImageUrl = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
           break;
         case 'createdAt':
-          result.createdAt =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(DateTime),
-                  )
-                  as DateTime?;
+          result.createdAt = serializers.deserialize(value,
+              specifiedType: const FullType(DateTime)) as DateTime?;
           break;
         case 'deletedAt':
-          result.deletedAt =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(DateTime),
-                  )
-                  as DateTime?;
+          result.deletedAt = serializers.deserialize(value,
+              specifiedType: const FullType(DateTime)) as DateTime?;
           break;
         case 'description':
-          result.description =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )
-                  as String?;
+          result.description = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
           break;
         case 'endedAt':
-          result.endedAt =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(DateTime),
-                  )
-                  as DateTime?;
+          result.endedAt = serializers.deserialize(value,
+              specifiedType: const FullType(DateTime)) as DateTime?;
           break;
         case 'id':
-          result.id =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )
-                  as String?;
+          result.id = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
           break;
         case 'note':
-          result.note =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )
-                  as String?;
+          result.note = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
           break;
         case 'status':
-          result.status =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(GQuestStatusEnum),
-                  )
-                  as GQuestStatusEnum?;
+          result.status = serializers.deserialize(value,
+                  specifiedType: const FullType(GQuestStatusEnum))
+              as GQuestStatusEnum?;
           break;
         case 'title':
-          result.title =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )
-                  as String?;
+          result.title = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
           break;
         case 'updatedAt':
-          result.updatedAt =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(DateTime),
-                  )
-                  as DateTime?;
+          result.updatedAt = serializers.deserialize(value,
+              specifiedType: const FullType(DateTime)) as DateTime?;
           break;
         case 'userId':
-          result.userId =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )
-                  as String?;
+          result.userId = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
           break;
       }
     }
@@ -3845,45 +3045,35 @@ class _$GMainQuestsStreamCursorInputSerializer
   @override
   final Iterable<Type> types = const [
     GMainQuestsStreamCursorInput,
-    _$GMainQuestsStreamCursorInput,
+    _$GMainQuestsStreamCursorInput
   ];
   @override
   final String wireName = 'GMainQuestsStreamCursorInput';
 
   @override
   Iterable<Object?> serialize(
-    Serializers serializers,
-    GMainQuestsStreamCursorInput object, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, GMainQuestsStreamCursorInput object,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[
       'initialValue',
-      serializers.serialize(
-        object.initialValue,
-        specifiedType: const FullType(GMainQuestsStreamCursorValueInput),
-      ),
+      serializers.serialize(object.initialValue,
+          specifiedType: const FullType(GMainQuestsStreamCursorValueInput)),
     ];
     Object? value;
     value = object.ordering;
     if (value != null) {
       result
         ..add('ordering')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GCursorOrdering),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GCursorOrdering)));
     }
     return result;
   }
 
   @override
   GMainQuestsStreamCursorInput deserialize(
-    Serializers serializers,
-    Iterable<Object?> serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = new GMainQuestsStreamCursorInputBuilder();
 
     final iterator = serialized.iterator;
@@ -3893,23 +3083,15 @@ class _$GMainQuestsStreamCursorInputSerializer
       final Object? value = iterator.current;
       switch (key) {
         case 'initialValue':
-          result.initialValue.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(
-                    GMainQuestsStreamCursorValueInput,
-                  ),
-                )!
-                as GMainQuestsStreamCursorValueInput,
-          );
+          result.initialValue.replace(serializers.deserialize(value,
+                  specifiedType:
+                      const FullType(GMainQuestsStreamCursorValueInput))!
+              as GMainQuestsStreamCursorValueInput);
           break;
         case 'ordering':
-          result.ordering =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(GCursorOrdering),
-                  )
-                  as GCursorOrdering?;
+          result.ordering = serializers.deserialize(value,
+                  specifiedType: const FullType(GCursorOrdering))
+              as GCursorOrdering?;
           break;
       }
     }
@@ -3923,135 +3105,115 @@ class _$GMainQuestsStreamCursorValueInputSerializer
   @override
   final Iterable<Type> types = const [
     GMainQuestsStreamCursorValueInput,
-    _$GMainQuestsStreamCursorValueInput,
+    _$GMainQuestsStreamCursorValueInput
   ];
   @override
   final String wireName = 'GMainQuestsStreamCursorValueInput';
 
   @override
   Iterable<Object?> serialize(
-    Serializers serializers,
-    GMainQuestsStreamCursorValueInput object, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, GMainQuestsStreamCursorValueInput object,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[];
     Object? value;
     value = object.begunAt;
     if (value != null) {
       result
         ..add('begunAt')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(DateTime)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(DateTime)));
     }
     value = object.categoryId;
     if (value != null) {
       result
         ..add('categoryId')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(String)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
     }
     value = object.coverImageUrl;
     if (value != null) {
       result
         ..add('coverImageUrl')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(String)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
     }
     value = object.createdAt;
     if (value != null) {
       result
         ..add('createdAt')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(DateTime)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(DateTime)));
     }
     value = object.deletedAt;
     if (value != null) {
       result
         ..add('deletedAt')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(DateTime)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(DateTime)));
     }
     value = object.description;
     if (value != null) {
       result
         ..add('description')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(String)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
     }
     value = object.endedAt;
     if (value != null) {
       result
         ..add('endedAt')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(DateTime)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(DateTime)));
     }
     value = object.id;
     if (value != null) {
       result
         ..add('id')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(String)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
     }
     value = object.note;
     if (value != null) {
       result
         ..add('note')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(String)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
     }
     value = object.status;
     if (value != null) {
       result
         ..add('status')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GQuestStatusEnum),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GQuestStatusEnum)));
     }
     value = object.title;
     if (value != null) {
       result
         ..add('title')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(String)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
     }
     value = object.updatedAt;
     if (value != null) {
       result
         ..add('updatedAt')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(DateTime)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(DateTime)));
     }
     value = object.userId;
     if (value != null) {
       result
         ..add('userId')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(String)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
     }
     return result;
   }
 
   @override
   GMainQuestsStreamCursorValueInput deserialize(
-    Serializers serializers,
-    Iterable<Object?> serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = new GMainQuestsStreamCursorValueInputBuilder();
 
     final iterator = serialized.iterator;
@@ -4061,108 +3223,57 @@ class _$GMainQuestsStreamCursorValueInputSerializer
       final Object? value = iterator.current;
       switch (key) {
         case 'begunAt':
-          result.begunAt =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(DateTime),
-                  )
-                  as DateTime?;
+          result.begunAt = serializers.deserialize(value,
+              specifiedType: const FullType(DateTime)) as DateTime?;
           break;
         case 'categoryId':
-          result.categoryId =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )
-                  as String?;
+          result.categoryId = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
           break;
         case 'coverImageUrl':
-          result.coverImageUrl =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )
-                  as String?;
+          result.coverImageUrl = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
           break;
         case 'createdAt':
-          result.createdAt =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(DateTime),
-                  )
-                  as DateTime?;
+          result.createdAt = serializers.deserialize(value,
+              specifiedType: const FullType(DateTime)) as DateTime?;
           break;
         case 'deletedAt':
-          result.deletedAt =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(DateTime),
-                  )
-                  as DateTime?;
+          result.deletedAt = serializers.deserialize(value,
+              specifiedType: const FullType(DateTime)) as DateTime?;
           break;
         case 'description':
-          result.description =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )
-                  as String?;
+          result.description = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
           break;
         case 'endedAt':
-          result.endedAt =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(DateTime),
-                  )
-                  as DateTime?;
+          result.endedAt = serializers.deserialize(value,
+              specifiedType: const FullType(DateTime)) as DateTime?;
           break;
         case 'id':
-          result.id =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )
-                  as String?;
+          result.id = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
           break;
         case 'note':
-          result.note =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )
-                  as String?;
+          result.note = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
           break;
         case 'status':
-          result.status =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(GQuestStatusEnum),
-                  )
-                  as GQuestStatusEnum?;
+          result.status = serializers.deserialize(value,
+                  specifiedType: const FullType(GQuestStatusEnum))
+              as GQuestStatusEnum?;
           break;
         case 'title':
-          result.title =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )
-                  as String?;
+          result.title = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
           break;
         case 'updatedAt':
-          result.updatedAt =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(DateTime),
-                  )
-                  as DateTime?;
+          result.updatedAt = serializers.deserialize(value,
+              specifiedType: const FullType(DateTime)) as DateTime?;
           break;
         case 'userId':
-          result.userId =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )
-                  as String?;
+          result.userId = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
           break;
       }
     }
@@ -4179,18 +3290,15 @@ class _$GMainQuestsUpdateColumnSerializer
   final String wireName = 'GMainQuestsUpdateColumn';
 
   @override
-  Object serialize(
-    Serializers serializers,
-    GMainQuestsUpdateColumn object, {
-    FullType specifiedType = FullType.unspecified,
-  }) => object.name;
+  Object serialize(Serializers serializers, GMainQuestsUpdateColumn object,
+          {FullType specifiedType = FullType.unspecified}) =>
+      object.name;
 
   @override
   GMainQuestsUpdateColumn deserialize(
-    Serializers serializers,
-    Object serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) => GMainQuestsUpdateColumn.valueOf(serialized as String);
+          Serializers serializers, Object serialized,
+          {FullType specifiedType = FullType.unspecified}) =>
+      GMainQuestsUpdateColumn.valueOf(serialized as String);
 }
 
 class _$GMainQuestsUpdatesSerializer
@@ -4202,38 +3310,28 @@ class _$GMainQuestsUpdatesSerializer
 
   @override
   Iterable<Object?> serialize(
-    Serializers serializers,
-    GMainQuestsUpdates object, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, GMainQuestsUpdates object,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[
       'where',
-      serializers.serialize(
-        object.where,
-        specifiedType: const FullType(GMainQuestsBoolExp),
-      ),
+      serializers.serialize(object.where,
+          specifiedType: const FullType(GMainQuestsBoolExp)),
     ];
     Object? value;
     value = object.G_set;
     if (value != null) {
       result
         ..add('_set')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GMainQuestsSetInput),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GMainQuestsSetInput)));
     }
     return result;
   }
 
   @override
   GMainQuestsUpdates deserialize(
-    Serializers serializers,
-    Iterable<Object?> serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = new GMainQuestsUpdatesBuilder();
 
     final iterator = serialized.iterator;
@@ -4243,22 +3341,14 @@ class _$GMainQuestsUpdatesSerializer
       final Object? value = iterator.current;
       switch (key) {
         case '_set':
-          result.G_set.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(GMainQuestsSetInput),
-                )!
-                as GMainQuestsSetInput,
-          );
+          result.G_set.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(GMainQuestsSetInput))!
+              as GMainQuestsSetInput);
           break;
         case 'where':
-          result.where.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(GMainQuestsBoolExp),
-                )!
-                as GMainQuestsBoolExp,
-          );
+          result.where.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(GMainQuestsBoolExp))!
+              as GMainQuestsBoolExp);
           break;
       }
     }
@@ -4274,180 +3364,117 @@ class _$GNewsBoolExpSerializer implements StructuredSerializer<GNewsBoolExp> {
   final String wireName = 'GNewsBoolExp';
 
   @override
-  Iterable<Object?> serialize(
-    Serializers serializers,
-    GNewsBoolExp object, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+  Iterable<Object?> serialize(Serializers serializers, GNewsBoolExp object,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[];
     Object? value;
     value = object.G_and;
     if (value != null) {
       result
         ..add('_and')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(BuiltList, const [
-              const FullType(GNewsBoolExp),
-            ]),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(
+                BuiltList, const [const FullType(GNewsBoolExp)])));
     }
     value = object.G_not;
     if (value != null) {
       result
         ..add('_not')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GNewsBoolExp),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GNewsBoolExp)));
     }
     value = object.G_or;
     if (value != null) {
       result
         ..add('_or')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(BuiltList, const [
-              const FullType(GNewsBoolExp),
-            ]),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(
+                BuiltList, const [const FullType(GNewsBoolExp)])));
     }
     value = object.content;
     if (value != null) {
       result
         ..add('content')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GStringComparisonExp),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GStringComparisonExp)));
     }
     value = object.coverImageUrl;
     if (value != null) {
       result
         ..add('coverImageUrl')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GStringComparisonExp),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GStringComparisonExp)));
     }
     value = object.createdAt;
     if (value != null) {
       result
         ..add('createdAt')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GTimestamptzComparisonExp),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GTimestamptzComparisonExp)));
     }
     value = object.excerpt;
     if (value != null) {
       result
         ..add('excerpt')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GStringComparisonExp),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GStringComparisonExp)));
     }
     value = object.id;
     if (value != null) {
       result
         ..add('id')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GUuidComparisonExp),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GUuidComparisonExp)));
     }
     value = object.publishedAt;
     if (value != null) {
       result
         ..add('publishedAt')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GTimestamptzComparisonExp),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GTimestamptzComparisonExp)));
     }
     value = object.seo;
     if (value != null) {
       result
         ..add('seo')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GSeosBoolExp),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GSeosBoolExp)));
     }
     value = object.seoId;
     if (value != null) {
       result
         ..add('seoId')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GUuidComparisonExp),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GUuidComparisonExp)));
     }
     value = object.slug;
     if (value != null) {
       result
         ..add('slug')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GStringComparisonExp),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GStringComparisonExp)));
     }
     value = object.title;
     if (value != null) {
       result
         ..add('title')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GStringComparisonExp),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GStringComparisonExp)));
     }
     value = object.updatedAt;
     if (value != null) {
       result
         ..add('updatedAt')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GTimestamptzComparisonExp),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GTimestamptzComparisonExp)));
     }
     return result;
   }
 
   @override
   GNewsBoolExp deserialize(
-    Serializers serializers,
-    Iterable<Object?> serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = new GNewsBoolExpBuilder();
 
     final iterator = serialized.iterator;
@@ -4457,134 +3484,74 @@ class _$GNewsBoolExpSerializer implements StructuredSerializer<GNewsBoolExp> {
       final Object? value = iterator.current;
       switch (key) {
         case '_and':
-          result.G_and.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(BuiltList, const [
-                    const FullType(GNewsBoolExp),
-                  ]),
-                )!
-                as BuiltList<Object?>,
-          );
+          result.G_and.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(
+                      BuiltList, const [const FullType(GNewsBoolExp)]))!
+              as BuiltList<Object?>);
           break;
         case '_not':
-          result.G_not.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(GNewsBoolExp),
-                )!
-                as GNewsBoolExp,
-          );
+          result.G_not.replace(serializers.deserialize(value,
+              specifiedType: const FullType(GNewsBoolExp))! as GNewsBoolExp);
           break;
         case '_or':
-          result.G_or.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(BuiltList, const [
-                    const FullType(GNewsBoolExp),
-                  ]),
-                )!
-                as BuiltList<Object?>,
-          );
+          result.G_or.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(
+                      BuiltList, const [const FullType(GNewsBoolExp)]))!
+              as BuiltList<Object?>);
           break;
         case 'content':
-          result.content.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(GStringComparisonExp),
-                )!
-                as GStringComparisonExp,
-          );
+          result.content.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(GStringComparisonExp))!
+              as GStringComparisonExp);
           break;
         case 'coverImageUrl':
-          result.coverImageUrl.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(GStringComparisonExp),
-                )!
-                as GStringComparisonExp,
-          );
+          result.coverImageUrl.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(GStringComparisonExp))!
+              as GStringComparisonExp);
           break;
         case 'createdAt':
-          result.createdAt.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(GTimestamptzComparisonExp),
-                )!
-                as GTimestamptzComparisonExp,
-          );
+          result.createdAt.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(GTimestamptzComparisonExp))!
+              as GTimestamptzComparisonExp);
           break;
         case 'excerpt':
-          result.excerpt.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(GStringComparisonExp),
-                )!
-                as GStringComparisonExp,
-          );
+          result.excerpt.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(GStringComparisonExp))!
+              as GStringComparisonExp);
           break;
         case 'id':
-          result.id.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(GUuidComparisonExp),
-                )!
-                as GUuidComparisonExp,
-          );
+          result.id.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(GUuidComparisonExp))!
+              as GUuidComparisonExp);
           break;
         case 'publishedAt':
-          result.publishedAt.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(GTimestamptzComparisonExp),
-                )!
-                as GTimestamptzComparisonExp,
-          );
+          result.publishedAt.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(GTimestamptzComparisonExp))!
+              as GTimestamptzComparisonExp);
           break;
         case 'seo':
-          result.seo.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(GSeosBoolExp),
-                )!
-                as GSeosBoolExp,
-          );
+          result.seo.replace(serializers.deserialize(value,
+              specifiedType: const FullType(GSeosBoolExp))! as GSeosBoolExp);
           break;
         case 'seoId':
-          result.seoId.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(GUuidComparisonExp),
-                )!
-                as GUuidComparisonExp,
-          );
+          result.seoId.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(GUuidComparisonExp))!
+              as GUuidComparisonExp);
           break;
         case 'slug':
-          result.slug.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(GStringComparisonExp),
-                )!
-                as GStringComparisonExp,
-          );
+          result.slug.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(GStringComparisonExp))!
+              as GStringComparisonExp);
           break;
         case 'title':
-          result.title.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(GStringComparisonExp),
-                )!
-                as GStringComparisonExp,
-          );
+          result.title.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(GStringComparisonExp))!
+              as GStringComparisonExp);
           break;
         case 'updatedAt':
-          result.updatedAt.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(GTimestamptzComparisonExp),
-                )!
-                as GTimestamptzComparisonExp,
-          );
+          result.updatedAt.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(GTimestamptzComparisonExp))!
+              as GTimestamptzComparisonExp);
           break;
       }
     }
@@ -4600,113 +3567,94 @@ class _$GNewsOrderBySerializer implements StructuredSerializer<GNewsOrderBy> {
   final String wireName = 'GNewsOrderBy';
 
   @override
-  Iterable<Object?> serialize(
-    Serializers serializers,
-    GNewsOrderBy object, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+  Iterable<Object?> serialize(Serializers serializers, GNewsOrderBy object,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[];
     Object? value;
     value = object.content;
     if (value != null) {
       result
         ..add('content')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(GOrderBy)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GOrderBy)));
     }
     value = object.coverImageUrl;
     if (value != null) {
       result
         ..add('coverImageUrl')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(GOrderBy)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GOrderBy)));
     }
     value = object.createdAt;
     if (value != null) {
       result
         ..add('createdAt')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(GOrderBy)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GOrderBy)));
     }
     value = object.excerpt;
     if (value != null) {
       result
         ..add('excerpt')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(GOrderBy)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GOrderBy)));
     }
     value = object.id;
     if (value != null) {
       result
         ..add('id')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(GOrderBy)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GOrderBy)));
     }
     value = object.publishedAt;
     if (value != null) {
       result
         ..add('publishedAt')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(GOrderBy)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GOrderBy)));
     }
     value = object.seo;
     if (value != null) {
       result
         ..add('seo')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GSeosOrderBy),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GSeosOrderBy)));
     }
     value = object.seoId;
     if (value != null) {
       result
         ..add('seoId')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(GOrderBy)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GOrderBy)));
     }
     value = object.slug;
     if (value != null) {
       result
         ..add('slug')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(GOrderBy)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GOrderBy)));
     }
     value = object.title;
     if (value != null) {
       result
         ..add('title')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(GOrderBy)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GOrderBy)));
     }
     value = object.updatedAt;
     if (value != null) {
       result
         ..add('updatedAt')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(GOrderBy)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GOrderBy)));
     }
     return result;
   }
 
   @override
   GNewsOrderBy deserialize(
-    Serializers serializers,
-    Iterable<Object?> serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = new GNewsOrderByBuilder();
 
     final iterator = serialized.iterator;
@@ -4716,93 +3664,48 @@ class _$GNewsOrderBySerializer implements StructuredSerializer<GNewsOrderBy> {
       final Object? value = iterator.current;
       switch (key) {
         case 'content':
-          result.content =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(GOrderBy),
-                  )
-                  as GOrderBy?;
+          result.content = serializers.deserialize(value,
+              specifiedType: const FullType(GOrderBy)) as GOrderBy?;
           break;
         case 'coverImageUrl':
-          result.coverImageUrl =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(GOrderBy),
-                  )
-                  as GOrderBy?;
+          result.coverImageUrl = serializers.deserialize(value,
+              specifiedType: const FullType(GOrderBy)) as GOrderBy?;
           break;
         case 'createdAt':
-          result.createdAt =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(GOrderBy),
-                  )
-                  as GOrderBy?;
+          result.createdAt = serializers.deserialize(value,
+              specifiedType: const FullType(GOrderBy)) as GOrderBy?;
           break;
         case 'excerpt':
-          result.excerpt =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(GOrderBy),
-                  )
-                  as GOrderBy?;
+          result.excerpt = serializers.deserialize(value,
+              specifiedType: const FullType(GOrderBy)) as GOrderBy?;
           break;
         case 'id':
-          result.id =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(GOrderBy),
-                  )
-                  as GOrderBy?;
+          result.id = serializers.deserialize(value,
+              specifiedType: const FullType(GOrderBy)) as GOrderBy?;
           break;
         case 'publishedAt':
-          result.publishedAt =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(GOrderBy),
-                  )
-                  as GOrderBy?;
+          result.publishedAt = serializers.deserialize(value,
+              specifiedType: const FullType(GOrderBy)) as GOrderBy?;
           break;
         case 'seo':
-          result.seo.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(GSeosOrderBy),
-                )!
-                as GSeosOrderBy,
-          );
+          result.seo.replace(serializers.deserialize(value,
+              specifiedType: const FullType(GSeosOrderBy))! as GSeosOrderBy);
           break;
         case 'seoId':
-          result.seoId =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(GOrderBy),
-                  )
-                  as GOrderBy?;
+          result.seoId = serializers.deserialize(value,
+              specifiedType: const FullType(GOrderBy)) as GOrderBy?;
           break;
         case 'slug':
-          result.slug =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(GOrderBy),
-                  )
-                  as GOrderBy?;
+          result.slug = serializers.deserialize(value,
+              specifiedType: const FullType(GOrderBy)) as GOrderBy?;
           break;
         case 'title':
-          result.title =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(GOrderBy),
-                  )
-                  as GOrderBy?;
+          result.title = serializers.deserialize(value,
+              specifiedType: const FullType(GOrderBy)) as GOrderBy?;
           break;
         case 'updatedAt':
-          result.updatedAt =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(GOrderBy),
-                  )
-                  as GOrderBy?;
+          result.updatedAt = serializers.deserialize(value,
+              specifiedType: const FullType(GOrderBy)) as GOrderBy?;
           break;
       }
     }
@@ -4819,18 +3722,14 @@ class _$GNewsSelectColumnSerializer
   final String wireName = 'GNewsSelectColumn';
 
   @override
-  Object serialize(
-    Serializers serializers,
-    GNewsSelectColumn object, {
-    FullType specifiedType = FullType.unspecified,
-  }) => object.name;
+  Object serialize(Serializers serializers, GNewsSelectColumn object,
+          {FullType specifiedType = FullType.unspecified}) =>
+      object.name;
 
   @override
-  GNewsSelectColumn deserialize(
-    Serializers serializers,
-    Object serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) => GNewsSelectColumn.valueOf(serialized as String);
+  GNewsSelectColumn deserialize(Serializers serializers, Object serialized,
+          {FullType specifiedType = FullType.unspecified}) =>
+      GNewsSelectColumn.valueOf(serialized as String);
 }
 
 class _$GNewsStreamCursorInputSerializer
@@ -4838,45 +3737,35 @@ class _$GNewsStreamCursorInputSerializer
   @override
   final Iterable<Type> types = const [
     GNewsStreamCursorInput,
-    _$GNewsStreamCursorInput,
+    _$GNewsStreamCursorInput
   ];
   @override
   final String wireName = 'GNewsStreamCursorInput';
 
   @override
   Iterable<Object?> serialize(
-    Serializers serializers,
-    GNewsStreamCursorInput object, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, GNewsStreamCursorInput object,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[
       'initialValue',
-      serializers.serialize(
-        object.initialValue,
-        specifiedType: const FullType(GNewsStreamCursorValueInput),
-      ),
+      serializers.serialize(object.initialValue,
+          specifiedType: const FullType(GNewsStreamCursorValueInput)),
     ];
     Object? value;
     value = object.ordering;
     if (value != null) {
       result
         ..add('ordering')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GCursorOrdering),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GCursorOrdering)));
     }
     return result;
   }
 
   @override
   GNewsStreamCursorInput deserialize(
-    Serializers serializers,
-    Iterable<Object?> serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = new GNewsStreamCursorInputBuilder();
 
     final iterator = serialized.iterator;
@@ -4886,21 +3775,14 @@ class _$GNewsStreamCursorInputSerializer
       final Object? value = iterator.current;
       switch (key) {
         case 'initialValue':
-          result.initialValue.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(GNewsStreamCursorValueInput),
-                )!
-                as GNewsStreamCursorValueInput,
-          );
+          result.initialValue.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(GNewsStreamCursorValueInput))!
+              as GNewsStreamCursorValueInput);
           break;
         case 'ordering':
-          result.ordering =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(GCursorOrdering),
-                  )
-                  as GCursorOrdering?;
+          result.ordering = serializers.deserialize(value,
+                  specifiedType: const FullType(GCursorOrdering))
+              as GCursorOrdering?;
           break;
       }
     }
@@ -4914,108 +3796,94 @@ class _$GNewsStreamCursorValueInputSerializer
   @override
   final Iterable<Type> types = const [
     GNewsStreamCursorValueInput,
-    _$GNewsStreamCursorValueInput,
+    _$GNewsStreamCursorValueInput
   ];
   @override
   final String wireName = 'GNewsStreamCursorValueInput';
 
   @override
   Iterable<Object?> serialize(
-    Serializers serializers,
-    GNewsStreamCursorValueInput object, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, GNewsStreamCursorValueInput object,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[];
     Object? value;
     value = object.content;
     if (value != null) {
       result
         ..add('content')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(String)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
     }
     value = object.coverImageUrl;
     if (value != null) {
       result
         ..add('coverImageUrl')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(String)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
     }
     value = object.createdAt;
     if (value != null) {
       result
         ..add('createdAt')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(DateTime)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(DateTime)));
     }
     value = object.excerpt;
     if (value != null) {
       result
         ..add('excerpt')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(String)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
     }
     value = object.id;
     if (value != null) {
       result
         ..add('id')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(String)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
     }
     value = object.publishedAt;
     if (value != null) {
       result
         ..add('publishedAt')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(DateTime)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(DateTime)));
     }
     value = object.seoId;
     if (value != null) {
       result
         ..add('seoId')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(String)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
     }
     value = object.slug;
     if (value != null) {
       result
         ..add('slug')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(String)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
     }
     value = object.title;
     if (value != null) {
       result
         ..add('title')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(String)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
     }
     value = object.updatedAt;
     if (value != null) {
       result
         ..add('updatedAt')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(DateTime)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(DateTime)));
     }
     return result;
   }
 
   @override
   GNewsStreamCursorValueInput deserialize(
-    Serializers serializers,
-    Iterable<Object?> serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = new GNewsStreamCursorValueInputBuilder();
 
     final iterator = serialized.iterator;
@@ -5025,84 +3893,44 @@ class _$GNewsStreamCursorValueInputSerializer
       final Object? value = iterator.current;
       switch (key) {
         case 'content':
-          result.content =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )
-                  as String?;
+          result.content = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
           break;
         case 'coverImageUrl':
-          result.coverImageUrl =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )
-                  as String?;
+          result.coverImageUrl = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
           break;
         case 'createdAt':
-          result.createdAt =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(DateTime),
-                  )
-                  as DateTime?;
+          result.createdAt = serializers.deserialize(value,
+              specifiedType: const FullType(DateTime)) as DateTime?;
           break;
         case 'excerpt':
-          result.excerpt =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )
-                  as String?;
+          result.excerpt = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
           break;
         case 'id':
-          result.id =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )
-                  as String?;
+          result.id = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
           break;
         case 'publishedAt':
-          result.publishedAt =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(DateTime),
-                  )
-                  as DateTime?;
+          result.publishedAt = serializers.deserialize(value,
+              specifiedType: const FullType(DateTime)) as DateTime?;
           break;
         case 'seoId':
-          result.seoId =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )
-                  as String?;
+          result.seoId = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
           break;
         case 'slug':
-          result.slug =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )
-                  as String?;
+          result.slug = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
           break;
         case 'title':
-          result.title =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )
-                  as String?;
+          result.title = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
           break;
         case 'updatedAt':
-          result.updatedAt =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(DateTime),
-                  )
-                  as DateTime?;
+          result.updatedAt = serializers.deserialize(value,
+              specifiedType: const FullType(DateTime)) as DateTime?;
           break;
       }
     }
@@ -5116,175 +3944,117 @@ class _$GNotificationsBoolExpSerializer
   @override
   final Iterable<Type> types = const [
     GNotificationsBoolExp,
-    _$GNotificationsBoolExp,
+    _$GNotificationsBoolExp
   ];
   @override
   final String wireName = 'GNotificationsBoolExp';
 
   @override
   Iterable<Object?> serialize(
-    Serializers serializers,
-    GNotificationsBoolExp object, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, GNotificationsBoolExp object,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[];
     Object? value;
     value = object.G_and;
     if (value != null) {
       result
         ..add('_and')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(BuiltList, const [
-              const FullType(GNotificationsBoolExp),
-            ]),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(
+                BuiltList, const [const FullType(GNotificationsBoolExp)])));
     }
     value = object.G_not;
     if (value != null) {
       result
         ..add('_not')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GNotificationsBoolExp),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GNotificationsBoolExp)));
     }
     value = object.G_or;
     if (value != null) {
       result
         ..add('_or')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(BuiltList, const [
-              const FullType(GNotificationsBoolExp),
-            ]),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(
+                BuiltList, const [const FullType(GNotificationsBoolExp)])));
     }
     value = object.content;
     if (value != null) {
       result
         ..add('content')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GStringComparisonExp),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GStringComparisonExp)));
     }
     value = object.coverImageUrl;
     if (value != null) {
       result
         ..add('coverImageUrl')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GStringComparisonExp),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GStringComparisonExp)));
     }
     value = object.createdAt;
     if (value != null) {
       result
         ..add('createdAt')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GTimestamptzComparisonExp),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GTimestamptzComparisonExp)));
     }
     value = object.excerpt;
     if (value != null) {
       result
         ..add('excerpt')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GStringComparisonExp),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GStringComparisonExp)));
     }
     value = object.firstOpenedAt;
     if (value != null) {
       result
         ..add('firstOpenedAt')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GTimestamptzComparisonExp),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GTimestamptzComparisonExp)));
     }
     value = object.id;
     if (value != null) {
       result
         ..add('id')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GUuidComparisonExp),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GUuidComparisonExp)));
     }
     value = object.publishedAt;
     if (value != null) {
       result
         ..add('publishedAt')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GTimestamptzComparisonExp),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GTimestamptzComparisonExp)));
     }
     value = object.title;
     if (value != null) {
       result
         ..add('title')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GStringComparisonExp),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GStringComparisonExp)));
     }
     value = object.updatedAt;
     if (value != null) {
       result
         ..add('updatedAt')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GTimestamptzComparisonExp),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GTimestamptzComparisonExp)));
     }
     value = object.userId;
     if (value != null) {
       result
         ..add('userId')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GStringComparisonExp),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GStringComparisonExp)));
     }
     return result;
   }
 
   @override
   GNotificationsBoolExp deserialize(
-    Serializers serializers,
-    Iterable<Object?> serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = new GNotificationsBoolExpBuilder();
 
     final iterator = serialized.iterator;
@@ -5294,125 +4064,71 @@ class _$GNotificationsBoolExpSerializer
       final Object? value = iterator.current;
       switch (key) {
         case '_and':
-          result.G_and.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(BuiltList, const [
-                    const FullType(GNotificationsBoolExp),
-                  ]),
-                )!
-                as BuiltList<Object?>,
-          );
+          result.G_and.replace(serializers.deserialize(value,
+              specifiedType: const FullType(BuiltList, const [
+                const FullType(GNotificationsBoolExp)
+              ]))! as BuiltList<Object?>);
           break;
         case '_not':
-          result.G_not.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(GNotificationsBoolExp),
-                )!
-                as GNotificationsBoolExp,
-          );
+          result.G_not.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(GNotificationsBoolExp))!
+              as GNotificationsBoolExp);
           break;
         case '_or':
-          result.G_or.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(BuiltList, const [
-                    const FullType(GNotificationsBoolExp),
-                  ]),
-                )!
-                as BuiltList<Object?>,
-          );
+          result.G_or.replace(serializers.deserialize(value,
+              specifiedType: const FullType(BuiltList, const [
+                const FullType(GNotificationsBoolExp)
+              ]))! as BuiltList<Object?>);
           break;
         case 'content':
-          result.content.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(GStringComparisonExp),
-                )!
-                as GStringComparisonExp,
-          );
+          result.content.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(GStringComparisonExp))!
+              as GStringComparisonExp);
           break;
         case 'coverImageUrl':
-          result.coverImageUrl.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(GStringComparisonExp),
-                )!
-                as GStringComparisonExp,
-          );
+          result.coverImageUrl.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(GStringComparisonExp))!
+              as GStringComparisonExp);
           break;
         case 'createdAt':
-          result.createdAt.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(GTimestamptzComparisonExp),
-                )!
-                as GTimestamptzComparisonExp,
-          );
+          result.createdAt.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(GTimestamptzComparisonExp))!
+              as GTimestamptzComparisonExp);
           break;
         case 'excerpt':
-          result.excerpt.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(GStringComparisonExp),
-                )!
-                as GStringComparisonExp,
-          );
+          result.excerpt.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(GStringComparisonExp))!
+              as GStringComparisonExp);
           break;
         case 'firstOpenedAt':
-          result.firstOpenedAt.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(GTimestamptzComparisonExp),
-                )!
-                as GTimestamptzComparisonExp,
-          );
+          result.firstOpenedAt.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(GTimestamptzComparisonExp))!
+              as GTimestamptzComparisonExp);
           break;
         case 'id':
-          result.id.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(GUuidComparisonExp),
-                )!
-                as GUuidComparisonExp,
-          );
+          result.id.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(GUuidComparisonExp))!
+              as GUuidComparisonExp);
           break;
         case 'publishedAt':
-          result.publishedAt.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(GTimestamptzComparisonExp),
-                )!
-                as GTimestamptzComparisonExp,
-          );
+          result.publishedAt.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(GTimestamptzComparisonExp))!
+              as GTimestamptzComparisonExp);
           break;
         case 'title':
-          result.title.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(GStringComparisonExp),
-                )!
-                as GStringComparisonExp,
-          );
+          result.title.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(GStringComparisonExp))!
+              as GStringComparisonExp);
           break;
         case 'updatedAt':
-          result.updatedAt.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(GTimestamptzComparisonExp),
-                )!
-                as GTimestamptzComparisonExp,
-          );
+          result.updatedAt.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(GTimestamptzComparisonExp))!
+              as GTimestamptzComparisonExp);
           break;
         case 'userId':
-          result.userId.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(GStringComparisonExp),
-                )!
-                as GStringComparisonExp,
-          );
+          result.userId.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(GStringComparisonExp))!
+              as GStringComparisonExp);
           break;
       }
     }
@@ -5426,108 +4142,94 @@ class _$GNotificationsOrderBySerializer
   @override
   final Iterable<Type> types = const [
     GNotificationsOrderBy,
-    _$GNotificationsOrderBy,
+    _$GNotificationsOrderBy
   ];
   @override
   final String wireName = 'GNotificationsOrderBy';
 
   @override
   Iterable<Object?> serialize(
-    Serializers serializers,
-    GNotificationsOrderBy object, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, GNotificationsOrderBy object,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[];
     Object? value;
     value = object.content;
     if (value != null) {
       result
         ..add('content')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(GOrderBy)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GOrderBy)));
     }
     value = object.coverImageUrl;
     if (value != null) {
       result
         ..add('coverImageUrl')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(GOrderBy)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GOrderBy)));
     }
     value = object.createdAt;
     if (value != null) {
       result
         ..add('createdAt')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(GOrderBy)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GOrderBy)));
     }
     value = object.excerpt;
     if (value != null) {
       result
         ..add('excerpt')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(GOrderBy)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GOrderBy)));
     }
     value = object.firstOpenedAt;
     if (value != null) {
       result
         ..add('firstOpenedAt')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(GOrderBy)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GOrderBy)));
     }
     value = object.id;
     if (value != null) {
       result
         ..add('id')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(GOrderBy)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GOrderBy)));
     }
     value = object.publishedAt;
     if (value != null) {
       result
         ..add('publishedAt')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(GOrderBy)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GOrderBy)));
     }
     value = object.title;
     if (value != null) {
       result
         ..add('title')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(GOrderBy)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GOrderBy)));
     }
     value = object.updatedAt;
     if (value != null) {
       result
         ..add('updatedAt')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(GOrderBy)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GOrderBy)));
     }
     value = object.userId;
     if (value != null) {
       result
         ..add('userId')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(GOrderBy)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GOrderBy)));
     }
     return result;
   }
 
   @override
   GNotificationsOrderBy deserialize(
-    Serializers serializers,
-    Iterable<Object?> serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = new GNotificationsOrderByBuilder();
 
     final iterator = serialized.iterator;
@@ -5537,84 +4239,44 @@ class _$GNotificationsOrderBySerializer
       final Object? value = iterator.current;
       switch (key) {
         case 'content':
-          result.content =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(GOrderBy),
-                  )
-                  as GOrderBy?;
+          result.content = serializers.deserialize(value,
+              specifiedType: const FullType(GOrderBy)) as GOrderBy?;
           break;
         case 'coverImageUrl':
-          result.coverImageUrl =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(GOrderBy),
-                  )
-                  as GOrderBy?;
+          result.coverImageUrl = serializers.deserialize(value,
+              specifiedType: const FullType(GOrderBy)) as GOrderBy?;
           break;
         case 'createdAt':
-          result.createdAt =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(GOrderBy),
-                  )
-                  as GOrderBy?;
+          result.createdAt = serializers.deserialize(value,
+              specifiedType: const FullType(GOrderBy)) as GOrderBy?;
           break;
         case 'excerpt':
-          result.excerpt =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(GOrderBy),
-                  )
-                  as GOrderBy?;
+          result.excerpt = serializers.deserialize(value,
+              specifiedType: const FullType(GOrderBy)) as GOrderBy?;
           break;
         case 'firstOpenedAt':
-          result.firstOpenedAt =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(GOrderBy),
-                  )
-                  as GOrderBy?;
+          result.firstOpenedAt = serializers.deserialize(value,
+              specifiedType: const FullType(GOrderBy)) as GOrderBy?;
           break;
         case 'id':
-          result.id =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(GOrderBy),
-                  )
-                  as GOrderBy?;
+          result.id = serializers.deserialize(value,
+              specifiedType: const FullType(GOrderBy)) as GOrderBy?;
           break;
         case 'publishedAt':
-          result.publishedAt =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(GOrderBy),
-                  )
-                  as GOrderBy?;
+          result.publishedAt = serializers.deserialize(value,
+              specifiedType: const FullType(GOrderBy)) as GOrderBy?;
           break;
         case 'title':
-          result.title =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(GOrderBy),
-                  )
-                  as GOrderBy?;
+          result.title = serializers.deserialize(value,
+              specifiedType: const FullType(GOrderBy)) as GOrderBy?;
           break;
         case 'updatedAt':
-          result.updatedAt =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(GOrderBy),
-                  )
-                  as GOrderBy?;
+          result.updatedAt = serializers.deserialize(value,
+              specifiedType: const FullType(GOrderBy)) as GOrderBy?;
           break;
         case 'userId':
-          result.userId =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(GOrderBy),
-                  )
-                  as GOrderBy?;
+          result.userId = serializers.deserialize(value,
+              specifiedType: const FullType(GOrderBy)) as GOrderBy?;
           break;
       }
     }
@@ -5631,18 +4293,15 @@ class _$GNotificationsSelectColumnSerializer
   final String wireName = 'GNotificationsSelectColumn';
 
   @override
-  Object serialize(
-    Serializers serializers,
-    GNotificationsSelectColumn object, {
-    FullType specifiedType = FullType.unspecified,
-  }) => object.name;
+  Object serialize(Serializers serializers, GNotificationsSelectColumn object,
+          {FullType specifiedType = FullType.unspecified}) =>
+      object.name;
 
   @override
   GNotificationsSelectColumn deserialize(
-    Serializers serializers,
-    Object serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) => GNotificationsSelectColumn.valueOf(serialized as String);
+          Serializers serializers, Object serialized,
+          {FullType specifiedType = FullType.unspecified}) =>
+      GNotificationsSelectColumn.valueOf(serialized as String);
 }
 
 class _$GNotificationsStreamCursorInputSerializer
@@ -5650,45 +4309,35 @@ class _$GNotificationsStreamCursorInputSerializer
   @override
   final Iterable<Type> types = const [
     GNotificationsStreamCursorInput,
-    _$GNotificationsStreamCursorInput,
+    _$GNotificationsStreamCursorInput
   ];
   @override
   final String wireName = 'GNotificationsStreamCursorInput';
 
   @override
   Iterable<Object?> serialize(
-    Serializers serializers,
-    GNotificationsStreamCursorInput object, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, GNotificationsStreamCursorInput object,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[
       'initialValue',
-      serializers.serialize(
-        object.initialValue,
-        specifiedType: const FullType(GNotificationsStreamCursorValueInput),
-      ),
+      serializers.serialize(object.initialValue,
+          specifiedType: const FullType(GNotificationsStreamCursorValueInput)),
     ];
     Object? value;
     value = object.ordering;
     if (value != null) {
       result
         ..add('ordering')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GCursorOrdering),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GCursorOrdering)));
     }
     return result;
   }
 
   @override
   GNotificationsStreamCursorInput deserialize(
-    Serializers serializers,
-    Iterable<Object?> serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = new GNotificationsStreamCursorInputBuilder();
 
     final iterator = serialized.iterator;
@@ -5698,23 +4347,15 @@ class _$GNotificationsStreamCursorInputSerializer
       final Object? value = iterator.current;
       switch (key) {
         case 'initialValue':
-          result.initialValue.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(
-                    GNotificationsStreamCursorValueInput,
-                  ),
-                )!
-                as GNotificationsStreamCursorValueInput,
-          );
+          result.initialValue.replace(serializers.deserialize(value,
+                  specifiedType:
+                      const FullType(GNotificationsStreamCursorValueInput))!
+              as GNotificationsStreamCursorValueInput);
           break;
         case 'ordering':
-          result.ordering =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(GCursorOrdering),
-                  )
-                  as GCursorOrdering?;
+          result.ordering = serializers.deserialize(value,
+                  specifiedType: const FullType(GCursorOrdering))
+              as GCursorOrdering?;
           break;
       }
     }
@@ -5728,108 +4369,94 @@ class _$GNotificationsStreamCursorValueInputSerializer
   @override
   final Iterable<Type> types = const [
     GNotificationsStreamCursorValueInput,
-    _$GNotificationsStreamCursorValueInput,
+    _$GNotificationsStreamCursorValueInput
   ];
   @override
   final String wireName = 'GNotificationsStreamCursorValueInput';
 
   @override
   Iterable<Object?> serialize(
-    Serializers serializers,
-    GNotificationsStreamCursorValueInput object, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, GNotificationsStreamCursorValueInput object,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[];
     Object? value;
     value = object.content;
     if (value != null) {
       result
         ..add('content')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(String)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
     }
     value = object.coverImageUrl;
     if (value != null) {
       result
         ..add('coverImageUrl')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(String)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
     }
     value = object.createdAt;
     if (value != null) {
       result
         ..add('createdAt')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(DateTime)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(DateTime)));
     }
     value = object.excerpt;
     if (value != null) {
       result
         ..add('excerpt')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(String)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
     }
     value = object.firstOpenedAt;
     if (value != null) {
       result
         ..add('firstOpenedAt')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(DateTime)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(DateTime)));
     }
     value = object.id;
     if (value != null) {
       result
         ..add('id')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(String)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
     }
     value = object.publishedAt;
     if (value != null) {
       result
         ..add('publishedAt')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(DateTime)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(DateTime)));
     }
     value = object.title;
     if (value != null) {
       result
         ..add('title')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(String)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
     }
     value = object.updatedAt;
     if (value != null) {
       result
         ..add('updatedAt')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(DateTime)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(DateTime)));
     }
     value = object.userId;
     if (value != null) {
       result
         ..add('userId')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(String)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
     }
     return result;
   }
 
   @override
   GNotificationsStreamCursorValueInput deserialize(
-    Serializers serializers,
-    Iterable<Object?> serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = new GNotificationsStreamCursorValueInputBuilder();
 
     final iterator = serialized.iterator;
@@ -5839,84 +4466,44 @@ class _$GNotificationsStreamCursorValueInputSerializer
       final Object? value = iterator.current;
       switch (key) {
         case 'content':
-          result.content =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )
-                  as String?;
+          result.content = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
           break;
         case 'coverImageUrl':
-          result.coverImageUrl =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )
-                  as String?;
+          result.coverImageUrl = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
           break;
         case 'createdAt':
-          result.createdAt =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(DateTime),
-                  )
-                  as DateTime?;
+          result.createdAt = serializers.deserialize(value,
+              specifiedType: const FullType(DateTime)) as DateTime?;
           break;
         case 'excerpt':
-          result.excerpt =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )
-                  as String?;
+          result.excerpt = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
           break;
         case 'firstOpenedAt':
-          result.firstOpenedAt =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(DateTime),
-                  )
-                  as DateTime?;
+          result.firstOpenedAt = serializers.deserialize(value,
+              specifiedType: const FullType(DateTime)) as DateTime?;
           break;
         case 'id':
-          result.id =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )
-                  as String?;
+          result.id = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
           break;
         case 'publishedAt':
-          result.publishedAt =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(DateTime),
-                  )
-                  as DateTime?;
+          result.publishedAt = serializers.deserialize(value,
+              specifiedType: const FullType(DateTime)) as DateTime?;
           break;
         case 'title':
-          result.title =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )
-                  as String?;
+          result.title = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
           break;
         case 'updatedAt':
-          result.updatedAt =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(DateTime),
-                  )
-                  as DateTime?;
+          result.updatedAt = serializers.deserialize(value,
+              specifiedType: const FullType(DateTime)) as DateTime?;
           break;
         case 'userId':
-          result.userId =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )
-                  as String?;
+          result.userId = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
           break;
       }
     }
@@ -5932,18 +4519,14 @@ class _$GOrderBySerializer implements PrimitiveSerializer<GOrderBy> {
   final String wireName = 'GOrderBy';
 
   @override
-  Object serialize(
-    Serializers serializers,
-    GOrderBy object, {
-    FullType specifiedType = FullType.unspecified,
-  }) => object.name;
+  Object serialize(Serializers serializers, GOrderBy object,
+          {FullType specifiedType = FullType.unspecified}) =>
+      object.name;
 
   @override
-  GOrderBy deserialize(
-    Serializers serializers,
-    Object serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) => GOrderBy.valueOf(serialized as String);
+  GOrderBy deserialize(Serializers serializers, Object serialized,
+          {FullType specifiedType = FullType.unspecified}) =>
+      GOrderBy.valueOf(serialized as String);
 }
 
 class _$GQuestCategoriesBoolExpSerializer
@@ -5951,131 +4534,89 @@ class _$GQuestCategoriesBoolExpSerializer
   @override
   final Iterable<Type> types = const [
     GQuestCategoriesBoolExp,
-    _$GQuestCategoriesBoolExp,
+    _$GQuestCategoriesBoolExp
   ];
   @override
   final String wireName = 'GQuestCategoriesBoolExp';
 
   @override
   Iterable<Object?> serialize(
-    Serializers serializers,
-    GQuestCategoriesBoolExp object, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, GQuestCategoriesBoolExp object,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[];
     Object? value;
     value = object.G_and;
     if (value != null) {
       result
         ..add('_and')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(BuiltList, const [
-              const FullType(GQuestCategoriesBoolExp),
-            ]),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(
+                BuiltList, const [const FullType(GQuestCategoriesBoolExp)])));
     }
     value = object.G_not;
     if (value != null) {
       result
         ..add('_not')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GQuestCategoriesBoolExp),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GQuestCategoriesBoolExp)));
     }
     value = object.G_or;
     if (value != null) {
       result
         ..add('_or')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(BuiltList, const [
-              const FullType(GQuestCategoriesBoolExp),
-            ]),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(
+                BuiltList, const [const FullType(GQuestCategoriesBoolExp)])));
     }
     value = object.createdAt;
     if (value != null) {
       result
         ..add('createdAt')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GTimestamptzComparisonExp),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GTimestamptzComparisonExp)));
     }
     value = object.description;
     if (value != null) {
       result
         ..add('description')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GStringComparisonExp),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GStringComparisonExp)));
     }
     value = object.id;
     if (value != null) {
       result
         ..add('id')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GUuidComparisonExp),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GUuidComparisonExp)));
     }
     value = object.name;
     if (value != null) {
       result
         ..add('name')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GStringComparisonExp),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GStringComparisonExp)));
     }
     value = object.sortNumber;
     if (value != null) {
       result
         ..add('sortNumber')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GIntComparisonExp),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GIntComparisonExp)));
     }
     value = object.updatedAt;
     if (value != null) {
       result
         ..add('updatedAt')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GTimestamptzComparisonExp),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GTimestamptzComparisonExp)));
     }
     return result;
   }
 
   @override
   GQuestCategoriesBoolExp deserialize(
-    Serializers serializers,
-    Iterable<Object?> serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = new GQuestCategoriesBoolExpBuilder();
 
     final iterator = serialized.iterator;
@@ -6085,89 +4626,51 @@ class _$GQuestCategoriesBoolExpSerializer
       final Object? value = iterator.current;
       switch (key) {
         case '_and':
-          result.G_and.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(BuiltList, const [
-                    const FullType(GQuestCategoriesBoolExp),
-                  ]),
-                )!
-                as BuiltList<Object?>,
-          );
+          result.G_and.replace(serializers.deserialize(value,
+              specifiedType: const FullType(BuiltList, const [
+                const FullType(GQuestCategoriesBoolExp)
+              ]))! as BuiltList<Object?>);
           break;
         case '_not':
-          result.G_not.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(GQuestCategoriesBoolExp),
-                )!
-                as GQuestCategoriesBoolExp,
-          );
+          result.G_not.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(GQuestCategoriesBoolExp))!
+              as GQuestCategoriesBoolExp);
           break;
         case '_or':
-          result.G_or.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(BuiltList, const [
-                    const FullType(GQuestCategoriesBoolExp),
-                  ]),
-                )!
-                as BuiltList<Object?>,
-          );
+          result.G_or.replace(serializers.deserialize(value,
+              specifiedType: const FullType(BuiltList, const [
+                const FullType(GQuestCategoriesBoolExp)
+              ]))! as BuiltList<Object?>);
           break;
         case 'createdAt':
-          result.createdAt.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(GTimestamptzComparisonExp),
-                )!
-                as GTimestamptzComparisonExp,
-          );
+          result.createdAt.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(GTimestamptzComparisonExp))!
+              as GTimestamptzComparisonExp);
           break;
         case 'description':
-          result.description.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(GStringComparisonExp),
-                )!
-                as GStringComparisonExp,
-          );
+          result.description.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(GStringComparisonExp))!
+              as GStringComparisonExp);
           break;
         case 'id':
-          result.id.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(GUuidComparisonExp),
-                )!
-                as GUuidComparisonExp,
-          );
+          result.id.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(GUuidComparisonExp))!
+              as GUuidComparisonExp);
           break;
         case 'name':
-          result.name.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(GStringComparisonExp),
-                )!
-                as GStringComparisonExp,
-          );
+          result.name.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(GStringComparisonExp))!
+              as GStringComparisonExp);
           break;
         case 'sortNumber':
-          result.sortNumber.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(GIntComparisonExp),
-                )!
-                as GIntComparisonExp,
-          );
+          result.sortNumber.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(GIntComparisonExp))!
+              as GIntComparisonExp);
           break;
         case 'updatedAt':
-          result.updatedAt.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(GTimestamptzComparisonExp),
-                )!
-                as GTimestamptzComparisonExp,
-          );
+          result.updatedAt.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(GTimestamptzComparisonExp))!
+              as GTimestamptzComparisonExp);
           break;
       }
     }
@@ -6181,76 +4684,66 @@ class _$GQuestCategoriesOrderBySerializer
   @override
   final Iterable<Type> types = const [
     GQuestCategoriesOrderBy,
-    _$GQuestCategoriesOrderBy,
+    _$GQuestCategoriesOrderBy
   ];
   @override
   final String wireName = 'GQuestCategoriesOrderBy';
 
   @override
   Iterable<Object?> serialize(
-    Serializers serializers,
-    GQuestCategoriesOrderBy object, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, GQuestCategoriesOrderBy object,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[];
     Object? value;
     value = object.createdAt;
     if (value != null) {
       result
         ..add('createdAt')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(GOrderBy)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GOrderBy)));
     }
     value = object.description;
     if (value != null) {
       result
         ..add('description')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(GOrderBy)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GOrderBy)));
     }
     value = object.id;
     if (value != null) {
       result
         ..add('id')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(GOrderBy)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GOrderBy)));
     }
     value = object.name;
     if (value != null) {
       result
         ..add('name')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(GOrderBy)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GOrderBy)));
     }
     value = object.sortNumber;
     if (value != null) {
       result
         ..add('sortNumber')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(GOrderBy)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GOrderBy)));
     }
     value = object.updatedAt;
     if (value != null) {
       result
         ..add('updatedAt')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(GOrderBy)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GOrderBy)));
     }
     return result;
   }
 
   @override
   GQuestCategoriesOrderBy deserialize(
-    Serializers serializers,
-    Iterable<Object?> serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = new GQuestCategoriesOrderByBuilder();
 
     final iterator = serialized.iterator;
@@ -6260,52 +4753,28 @@ class _$GQuestCategoriesOrderBySerializer
       final Object? value = iterator.current;
       switch (key) {
         case 'createdAt':
-          result.createdAt =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(GOrderBy),
-                  )
-                  as GOrderBy?;
+          result.createdAt = serializers.deserialize(value,
+              specifiedType: const FullType(GOrderBy)) as GOrderBy?;
           break;
         case 'description':
-          result.description =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(GOrderBy),
-                  )
-                  as GOrderBy?;
+          result.description = serializers.deserialize(value,
+              specifiedType: const FullType(GOrderBy)) as GOrderBy?;
           break;
         case 'id':
-          result.id =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(GOrderBy),
-                  )
-                  as GOrderBy?;
+          result.id = serializers.deserialize(value,
+              specifiedType: const FullType(GOrderBy)) as GOrderBy?;
           break;
         case 'name':
-          result.name =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(GOrderBy),
-                  )
-                  as GOrderBy?;
+          result.name = serializers.deserialize(value,
+              specifiedType: const FullType(GOrderBy)) as GOrderBy?;
           break;
         case 'sortNumber':
-          result.sortNumber =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(GOrderBy),
-                  )
-                  as GOrderBy?;
+          result.sortNumber = serializers.deserialize(value,
+              specifiedType: const FullType(GOrderBy)) as GOrderBy?;
           break;
         case 'updatedAt':
-          result.updatedAt =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(GOrderBy),
-                  )
-                  as GOrderBy?;
+          result.updatedAt = serializers.deserialize(value,
+              specifiedType: const FullType(GOrderBy)) as GOrderBy?;
           break;
       }
     }
@@ -6329,20 +4798,16 @@ class _$GQuestCategoriesSelectColumnSerializer
   final String wireName = 'GQuestCategoriesSelectColumn';
 
   @override
-  Object serialize(
-    Serializers serializers,
-    GQuestCategoriesSelectColumn object, {
-    FullType specifiedType = FullType.unspecified,
-  }) => _toWire[object.name] ?? object.name;
+  Object serialize(Serializers serializers, GQuestCategoriesSelectColumn object,
+          {FullType specifiedType = FullType.unspecified}) =>
+      _toWire[object.name] ?? object.name;
 
   @override
   GQuestCategoriesSelectColumn deserialize(
-    Serializers serializers,
-    Object serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) => GQuestCategoriesSelectColumn.valueOf(
-    _fromWire[serialized] ?? (serialized is String ? serialized : ''),
-  );
+          Serializers serializers, Object serialized,
+          {FullType specifiedType = FullType.unspecified}) =>
+      GQuestCategoriesSelectColumn.valueOf(
+          _fromWire[serialized] ?? (serialized is String ? serialized : ''));
 }
 
 class _$GQuestCategoriesStreamCursorInputSerializer
@@ -6350,45 +4815,36 @@ class _$GQuestCategoriesStreamCursorInputSerializer
   @override
   final Iterable<Type> types = const [
     GQuestCategoriesStreamCursorInput,
-    _$GQuestCategoriesStreamCursorInput,
+    _$GQuestCategoriesStreamCursorInput
   ];
   @override
   final String wireName = 'GQuestCategoriesStreamCursorInput';
 
   @override
   Iterable<Object?> serialize(
-    Serializers serializers,
-    GQuestCategoriesStreamCursorInput object, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, GQuestCategoriesStreamCursorInput object,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[
       'initialValue',
-      serializers.serialize(
-        object.initialValue,
-        specifiedType: const FullType(GQuestCategoriesStreamCursorValueInput),
-      ),
+      serializers.serialize(object.initialValue,
+          specifiedType:
+              const FullType(GQuestCategoriesStreamCursorValueInput)),
     ];
     Object? value;
     value = object.ordering;
     if (value != null) {
       result
         ..add('ordering')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GCursorOrdering),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GCursorOrdering)));
     }
     return result;
   }
 
   @override
   GQuestCategoriesStreamCursorInput deserialize(
-    Serializers serializers,
-    Iterable<Object?> serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = new GQuestCategoriesStreamCursorInputBuilder();
 
     final iterator = serialized.iterator;
@@ -6398,23 +4854,15 @@ class _$GQuestCategoriesStreamCursorInputSerializer
       final Object? value = iterator.current;
       switch (key) {
         case 'initialValue':
-          result.initialValue.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(
-                    GQuestCategoriesStreamCursorValueInput,
-                  ),
-                )!
-                as GQuestCategoriesStreamCursorValueInput,
-          );
+          result.initialValue.replace(serializers.deserialize(value,
+                  specifiedType:
+                      const FullType(GQuestCategoriesStreamCursorValueInput))!
+              as GQuestCategoriesStreamCursorValueInput);
           break;
         case 'ordering':
-          result.ordering =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(GCursorOrdering),
-                  )
-                  as GCursorOrdering?;
+          result.ordering = serializers.deserialize(value,
+                  specifiedType: const FullType(GCursorOrdering))
+              as GCursorOrdering?;
           break;
       }
     }
@@ -6428,50 +4876,44 @@ class _$GQuestCategoriesStreamCursorValueInputSerializer
   @override
   final Iterable<Type> types = const [
     GQuestCategoriesStreamCursorValueInput,
-    _$GQuestCategoriesStreamCursorValueInput,
+    _$GQuestCategoriesStreamCursorValueInput
   ];
   @override
   final String wireName = 'GQuestCategoriesStreamCursorValueInput';
 
   @override
   Iterable<Object?> serialize(
-    Serializers serializers,
-    GQuestCategoriesStreamCursorValueInput object, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, GQuestCategoriesStreamCursorValueInput object,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[];
     Object? value;
     value = object.createdAt;
     if (value != null) {
       result
         ..add('createdAt')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(DateTime)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(DateTime)));
     }
     value = object.description;
     if (value != null) {
       result
         ..add('description')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(String)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
     }
     value = object.id;
     if (value != null) {
       result
         ..add('id')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(String)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
     }
     value = object.name;
     if (value != null) {
       result
         ..add('name')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(String)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
     }
     value = object.sortNumber;
     if (value != null) {
@@ -6483,19 +4925,16 @@ class _$GQuestCategoriesStreamCursorValueInputSerializer
     if (value != null) {
       result
         ..add('updatedAt')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(DateTime)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(DateTime)));
     }
     return result;
   }
 
   @override
   GQuestCategoriesStreamCursorValueInput deserialize(
-    Serializers serializers,
-    Iterable<Object?> serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = new GQuestCategoriesStreamCursorValueInputBuilder();
 
     final iterator = serialized.iterator;
@@ -6505,49 +4944,28 @@ class _$GQuestCategoriesStreamCursorValueInputSerializer
       final Object? value = iterator.current;
       switch (key) {
         case 'createdAt':
-          result.createdAt =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(DateTime),
-                  )
-                  as DateTime?;
+          result.createdAt = serializers.deserialize(value,
+              specifiedType: const FullType(DateTime)) as DateTime?;
           break;
         case 'description':
-          result.description =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )
-                  as String?;
+          result.description = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
           break;
         case 'id':
-          result.id =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )
-                  as String?;
+          result.id = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
           break;
         case 'name':
-          result.name =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )
-                  as String?;
+          result.name = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
           break;
         case 'sortNumber':
-          result.sortNumber =
-              serializers.deserialize(value, specifiedType: const FullType(int))
-                  as int?;
+          result.sortNumber = serializers.deserialize(value,
+              specifiedType: const FullType(int)) as int?;
           break;
         case 'updatedAt':
-          result.updatedAt =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(DateTime),
-                  )
-                  as DateTime?;
+          result.updatedAt = serializers.deserialize(value,
+              specifiedType: const FullType(DateTime)) as DateTime?;
           break;
       }
     }
@@ -6561,76 +4979,54 @@ class _$GQuestStatusBoolExpSerializer
   @override
   final Iterable<Type> types = const [
     GQuestStatusBoolExp,
-    _$GQuestStatusBoolExp,
+    _$GQuestStatusBoolExp
   ];
   @override
   final String wireName = 'GQuestStatusBoolExp';
 
   @override
   Iterable<Object?> serialize(
-    Serializers serializers,
-    GQuestStatusBoolExp object, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, GQuestStatusBoolExp object,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[];
     Object? value;
     value = object.G_and;
     if (value != null) {
       result
         ..add('_and')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(BuiltList, const [
-              const FullType(GQuestStatusBoolExp),
-            ]),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(
+                BuiltList, const [const FullType(GQuestStatusBoolExp)])));
     }
     value = object.G_not;
     if (value != null) {
       result
         ..add('_not')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GQuestStatusBoolExp),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GQuestStatusBoolExp)));
     }
     value = object.G_or;
     if (value != null) {
       result
         ..add('_or')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(BuiltList, const [
-              const FullType(GQuestStatusBoolExp),
-            ]),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(
+                BuiltList, const [const FullType(GQuestStatusBoolExp)])));
     }
     value = object.value;
     if (value != null) {
       result
         ..add('value')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GStringComparisonExp),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GStringComparisonExp)));
     }
     return result;
   }
 
   @override
   GQuestStatusBoolExp deserialize(
-    Serializers serializers,
-    Iterable<Object?> serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = new GQuestStatusBoolExpBuilder();
 
     final iterator = serialized.iterator;
@@ -6640,44 +5036,26 @@ class _$GQuestStatusBoolExpSerializer
       final Object? value = iterator.current;
       switch (key) {
         case '_and':
-          result.G_and.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(BuiltList, const [
-                    const FullType(GQuestStatusBoolExp),
-                  ]),
-                )!
-                as BuiltList<Object?>,
-          );
+          result.G_and.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(
+                      BuiltList, const [const FullType(GQuestStatusBoolExp)]))!
+              as BuiltList<Object?>);
           break;
         case '_not':
-          result.G_not.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(GQuestStatusBoolExp),
-                )!
-                as GQuestStatusBoolExp,
-          );
+          result.G_not.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(GQuestStatusBoolExp))!
+              as GQuestStatusBoolExp);
           break;
         case '_or':
-          result.G_or.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(BuiltList, const [
-                    const FullType(GQuestStatusBoolExp),
-                  ]),
-                )!
-                as BuiltList<Object?>,
-          );
+          result.G_or.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(
+                      BuiltList, const [const FullType(GQuestStatusBoolExp)]))!
+              as BuiltList<Object?>);
           break;
         case 'value':
-          result.value.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(GStringComparisonExp),
-                )!
-                as GStringComparisonExp,
-          );
+          result.value.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(GStringComparisonExp))!
+              as GStringComparisonExp);
           break;
       }
     }
@@ -6694,18 +5072,14 @@ class _$GQuestStatusEnumSerializer
   final String wireName = 'GQuestStatusEnum';
 
   @override
-  Object serialize(
-    Serializers serializers,
-    GQuestStatusEnum object, {
-    FullType specifiedType = FullType.unspecified,
-  }) => object.name;
+  Object serialize(Serializers serializers, GQuestStatusEnum object,
+          {FullType specifiedType = FullType.unspecified}) =>
+      object.name;
 
   @override
-  GQuestStatusEnum deserialize(
-    Serializers serializers,
-    Object serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) => GQuestStatusEnum.valueOf(serialized as String);
+  GQuestStatusEnum deserialize(Serializers serializers, Object serialized,
+          {FullType specifiedType = FullType.unspecified}) =>
+      GQuestStatusEnum.valueOf(serialized as String);
 }
 
 class _$GQuestStatusEnumComparisonExpSerializer
@@ -6713,84 +5087,61 @@ class _$GQuestStatusEnumComparisonExpSerializer
   @override
   final Iterable<Type> types = const [
     GQuestStatusEnumComparisonExp,
-    _$GQuestStatusEnumComparisonExp,
+    _$GQuestStatusEnumComparisonExp
   ];
   @override
   final String wireName = 'GQuestStatusEnumComparisonExp';
 
   @override
   Iterable<Object?> serialize(
-    Serializers serializers,
-    GQuestStatusEnumComparisonExp object, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, GQuestStatusEnumComparisonExp object,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[];
     Object? value;
     value = object.G_eq;
     if (value != null) {
       result
         ..add('_eq')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GQuestStatusEnum),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GQuestStatusEnum)));
     }
     value = object.G_in;
     if (value != null) {
       result
         ..add('_in')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(BuiltList, const [
-              const FullType(GQuestStatusEnum),
-            ]),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(
+                BuiltList, const [const FullType(GQuestStatusEnum)])));
     }
     value = object.G_isNull;
     if (value != null) {
       result
         ..add('_isNull')
         ..add(
-          serializers.serialize(value, specifiedType: const FullType(bool)),
-        );
+            serializers.serialize(value, specifiedType: const FullType(bool)));
     }
     value = object.G_neq;
     if (value != null) {
       result
         ..add('_neq')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GQuestStatusEnum),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GQuestStatusEnum)));
     }
     value = object.G_nin;
     if (value != null) {
       result
         ..add('_nin')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(BuiltList, const [
-              const FullType(GQuestStatusEnum),
-            ]),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(
+                BuiltList, const [const FullType(GQuestStatusEnum)])));
     }
     return result;
   }
 
   @override
   GQuestStatusEnumComparisonExp deserialize(
-    Serializers serializers,
-    Iterable<Object?> serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = new GQuestStatusEnumComparisonExpBuilder();
 
     final iterator = serialized.iterator;
@@ -6800,50 +5151,30 @@ class _$GQuestStatusEnumComparisonExpSerializer
       final Object? value = iterator.current;
       switch (key) {
         case '_eq':
-          result.G_eq =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(GQuestStatusEnum),
-                  )
-                  as GQuestStatusEnum?;
+          result.G_eq = serializers.deserialize(value,
+                  specifiedType: const FullType(GQuestStatusEnum))
+              as GQuestStatusEnum?;
           break;
         case '_in':
-          result.G_in.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(BuiltList, const [
-                    const FullType(GQuestStatusEnum),
-                  ]),
-                )!
-                as BuiltList<Object?>,
-          );
+          result.G_in.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(
+                      BuiltList, const [const FullType(GQuestStatusEnum)]))!
+              as BuiltList<Object?>);
           break;
         case '_isNull':
-          result.G_isNull =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(bool),
-                  )
-                  as bool?;
+          result.G_isNull = serializers.deserialize(value,
+              specifiedType: const FullType(bool)) as bool?;
           break;
         case '_neq':
-          result.G_neq =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(GQuestStatusEnum),
-                  )
-                  as GQuestStatusEnum?;
+          result.G_neq = serializers.deserialize(value,
+                  specifiedType: const FullType(GQuestStatusEnum))
+              as GQuestStatusEnum?;
           break;
         case '_nin':
-          result.G_nin.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(BuiltList, const [
-                    const FullType(GQuestStatusEnum),
-                  ]),
-                )!
-                as BuiltList<Object?>,
-          );
+          result.G_nin.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(
+                      BuiltList, const [const FullType(GQuestStatusEnum)]))!
+              as BuiltList<Object?>);
           break;
       }
     }
@@ -6857,36 +5188,31 @@ class _$GQuestStatusOrderBySerializer
   @override
   final Iterable<Type> types = const [
     GQuestStatusOrderBy,
-    _$GQuestStatusOrderBy,
+    _$GQuestStatusOrderBy
   ];
   @override
   final String wireName = 'GQuestStatusOrderBy';
 
   @override
   Iterable<Object?> serialize(
-    Serializers serializers,
-    GQuestStatusOrderBy object, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, GQuestStatusOrderBy object,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[];
     Object? value;
     value = object.value;
     if (value != null) {
       result
         ..add('value')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(GOrderBy)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GOrderBy)));
     }
     return result;
   }
 
   @override
   GQuestStatusOrderBy deserialize(
-    Serializers serializers,
-    Iterable<Object?> serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = new GQuestStatusOrderByBuilder();
 
     final iterator = serialized.iterator;
@@ -6896,12 +5222,8 @@ class _$GQuestStatusOrderBySerializer
       final Object? value = iterator.current;
       switch (key) {
         case 'value':
-          result.value =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(GOrderBy),
-                  )
-                  as GOrderBy?;
+          result.value = serializers.deserialize(value,
+              specifiedType: const FullType(GOrderBy)) as GOrderBy?;
           break;
       }
     }
@@ -6918,18 +5240,15 @@ class _$GQuestStatusSelectColumnSerializer
   final String wireName = 'GQuestStatusSelectColumn';
 
   @override
-  Object serialize(
-    Serializers serializers,
-    GQuestStatusSelectColumn object, {
-    FullType specifiedType = FullType.unspecified,
-  }) => object.name;
+  Object serialize(Serializers serializers, GQuestStatusSelectColumn object,
+          {FullType specifiedType = FullType.unspecified}) =>
+      object.name;
 
   @override
   GQuestStatusSelectColumn deserialize(
-    Serializers serializers,
-    Object serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) => GQuestStatusSelectColumn.valueOf(serialized as String);
+          Serializers serializers, Object serialized,
+          {FullType specifiedType = FullType.unspecified}) =>
+      GQuestStatusSelectColumn.valueOf(serialized as String);
 }
 
 class _$GQuestStatusStreamCursorInputSerializer
@@ -6937,45 +5256,35 @@ class _$GQuestStatusStreamCursorInputSerializer
   @override
   final Iterable<Type> types = const [
     GQuestStatusStreamCursorInput,
-    _$GQuestStatusStreamCursorInput,
+    _$GQuestStatusStreamCursorInput
   ];
   @override
   final String wireName = 'GQuestStatusStreamCursorInput';
 
   @override
   Iterable<Object?> serialize(
-    Serializers serializers,
-    GQuestStatusStreamCursorInput object, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, GQuestStatusStreamCursorInput object,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[
       'initialValue',
-      serializers.serialize(
-        object.initialValue,
-        specifiedType: const FullType(GQuestStatusStreamCursorValueInput),
-      ),
+      serializers.serialize(object.initialValue,
+          specifiedType: const FullType(GQuestStatusStreamCursorValueInput)),
     ];
     Object? value;
     value = object.ordering;
     if (value != null) {
       result
         ..add('ordering')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GCursorOrdering),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GCursorOrdering)));
     }
     return result;
   }
 
   @override
   GQuestStatusStreamCursorInput deserialize(
-    Serializers serializers,
-    Iterable<Object?> serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = new GQuestStatusStreamCursorInputBuilder();
 
     final iterator = serialized.iterator;
@@ -6985,23 +5294,15 @@ class _$GQuestStatusStreamCursorInputSerializer
       final Object? value = iterator.current;
       switch (key) {
         case 'initialValue':
-          result.initialValue.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(
-                    GQuestStatusStreamCursorValueInput,
-                  ),
-                )!
-                as GQuestStatusStreamCursorValueInput,
-          );
+          result.initialValue.replace(serializers.deserialize(value,
+                  specifiedType:
+                      const FullType(GQuestStatusStreamCursorValueInput))!
+              as GQuestStatusStreamCursorValueInput);
           break;
         case 'ordering':
-          result.ordering =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(GCursorOrdering),
-                  )
-                  as GCursorOrdering?;
+          result.ordering = serializers.deserialize(value,
+                  specifiedType: const FullType(GCursorOrdering))
+              as GCursorOrdering?;
           break;
       }
     }
@@ -7015,36 +5316,31 @@ class _$GQuestStatusStreamCursorValueInputSerializer
   @override
   final Iterable<Type> types = const [
     GQuestStatusStreamCursorValueInput,
-    _$GQuestStatusStreamCursorValueInput,
+    _$GQuestStatusStreamCursorValueInput
   ];
   @override
   final String wireName = 'GQuestStatusStreamCursorValueInput';
 
   @override
   Iterable<Object?> serialize(
-    Serializers serializers,
-    GQuestStatusStreamCursorValueInput object, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, GQuestStatusStreamCursorValueInput object,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[];
     Object? value;
     value = object.value;
     if (value != null) {
       result
         ..add('value')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(String)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
     }
     return result;
   }
 
   @override
   GQuestStatusStreamCursorValueInput deserialize(
-    Serializers serializers,
-    Iterable<Object?> serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = new GQuestStatusStreamCursorValueInputBuilder();
 
     final iterator = serialized.iterator;
@@ -7054,12 +5350,8 @@ class _$GQuestStatusStreamCursorValueInputSerializer
       final Object? value = iterator.current;
       switch (key) {
         case 'value':
-          result.value =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )
-                  as String?;
+          result.value = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
           break;
       }
     }
@@ -7075,125 +5367,82 @@ class _$GSeosBoolExpSerializer implements StructuredSerializer<GSeosBoolExp> {
   final String wireName = 'GSeosBoolExp';
 
   @override
-  Iterable<Object?> serialize(
-    Serializers serializers,
-    GSeosBoolExp object, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+  Iterable<Object?> serialize(Serializers serializers, GSeosBoolExp object,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[];
     Object? value;
     value = object.G_and;
     if (value != null) {
       result
         ..add('_and')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(BuiltList, const [
-              const FullType(GSeosBoolExp),
-            ]),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(
+                BuiltList, const [const FullType(GSeosBoolExp)])));
     }
     value = object.G_not;
     if (value != null) {
       result
         ..add('_not')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GSeosBoolExp),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GSeosBoolExp)));
     }
     value = object.G_or;
     if (value != null) {
       result
         ..add('_or')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(BuiltList, const [
-              const FullType(GSeosBoolExp),
-            ]),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(
+                BuiltList, const [const FullType(GSeosBoolExp)])));
     }
     value = object.createdAt;
     if (value != null) {
       result
         ..add('createdAt')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GTimestamptzComparisonExp),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GTimestamptzComparisonExp)));
     }
     value = object.description;
     if (value != null) {
       result
         ..add('description')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GStringComparisonExp),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GStringComparisonExp)));
     }
     value = object.id;
     if (value != null) {
       result
         ..add('id')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GUuidComparisonExp),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GUuidComparisonExp)));
     }
     value = object.ogImageUrl;
     if (value != null) {
       result
         ..add('ogImageUrl')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GStringComparisonExp),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GStringComparisonExp)));
     }
     value = object.title;
     if (value != null) {
       result
         ..add('title')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GStringComparisonExp),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GStringComparisonExp)));
     }
     value = object.updatedAt;
     if (value != null) {
       result
         ..add('updatedAt')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GTimestamptzComparisonExp),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GTimestamptzComparisonExp)));
     }
     return result;
   }
 
   @override
   GSeosBoolExp deserialize(
-    Serializers serializers,
-    Iterable<Object?> serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = new GSeosBoolExpBuilder();
 
     final iterator = serialized.iterator;
@@ -7203,89 +5452,50 @@ class _$GSeosBoolExpSerializer implements StructuredSerializer<GSeosBoolExp> {
       final Object? value = iterator.current;
       switch (key) {
         case '_and':
-          result.G_and.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(BuiltList, const [
-                    const FullType(GSeosBoolExp),
-                  ]),
-                )!
-                as BuiltList<Object?>,
-          );
+          result.G_and.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(
+                      BuiltList, const [const FullType(GSeosBoolExp)]))!
+              as BuiltList<Object?>);
           break;
         case '_not':
-          result.G_not.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(GSeosBoolExp),
-                )!
-                as GSeosBoolExp,
-          );
+          result.G_not.replace(serializers.deserialize(value,
+              specifiedType: const FullType(GSeosBoolExp))! as GSeosBoolExp);
           break;
         case '_or':
-          result.G_or.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(BuiltList, const [
-                    const FullType(GSeosBoolExp),
-                  ]),
-                )!
-                as BuiltList<Object?>,
-          );
+          result.G_or.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(
+                      BuiltList, const [const FullType(GSeosBoolExp)]))!
+              as BuiltList<Object?>);
           break;
         case 'createdAt':
-          result.createdAt.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(GTimestamptzComparisonExp),
-                )!
-                as GTimestamptzComparisonExp,
-          );
+          result.createdAt.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(GTimestamptzComparisonExp))!
+              as GTimestamptzComparisonExp);
           break;
         case 'description':
-          result.description.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(GStringComparisonExp),
-                )!
-                as GStringComparisonExp,
-          );
+          result.description.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(GStringComparisonExp))!
+              as GStringComparisonExp);
           break;
         case 'id':
-          result.id.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(GUuidComparisonExp),
-                )!
-                as GUuidComparisonExp,
-          );
+          result.id.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(GUuidComparisonExp))!
+              as GUuidComparisonExp);
           break;
         case 'ogImageUrl':
-          result.ogImageUrl.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(GStringComparisonExp),
-                )!
-                as GStringComparisonExp,
-          );
+          result.ogImageUrl.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(GStringComparisonExp))!
+              as GStringComparisonExp);
           break;
         case 'title':
-          result.title.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(GStringComparisonExp),
-                )!
-                as GStringComparisonExp,
-          );
+          result.title.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(GStringComparisonExp))!
+              as GStringComparisonExp);
           break;
         case 'updatedAt':
-          result.updatedAt.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(GTimestamptzComparisonExp),
-                )!
-                as GTimestamptzComparisonExp,
-          );
+          result.updatedAt.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(GTimestamptzComparisonExp))!
+              as GTimestamptzComparisonExp);
           break;
       }
     }
@@ -7301,70 +5511,59 @@ class _$GSeosOrderBySerializer implements StructuredSerializer<GSeosOrderBy> {
   final String wireName = 'GSeosOrderBy';
 
   @override
-  Iterable<Object?> serialize(
-    Serializers serializers,
-    GSeosOrderBy object, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+  Iterable<Object?> serialize(Serializers serializers, GSeosOrderBy object,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[];
     Object? value;
     value = object.createdAt;
     if (value != null) {
       result
         ..add('createdAt')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(GOrderBy)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GOrderBy)));
     }
     value = object.description;
     if (value != null) {
       result
         ..add('description')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(GOrderBy)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GOrderBy)));
     }
     value = object.id;
     if (value != null) {
       result
         ..add('id')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(GOrderBy)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GOrderBy)));
     }
     value = object.ogImageUrl;
     if (value != null) {
       result
         ..add('ogImageUrl')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(GOrderBy)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GOrderBy)));
     }
     value = object.title;
     if (value != null) {
       result
         ..add('title')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(GOrderBy)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GOrderBy)));
     }
     value = object.updatedAt;
     if (value != null) {
       result
         ..add('updatedAt')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(GOrderBy)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GOrderBy)));
     }
     return result;
   }
 
   @override
   GSeosOrderBy deserialize(
-    Serializers serializers,
-    Iterable<Object?> serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = new GSeosOrderByBuilder();
 
     final iterator = serialized.iterator;
@@ -7374,52 +5573,28 @@ class _$GSeosOrderBySerializer implements StructuredSerializer<GSeosOrderBy> {
       final Object? value = iterator.current;
       switch (key) {
         case 'createdAt':
-          result.createdAt =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(GOrderBy),
-                  )
-                  as GOrderBy?;
+          result.createdAt = serializers.deserialize(value,
+              specifiedType: const FullType(GOrderBy)) as GOrderBy?;
           break;
         case 'description':
-          result.description =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(GOrderBy),
-                  )
-                  as GOrderBy?;
+          result.description = serializers.deserialize(value,
+              specifiedType: const FullType(GOrderBy)) as GOrderBy?;
           break;
         case 'id':
-          result.id =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(GOrderBy),
-                  )
-                  as GOrderBy?;
+          result.id = serializers.deserialize(value,
+              specifiedType: const FullType(GOrderBy)) as GOrderBy?;
           break;
         case 'ogImageUrl':
-          result.ogImageUrl =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(GOrderBy),
-                  )
-                  as GOrderBy?;
+          result.ogImageUrl = serializers.deserialize(value,
+              specifiedType: const FullType(GOrderBy)) as GOrderBy?;
           break;
         case 'title':
-          result.title =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(GOrderBy),
-                  )
-                  as GOrderBy?;
+          result.title = serializers.deserialize(value,
+              specifiedType: const FullType(GOrderBy)) as GOrderBy?;
           break;
         case 'updatedAt':
-          result.updatedAt =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(GOrderBy),
-                  )
-                  as GOrderBy?;
+          result.updatedAt = serializers.deserialize(value,
+              specifiedType: const FullType(GOrderBy)) as GOrderBy?;
           break;
       }
     }
@@ -7436,18 +5611,14 @@ class _$GSeosSelectColumnSerializer
   final String wireName = 'GSeosSelectColumn';
 
   @override
-  Object serialize(
-    Serializers serializers,
-    GSeosSelectColumn object, {
-    FullType specifiedType = FullType.unspecified,
-  }) => object.name;
+  Object serialize(Serializers serializers, GSeosSelectColumn object,
+          {FullType specifiedType = FullType.unspecified}) =>
+      object.name;
 
   @override
-  GSeosSelectColumn deserialize(
-    Serializers serializers,
-    Object serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) => GSeosSelectColumn.valueOf(serialized as String);
+  GSeosSelectColumn deserialize(Serializers serializers, Object serialized,
+          {FullType specifiedType = FullType.unspecified}) =>
+      GSeosSelectColumn.valueOf(serialized as String);
 }
 
 class _$GSeosStreamCursorInputSerializer
@@ -7455,45 +5626,35 @@ class _$GSeosStreamCursorInputSerializer
   @override
   final Iterable<Type> types = const [
     GSeosStreamCursorInput,
-    _$GSeosStreamCursorInput,
+    _$GSeosStreamCursorInput
   ];
   @override
   final String wireName = 'GSeosStreamCursorInput';
 
   @override
   Iterable<Object?> serialize(
-    Serializers serializers,
-    GSeosStreamCursorInput object, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, GSeosStreamCursorInput object,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[
       'initialValue',
-      serializers.serialize(
-        object.initialValue,
-        specifiedType: const FullType(GSeosStreamCursorValueInput),
-      ),
+      serializers.serialize(object.initialValue,
+          specifiedType: const FullType(GSeosStreamCursorValueInput)),
     ];
     Object? value;
     value = object.ordering;
     if (value != null) {
       result
         ..add('ordering')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GCursorOrdering),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GCursorOrdering)));
     }
     return result;
   }
 
   @override
   GSeosStreamCursorInput deserialize(
-    Serializers serializers,
-    Iterable<Object?> serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = new GSeosStreamCursorInputBuilder();
 
     final iterator = serialized.iterator;
@@ -7503,21 +5664,14 @@ class _$GSeosStreamCursorInputSerializer
       final Object? value = iterator.current;
       switch (key) {
         case 'initialValue':
-          result.initialValue.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(GSeosStreamCursorValueInput),
-                )!
-                as GSeosStreamCursorValueInput,
-          );
+          result.initialValue.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(GSeosStreamCursorValueInput))!
+              as GSeosStreamCursorValueInput);
           break;
         case 'ordering':
-          result.ordering =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(GCursorOrdering),
-                  )
-                  as GCursorOrdering?;
+          result.ordering = serializers.deserialize(value,
+                  specifiedType: const FullType(GCursorOrdering))
+              as GCursorOrdering?;
           break;
       }
     }
@@ -7531,76 +5685,66 @@ class _$GSeosStreamCursorValueInputSerializer
   @override
   final Iterable<Type> types = const [
     GSeosStreamCursorValueInput,
-    _$GSeosStreamCursorValueInput,
+    _$GSeosStreamCursorValueInput
   ];
   @override
   final String wireName = 'GSeosStreamCursorValueInput';
 
   @override
   Iterable<Object?> serialize(
-    Serializers serializers,
-    GSeosStreamCursorValueInput object, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, GSeosStreamCursorValueInput object,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[];
     Object? value;
     value = object.createdAt;
     if (value != null) {
       result
         ..add('createdAt')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(DateTime)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(DateTime)));
     }
     value = object.description;
     if (value != null) {
       result
         ..add('description')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(String)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
     }
     value = object.id;
     if (value != null) {
       result
         ..add('id')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(String)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
     }
     value = object.ogImageUrl;
     if (value != null) {
       result
         ..add('ogImageUrl')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(String)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
     }
     value = object.title;
     if (value != null) {
       result
         ..add('title')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(String)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
     }
     value = object.updatedAt;
     if (value != null) {
       result
         ..add('updatedAt')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(DateTime)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(DateTime)));
     }
     return result;
   }
 
   @override
   GSeosStreamCursorValueInput deserialize(
-    Serializers serializers,
-    Iterable<Object?> serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = new GSeosStreamCursorValueInputBuilder();
 
     final iterator = serialized.iterator;
@@ -7610,52 +5754,28 @@ class _$GSeosStreamCursorValueInputSerializer
       final Object? value = iterator.current;
       switch (key) {
         case 'createdAt':
-          result.createdAt =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(DateTime),
-                  )
-                  as DateTime?;
+          result.createdAt = serializers.deserialize(value,
+              specifiedType: const FullType(DateTime)) as DateTime?;
           break;
         case 'description':
-          result.description =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )
-                  as String?;
+          result.description = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
           break;
         case 'id':
-          result.id =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )
-                  as String?;
+          result.id = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
           break;
         case 'ogImageUrl':
-          result.ogImageUrl =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )
-                  as String?;
+          result.ogImageUrl = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
           break;
         case 'title':
-          result.title =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )
-                  as String?;
+          result.title = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
           break;
         case 'updatedAt':
-          result.updatedAt =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(DateTime),
-                  )
-                  as DateTime?;
+          result.updatedAt = serializers.deserialize(value,
+              specifiedType: const FullType(DateTime)) as DateTime?;
           break;
       }
     }
@@ -7669,190 +5789,159 @@ class _$GStringComparisonExpSerializer
   @override
   final Iterable<Type> types = const [
     GStringComparisonExp,
-    _$GStringComparisonExp,
+    _$GStringComparisonExp
   ];
   @override
   final String wireName = 'GStringComparisonExp';
 
   @override
   Iterable<Object?> serialize(
-    Serializers serializers,
-    GStringComparisonExp object, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, GStringComparisonExp object,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[];
     Object? value;
     value = object.G_eq;
     if (value != null) {
       result
         ..add('_eq')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(String)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
     }
     value = object.G_gt;
     if (value != null) {
       result
         ..add('_gt')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(String)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
     }
     value = object.G_gte;
     if (value != null) {
       result
         ..add('_gte')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(String)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
     }
     value = object.G_ilike;
     if (value != null) {
       result
         ..add('_ilike')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(String)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
     }
     value = object.G_in;
     if (value != null) {
       result
         ..add('_in')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(BuiltList, const [
-              const FullType(String),
-            ]),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType:
+                const FullType(BuiltList, const [const FullType(String)])));
     }
     value = object.G_iregex;
     if (value != null) {
       result
         ..add('_iregex')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(String)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
     }
     value = object.G_isNull;
     if (value != null) {
       result
         ..add('_isNull')
         ..add(
-          serializers.serialize(value, specifiedType: const FullType(bool)),
-        );
+            serializers.serialize(value, specifiedType: const FullType(bool)));
     }
     value = object.G_like;
     if (value != null) {
       result
         ..add('_like')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(String)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
     }
     value = object.G_lt;
     if (value != null) {
       result
         ..add('_lt')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(String)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
     }
     value = object.G_lte;
     if (value != null) {
       result
         ..add('_lte')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(String)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
     }
     value = object.G_neq;
     if (value != null) {
       result
         ..add('_neq')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(String)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
     }
     value = object.G_nilike;
     if (value != null) {
       result
         ..add('_nilike')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(String)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
     }
     value = object.G_nin;
     if (value != null) {
       result
         ..add('_nin')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(BuiltList, const [
-              const FullType(String),
-            ]),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType:
+                const FullType(BuiltList, const [const FullType(String)])));
     }
     value = object.G_niregex;
     if (value != null) {
       result
         ..add('_niregex')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(String)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
     }
     value = object.G_nlike;
     if (value != null) {
       result
         ..add('_nlike')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(String)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
     }
     value = object.G_nregex;
     if (value != null) {
       result
         ..add('_nregex')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(String)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
     }
     value = object.G_nsimilar;
     if (value != null) {
       result
         ..add('_nsimilar')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(String)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
     }
     value = object.G_regex;
     if (value != null) {
       result
         ..add('_regex')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(String)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
     }
     value = object.G_similar;
     if (value != null) {
       result
         ..add('_similar')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(String)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
     }
     return result;
   }
 
   @override
   GStringComparisonExp deserialize(
-    Serializers serializers,
-    Iterable<Object?> serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = new GStringComparisonExpBuilder();
 
     final iterator = serialized.iterator;
@@ -7862,162 +5951,84 @@ class _$GStringComparisonExpSerializer
       final Object? value = iterator.current;
       switch (key) {
         case '_eq':
-          result.G_eq =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )
-                  as String?;
+          result.G_eq = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
           break;
         case '_gt':
-          result.G_gt =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )
-                  as String?;
+          result.G_gt = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
           break;
         case '_gte':
-          result.G_gte =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )
-                  as String?;
+          result.G_gte = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
           break;
         case '_ilike':
-          result.G_ilike =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )
-                  as String?;
+          result.G_ilike = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
           break;
         case '_in':
-          result.G_in.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(BuiltList, const [
-                    const FullType(String),
-                  ]),
-                )!
-                as BuiltList<Object?>,
-          );
+          result.G_in.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(
+                      BuiltList, const [const FullType(String)]))!
+              as BuiltList<Object?>);
           break;
         case '_iregex':
-          result.G_iregex =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )
-                  as String?;
+          result.G_iregex = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
           break;
         case '_isNull':
-          result.G_isNull =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(bool),
-                  )
-                  as bool?;
+          result.G_isNull = serializers.deserialize(value,
+              specifiedType: const FullType(bool)) as bool?;
           break;
         case '_like':
-          result.G_like =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )
-                  as String?;
+          result.G_like = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
           break;
         case '_lt':
-          result.G_lt =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )
-                  as String?;
+          result.G_lt = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
           break;
         case '_lte':
-          result.G_lte =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )
-                  as String?;
+          result.G_lte = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
           break;
         case '_neq':
-          result.G_neq =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )
-                  as String?;
+          result.G_neq = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
           break;
         case '_nilike':
-          result.G_nilike =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )
-                  as String?;
+          result.G_nilike = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
           break;
         case '_nin':
-          result.G_nin.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(BuiltList, const [
-                    const FullType(String),
-                  ]),
-                )!
-                as BuiltList<Object?>,
-          );
+          result.G_nin.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(
+                      BuiltList, const [const FullType(String)]))!
+              as BuiltList<Object?>);
           break;
         case '_niregex':
-          result.G_niregex =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )
-                  as String?;
+          result.G_niregex = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
           break;
         case '_nlike':
-          result.G_nlike =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )
-                  as String?;
+          result.G_nlike = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
           break;
         case '_nregex':
-          result.G_nregex =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )
-                  as String?;
+          result.G_nregex = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
           break;
         case '_nsimilar':
-          result.G_nsimilar =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )
-                  as String?;
+          result.G_nsimilar = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
           break;
         case '_regex':
-          result.G_regex =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )
-                  as String?;
+          result.G_regex = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
           break;
         case '_similar':
-          result.G_similar =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )
-                  as String?;
+          result.G_similar = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
           break;
       }
     }
@@ -8033,114 +6044,75 @@ class _$GTagsBoolExpSerializer implements StructuredSerializer<GTagsBoolExp> {
   final String wireName = 'GTagsBoolExp';
 
   @override
-  Iterable<Object?> serialize(
-    Serializers serializers,
-    GTagsBoolExp object, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+  Iterable<Object?> serialize(Serializers serializers, GTagsBoolExp object,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[];
     Object? value;
     value = object.G_and;
     if (value != null) {
       result
         ..add('_and')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(BuiltList, const [
-              const FullType(GTagsBoolExp),
-            ]),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(
+                BuiltList, const [const FullType(GTagsBoolExp)])));
     }
     value = object.G_not;
     if (value != null) {
       result
         ..add('_not')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GTagsBoolExp),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GTagsBoolExp)));
     }
     value = object.G_or;
     if (value != null) {
       result
         ..add('_or')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(BuiltList, const [
-              const FullType(GTagsBoolExp),
-            ]),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(
+                BuiltList, const [const FullType(GTagsBoolExp)])));
     }
     value = object.createdAt;
     if (value != null) {
       result
         ..add('createdAt')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GTimestamptzComparisonExp),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GTimestamptzComparisonExp)));
     }
     value = object.description;
     if (value != null) {
       result
         ..add('description')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GStringComparisonExp),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GStringComparisonExp)));
     }
     value = object.id;
     if (value != null) {
       result
         ..add('id')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GUuidComparisonExp),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GUuidComparisonExp)));
     }
     value = object.tag;
     if (value != null) {
       result
         ..add('tag')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GStringComparisonExp),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GStringComparisonExp)));
     }
     value = object.updatedAt;
     if (value != null) {
       result
         ..add('updatedAt')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GTimestamptzComparisonExp),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GTimestamptzComparisonExp)));
     }
     return result;
   }
 
   @override
   GTagsBoolExp deserialize(
-    Serializers serializers,
-    Iterable<Object?> serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = new GTagsBoolExpBuilder();
 
     final iterator = serialized.iterator;
@@ -8150,80 +6122,45 @@ class _$GTagsBoolExpSerializer implements StructuredSerializer<GTagsBoolExp> {
       final Object? value = iterator.current;
       switch (key) {
         case '_and':
-          result.G_and.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(BuiltList, const [
-                    const FullType(GTagsBoolExp),
-                  ]),
-                )!
-                as BuiltList<Object?>,
-          );
+          result.G_and.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(
+                      BuiltList, const [const FullType(GTagsBoolExp)]))!
+              as BuiltList<Object?>);
           break;
         case '_not':
-          result.G_not.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(GTagsBoolExp),
-                )!
-                as GTagsBoolExp,
-          );
+          result.G_not.replace(serializers.deserialize(value,
+              specifiedType: const FullType(GTagsBoolExp))! as GTagsBoolExp);
           break;
         case '_or':
-          result.G_or.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(BuiltList, const [
-                    const FullType(GTagsBoolExp),
-                  ]),
-                )!
-                as BuiltList<Object?>,
-          );
+          result.G_or.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(
+                      BuiltList, const [const FullType(GTagsBoolExp)]))!
+              as BuiltList<Object?>);
           break;
         case 'createdAt':
-          result.createdAt.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(GTimestamptzComparisonExp),
-                )!
-                as GTimestamptzComparisonExp,
-          );
+          result.createdAt.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(GTimestamptzComparisonExp))!
+              as GTimestamptzComparisonExp);
           break;
         case 'description':
-          result.description.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(GStringComparisonExp),
-                )!
-                as GStringComparisonExp,
-          );
+          result.description.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(GStringComparisonExp))!
+              as GStringComparisonExp);
           break;
         case 'id':
-          result.id.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(GUuidComparisonExp),
-                )!
-                as GUuidComparisonExp,
-          );
+          result.id.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(GUuidComparisonExp))!
+              as GUuidComparisonExp);
           break;
         case 'tag':
-          result.tag.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(GStringComparisonExp),
-                )!
-                as GStringComparisonExp,
-          );
+          result.tag.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(GStringComparisonExp))!
+              as GStringComparisonExp);
           break;
         case 'updatedAt':
-          result.updatedAt.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(GTimestamptzComparisonExp),
-                )!
-                as GTimestamptzComparisonExp,
-          );
+          result.updatedAt.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(GTimestamptzComparisonExp))!
+              as GTimestamptzComparisonExp);
           break;
       }
     }
@@ -8239,62 +6176,52 @@ class _$GTagsOrderBySerializer implements StructuredSerializer<GTagsOrderBy> {
   final String wireName = 'GTagsOrderBy';
 
   @override
-  Iterable<Object?> serialize(
-    Serializers serializers,
-    GTagsOrderBy object, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+  Iterable<Object?> serialize(Serializers serializers, GTagsOrderBy object,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[];
     Object? value;
     value = object.createdAt;
     if (value != null) {
       result
         ..add('createdAt')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(GOrderBy)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GOrderBy)));
     }
     value = object.description;
     if (value != null) {
       result
         ..add('description')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(GOrderBy)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GOrderBy)));
     }
     value = object.id;
     if (value != null) {
       result
         ..add('id')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(GOrderBy)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GOrderBy)));
     }
     value = object.tag;
     if (value != null) {
       result
         ..add('tag')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(GOrderBy)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GOrderBy)));
     }
     value = object.updatedAt;
     if (value != null) {
       result
         ..add('updatedAt')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(GOrderBy)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GOrderBy)));
     }
     return result;
   }
 
   @override
   GTagsOrderBy deserialize(
-    Serializers serializers,
-    Iterable<Object?> serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = new GTagsOrderByBuilder();
 
     final iterator = serialized.iterator;
@@ -8304,44 +6231,24 @@ class _$GTagsOrderBySerializer implements StructuredSerializer<GTagsOrderBy> {
       final Object? value = iterator.current;
       switch (key) {
         case 'createdAt':
-          result.createdAt =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(GOrderBy),
-                  )
-                  as GOrderBy?;
+          result.createdAt = serializers.deserialize(value,
+              specifiedType: const FullType(GOrderBy)) as GOrderBy?;
           break;
         case 'description':
-          result.description =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(GOrderBy),
-                  )
-                  as GOrderBy?;
+          result.description = serializers.deserialize(value,
+              specifiedType: const FullType(GOrderBy)) as GOrderBy?;
           break;
         case 'id':
-          result.id =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(GOrderBy),
-                  )
-                  as GOrderBy?;
+          result.id = serializers.deserialize(value,
+              specifiedType: const FullType(GOrderBy)) as GOrderBy?;
           break;
         case 'tag':
-          result.tag =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(GOrderBy),
-                  )
-                  as GOrderBy?;
+          result.tag = serializers.deserialize(value,
+              specifiedType: const FullType(GOrderBy)) as GOrderBy?;
           break;
         case 'updatedAt':
-          result.updatedAt =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(GOrderBy),
-                  )
-                  as GOrderBy?;
+          result.updatedAt = serializers.deserialize(value,
+              specifiedType: const FullType(GOrderBy)) as GOrderBy?;
           break;
       }
     }
@@ -8358,18 +6265,14 @@ class _$GTagsSelectColumnSerializer
   final String wireName = 'GTagsSelectColumn';
 
   @override
-  Object serialize(
-    Serializers serializers,
-    GTagsSelectColumn object, {
-    FullType specifiedType = FullType.unspecified,
-  }) => object.name;
+  Object serialize(Serializers serializers, GTagsSelectColumn object,
+          {FullType specifiedType = FullType.unspecified}) =>
+      object.name;
 
   @override
-  GTagsSelectColumn deserialize(
-    Serializers serializers,
-    Object serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) => GTagsSelectColumn.valueOf(serialized as String);
+  GTagsSelectColumn deserialize(Serializers serializers, Object serialized,
+          {FullType specifiedType = FullType.unspecified}) =>
+      GTagsSelectColumn.valueOf(serialized as String);
 }
 
 class _$GTagsStreamCursorInputSerializer
@@ -8377,45 +6280,35 @@ class _$GTagsStreamCursorInputSerializer
   @override
   final Iterable<Type> types = const [
     GTagsStreamCursorInput,
-    _$GTagsStreamCursorInput,
+    _$GTagsStreamCursorInput
   ];
   @override
   final String wireName = 'GTagsStreamCursorInput';
 
   @override
   Iterable<Object?> serialize(
-    Serializers serializers,
-    GTagsStreamCursorInput object, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, GTagsStreamCursorInput object,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[
       'initialValue',
-      serializers.serialize(
-        object.initialValue,
-        specifiedType: const FullType(GTagsStreamCursorValueInput),
-      ),
+      serializers.serialize(object.initialValue,
+          specifiedType: const FullType(GTagsStreamCursorValueInput)),
     ];
     Object? value;
     value = object.ordering;
     if (value != null) {
       result
         ..add('ordering')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GCursorOrdering),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GCursorOrdering)));
     }
     return result;
   }
 
   @override
   GTagsStreamCursorInput deserialize(
-    Serializers serializers,
-    Iterable<Object?> serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = new GTagsStreamCursorInputBuilder();
 
     final iterator = serialized.iterator;
@@ -8425,21 +6318,14 @@ class _$GTagsStreamCursorInputSerializer
       final Object? value = iterator.current;
       switch (key) {
         case 'initialValue':
-          result.initialValue.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(GTagsStreamCursorValueInput),
-                )!
-                as GTagsStreamCursorValueInput,
-          );
+          result.initialValue.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(GTagsStreamCursorValueInput))!
+              as GTagsStreamCursorValueInput);
           break;
         case 'ordering':
-          result.ordering =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(GCursorOrdering),
-                  )
-                  as GCursorOrdering?;
+          result.ordering = serializers.deserialize(value,
+                  specifiedType: const FullType(GCursorOrdering))
+              as GCursorOrdering?;
           break;
       }
     }
@@ -8453,68 +6339,59 @@ class _$GTagsStreamCursorValueInputSerializer
   @override
   final Iterable<Type> types = const [
     GTagsStreamCursorValueInput,
-    _$GTagsStreamCursorValueInput,
+    _$GTagsStreamCursorValueInput
   ];
   @override
   final String wireName = 'GTagsStreamCursorValueInput';
 
   @override
   Iterable<Object?> serialize(
-    Serializers serializers,
-    GTagsStreamCursorValueInput object, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, GTagsStreamCursorValueInput object,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[];
     Object? value;
     value = object.createdAt;
     if (value != null) {
       result
         ..add('createdAt')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(DateTime)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(DateTime)));
     }
     value = object.description;
     if (value != null) {
       result
         ..add('description')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(String)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
     }
     value = object.id;
     if (value != null) {
       result
         ..add('id')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(String)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
     }
     value = object.tag;
     if (value != null) {
       result
         ..add('tag')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(String)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
     }
     value = object.updatedAt;
     if (value != null) {
       result
         ..add('updatedAt')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(DateTime)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(DateTime)));
     }
     return result;
   }
 
   @override
   GTagsStreamCursorValueInput deserialize(
-    Serializers serializers,
-    Iterable<Object?> serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = new GTagsStreamCursorValueInputBuilder();
 
     final iterator = serialized.iterator;
@@ -8524,44 +6401,24 @@ class _$GTagsStreamCursorValueInputSerializer
       final Object? value = iterator.current;
       switch (key) {
         case 'createdAt':
-          result.createdAt =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(DateTime),
-                  )
-                  as DateTime?;
+          result.createdAt = serializers.deserialize(value,
+              specifiedType: const FullType(DateTime)) as DateTime?;
           break;
         case 'description':
-          result.description =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )
-                  as String?;
+          result.description = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
           break;
         case 'id':
-          result.id =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )
-                  as String?;
+          result.id = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
           break;
         case 'tag':
-          result.tag =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )
-                  as String?;
+          result.tag = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
           break;
         case 'updatedAt':
-          result.updatedAt =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(DateTime),
-                  )
-                  as DateTime?;
+          result.updatedAt = serializers.deserialize(value,
+              specifiedType: const FullType(DateTime)) as DateTime?;
           break;
       }
     }
@@ -8575,110 +6432,89 @@ class _$GTimestamptzComparisonExpSerializer
   @override
   final Iterable<Type> types = const [
     GTimestamptzComparisonExp,
-    _$GTimestamptzComparisonExp,
+    _$GTimestamptzComparisonExp
   ];
   @override
   final String wireName = 'GTimestamptzComparisonExp';
 
   @override
   Iterable<Object?> serialize(
-    Serializers serializers,
-    GTimestamptzComparisonExp object, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, GTimestamptzComparisonExp object,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[];
     Object? value;
     value = object.G_eq;
     if (value != null) {
       result
         ..add('_eq')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(DateTime)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(DateTime)));
     }
     value = object.G_gt;
     if (value != null) {
       result
         ..add('_gt')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(DateTime)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(DateTime)));
     }
     value = object.G_gte;
     if (value != null) {
       result
         ..add('_gte')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(DateTime)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(DateTime)));
     }
     value = object.G_in;
     if (value != null) {
       result
         ..add('_in')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(BuiltList, const [
-              const FullType(DateTime),
-            ]),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType:
+                const FullType(BuiltList, const [const FullType(DateTime)])));
     }
     value = object.G_isNull;
     if (value != null) {
       result
         ..add('_isNull')
         ..add(
-          serializers.serialize(value, specifiedType: const FullType(bool)),
-        );
+            serializers.serialize(value, specifiedType: const FullType(bool)));
     }
     value = object.G_lt;
     if (value != null) {
       result
         ..add('_lt')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(DateTime)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(DateTime)));
     }
     value = object.G_lte;
     if (value != null) {
       result
         ..add('_lte')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(DateTime)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(DateTime)));
     }
     value = object.G_neq;
     if (value != null) {
       result
         ..add('_neq')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(DateTime)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(DateTime)));
     }
     value = object.G_nin;
     if (value != null) {
       result
         ..add('_nin')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(BuiltList, const [
-              const FullType(DateTime),
-            ]),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType:
+                const FullType(BuiltList, const [const FullType(DateTime)])));
     }
     return result;
   }
 
   @override
   GTimestamptzComparisonExp deserialize(
-    Serializers serializers,
-    Iterable<Object?> serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = new GTimestamptzComparisonExpBuilder();
 
     final iterator = serialized.iterator;
@@ -8688,82 +6524,44 @@ class _$GTimestamptzComparisonExpSerializer
       final Object? value = iterator.current;
       switch (key) {
         case '_eq':
-          result.G_eq =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(DateTime),
-                  )
-                  as DateTime?;
+          result.G_eq = serializers.deserialize(value,
+              specifiedType: const FullType(DateTime)) as DateTime?;
           break;
         case '_gt':
-          result.G_gt =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(DateTime),
-                  )
-                  as DateTime?;
+          result.G_gt = serializers.deserialize(value,
+              specifiedType: const FullType(DateTime)) as DateTime?;
           break;
         case '_gte':
-          result.G_gte =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(DateTime),
-                  )
-                  as DateTime?;
+          result.G_gte = serializers.deserialize(value,
+              specifiedType: const FullType(DateTime)) as DateTime?;
           break;
         case '_in':
-          result.G_in.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(BuiltList, const [
-                    const FullType(DateTime),
-                  ]),
-                )!
-                as BuiltList<Object?>,
-          );
+          result.G_in.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(
+                      BuiltList, const [const FullType(DateTime)]))!
+              as BuiltList<Object?>);
           break;
         case '_isNull':
-          result.G_isNull =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(bool),
-                  )
-                  as bool?;
+          result.G_isNull = serializers.deserialize(value,
+              specifiedType: const FullType(bool)) as bool?;
           break;
         case '_lt':
-          result.G_lt =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(DateTime),
-                  )
-                  as DateTime?;
+          result.G_lt = serializers.deserialize(value,
+              specifiedType: const FullType(DateTime)) as DateTime?;
           break;
         case '_lte':
-          result.G_lte =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(DateTime),
-                  )
-                  as DateTime?;
+          result.G_lte = serializers.deserialize(value,
+              specifiedType: const FullType(DateTime)) as DateTime?;
           break;
         case '_neq':
-          result.G_neq =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(DateTime),
-                  )
-                  as DateTime?;
+          result.G_neq = serializers.deserialize(value,
+              specifiedType: const FullType(DateTime)) as DateTime?;
           break;
         case '_nin':
-          result.G_nin.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(BuiltList, const [
-                    const FullType(DateTime),
-                  ]),
-                )!
-                as BuiltList<Object?>,
-          );
+          result.G_nin.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(
+                      BuiltList, const [const FullType(DateTime)]))!
+              as BuiltList<Object?>);
           break;
       }
     }
@@ -8777,87 +6575,61 @@ class _$GUserAchievementsBoolExpSerializer
   @override
   final Iterable<Type> types = const [
     GUserAchievementsBoolExp,
-    _$GUserAchievementsBoolExp,
+    _$GUserAchievementsBoolExp
   ];
   @override
   final String wireName = 'GUserAchievementsBoolExp';
 
   @override
   Iterable<Object?> serialize(
-    Serializers serializers,
-    GUserAchievementsBoolExp object, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, GUserAchievementsBoolExp object,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[];
     Object? value;
     value = object.G_and;
     if (value != null) {
       result
         ..add('_and')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(BuiltList, const [
-              const FullType(GUserAchievementsBoolExp),
-            ]),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(
+                BuiltList, const [const FullType(GUserAchievementsBoolExp)])));
     }
     value = object.G_not;
     if (value != null) {
       result
         ..add('_not')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GUserAchievementsBoolExp),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GUserAchievementsBoolExp)));
     }
     value = object.G_or;
     if (value != null) {
       result
         ..add('_or')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(BuiltList, const [
-              const FullType(GUserAchievementsBoolExp),
-            ]),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(
+                BuiltList, const [const FullType(GUserAchievementsBoolExp)])));
     }
     value = object.achievementId;
     if (value != null) {
       result
         ..add('achievementId')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GUuidComparisonExp),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GUuidComparisonExp)));
     }
     value = object.userId;
     if (value != null) {
       result
         ..add('userId')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GStringComparisonExp),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GStringComparisonExp)));
     }
     return result;
   }
 
   @override
   GUserAchievementsBoolExp deserialize(
-    Serializers serializers,
-    Iterable<Object?> serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = new GUserAchievementsBoolExpBuilder();
 
     final iterator = serialized.iterator;
@@ -8867,53 +6639,31 @@ class _$GUserAchievementsBoolExpSerializer
       final Object? value = iterator.current;
       switch (key) {
         case '_and':
-          result.G_and.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(BuiltList, const [
-                    const FullType(GUserAchievementsBoolExp),
-                  ]),
-                )!
-                as BuiltList<Object?>,
-          );
+          result.G_and.replace(serializers.deserialize(value,
+              specifiedType: const FullType(BuiltList, const [
+                const FullType(GUserAchievementsBoolExp)
+              ]))! as BuiltList<Object?>);
           break;
         case '_not':
-          result.G_not.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(GUserAchievementsBoolExp),
-                )!
-                as GUserAchievementsBoolExp,
-          );
+          result.G_not.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(GUserAchievementsBoolExp))!
+              as GUserAchievementsBoolExp);
           break;
         case '_or':
-          result.G_or.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(BuiltList, const [
-                    const FullType(GUserAchievementsBoolExp),
-                  ]),
-                )!
-                as BuiltList<Object?>,
-          );
+          result.G_or.replace(serializers.deserialize(value,
+              specifiedType: const FullType(BuiltList, const [
+                const FullType(GUserAchievementsBoolExp)
+              ]))! as BuiltList<Object?>);
           break;
         case 'achievementId':
-          result.achievementId.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(GUuidComparisonExp),
-                )!
-                as GUuidComparisonExp,
-          );
+          result.achievementId.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(GUuidComparisonExp))!
+              as GUuidComparisonExp);
           break;
         case 'userId':
-          result.userId.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(GStringComparisonExp),
-                )!
-                as GStringComparisonExp,
-          );
+          result.userId.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(GStringComparisonExp))!
+              as GStringComparisonExp);
           break;
       }
     }
@@ -8927,44 +6677,38 @@ class _$GUserAchievementsOrderBySerializer
   @override
   final Iterable<Type> types = const [
     GUserAchievementsOrderBy,
-    _$GUserAchievementsOrderBy,
+    _$GUserAchievementsOrderBy
   ];
   @override
   final String wireName = 'GUserAchievementsOrderBy';
 
   @override
   Iterable<Object?> serialize(
-    Serializers serializers,
-    GUserAchievementsOrderBy object, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, GUserAchievementsOrderBy object,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[];
     Object? value;
     value = object.achievementId;
     if (value != null) {
       result
         ..add('achievementId')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(GOrderBy)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GOrderBy)));
     }
     value = object.userId;
     if (value != null) {
       result
         ..add('userId')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(GOrderBy)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GOrderBy)));
     }
     return result;
   }
 
   @override
   GUserAchievementsOrderBy deserialize(
-    Serializers serializers,
-    Iterable<Object?> serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = new GUserAchievementsOrderByBuilder();
 
     final iterator = serialized.iterator;
@@ -8974,20 +6718,12 @@ class _$GUserAchievementsOrderBySerializer
       final Object? value = iterator.current;
       switch (key) {
         case 'achievementId':
-          result.achievementId =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(GOrderBy),
-                  )
-                  as GOrderBy?;
+          result.achievementId = serializers.deserialize(value,
+              specifiedType: const FullType(GOrderBy)) as GOrderBy?;
           break;
         case 'userId':
-          result.userId =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(GOrderBy),
-                  )
-                  as GOrderBy?;
+          result.userId = serializers.deserialize(value,
+              specifiedType: const FullType(GOrderBy)) as GOrderBy?;
           break;
       }
     }
@@ -9005,17 +6741,15 @@ class _$GUserAchievementsSelectColumnSerializer
 
   @override
   Object serialize(
-    Serializers serializers,
-    GUserAchievementsSelectColumn object, {
-    FullType specifiedType = FullType.unspecified,
-  }) => object.name;
+          Serializers serializers, GUserAchievementsSelectColumn object,
+          {FullType specifiedType = FullType.unspecified}) =>
+      object.name;
 
   @override
   GUserAchievementsSelectColumn deserialize(
-    Serializers serializers,
-    Object serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) => GUserAchievementsSelectColumn.valueOf(serialized as String);
+          Serializers serializers, Object serialized,
+          {FullType specifiedType = FullType.unspecified}) =>
+      GUserAchievementsSelectColumn.valueOf(serialized as String);
 }
 
 class _$GUserAchievementsStreamCursorInputSerializer
@@ -9023,45 +6757,36 @@ class _$GUserAchievementsStreamCursorInputSerializer
   @override
   final Iterable<Type> types = const [
     GUserAchievementsStreamCursorInput,
-    _$GUserAchievementsStreamCursorInput,
+    _$GUserAchievementsStreamCursorInput
   ];
   @override
   final String wireName = 'GUserAchievementsStreamCursorInput';
 
   @override
   Iterable<Object?> serialize(
-    Serializers serializers,
-    GUserAchievementsStreamCursorInput object, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, GUserAchievementsStreamCursorInput object,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[
       'initialValue',
-      serializers.serialize(
-        object.initialValue,
-        specifiedType: const FullType(GUserAchievementsStreamCursorValueInput),
-      ),
+      serializers.serialize(object.initialValue,
+          specifiedType:
+              const FullType(GUserAchievementsStreamCursorValueInput)),
     ];
     Object? value;
     value = object.ordering;
     if (value != null) {
       result
         ..add('ordering')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GCursorOrdering),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GCursorOrdering)));
     }
     return result;
   }
 
   @override
   GUserAchievementsStreamCursorInput deserialize(
-    Serializers serializers,
-    Iterable<Object?> serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = new GUserAchievementsStreamCursorInputBuilder();
 
     final iterator = serialized.iterator;
@@ -9071,23 +6796,15 @@ class _$GUserAchievementsStreamCursorInputSerializer
       final Object? value = iterator.current;
       switch (key) {
         case 'initialValue':
-          result.initialValue.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(
-                    GUserAchievementsStreamCursorValueInput,
-                  ),
-                )!
-                as GUserAchievementsStreamCursorValueInput,
-          );
+          result.initialValue.replace(serializers.deserialize(value,
+                  specifiedType:
+                      const FullType(GUserAchievementsStreamCursorValueInput))!
+              as GUserAchievementsStreamCursorValueInput);
           break;
         case 'ordering':
-          result.ordering =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(GCursorOrdering),
-                  )
-                  as GCursorOrdering?;
+          result.ordering = serializers.deserialize(value,
+                  specifiedType: const FullType(GCursorOrdering))
+              as GCursorOrdering?;
           break;
       }
     }
@@ -9101,44 +6818,38 @@ class _$GUserAchievementsStreamCursorValueInputSerializer
   @override
   final Iterable<Type> types = const [
     GUserAchievementsStreamCursorValueInput,
-    _$GUserAchievementsStreamCursorValueInput,
+    _$GUserAchievementsStreamCursorValueInput
   ];
   @override
   final String wireName = 'GUserAchievementsStreamCursorValueInput';
 
   @override
   Iterable<Object?> serialize(
-    Serializers serializers,
-    GUserAchievementsStreamCursorValueInput object, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, GUserAchievementsStreamCursorValueInput object,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[];
     Object? value;
     value = object.achievementId;
     if (value != null) {
       result
         ..add('achievementId')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(String)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
     }
     value = object.userId;
     if (value != null) {
       result
         ..add('userId')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(String)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
     }
     return result;
   }
 
   @override
   GUserAchievementsStreamCursorValueInput deserialize(
-    Serializers serializers,
-    Iterable<Object?> serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = new GUserAchievementsStreamCursorValueInputBuilder();
 
     final iterator = serialized.iterator;
@@ -9148,20 +6859,12 @@ class _$GUserAchievementsStreamCursorValueInputSerializer
       final Object? value = iterator.current;
       switch (key) {
         case 'achievementId':
-          result.achievementId =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )
-                  as String?;
+          result.achievementId = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
           break;
         case 'userId':
-          result.userId =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )
-                  as String?;
+          result.userId = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
           break;
       }
     }
@@ -9177,158 +6880,103 @@ class _$GUsersBoolExpSerializer implements StructuredSerializer<GUsersBoolExp> {
   final String wireName = 'GUsersBoolExp';
 
   @override
-  Iterable<Object?> serialize(
-    Serializers serializers,
-    GUsersBoolExp object, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+  Iterable<Object?> serialize(Serializers serializers, GUsersBoolExp object,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[];
     Object? value;
     value = object.G_and;
     if (value != null) {
       result
         ..add('_and')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(BuiltList, const [
-              const FullType(GUsersBoolExp),
-            ]),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(
+                BuiltList, const [const FullType(GUsersBoolExp)])));
     }
     value = object.G_not;
     if (value != null) {
       result
         ..add('_not')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GUsersBoolExp),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GUsersBoolExp)));
     }
     value = object.G_or;
     if (value != null) {
       result
         ..add('_or')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(BuiltList, const [
-              const FullType(GUsersBoolExp),
-            ]),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(
+                BuiltList, const [const FullType(GUsersBoolExp)])));
     }
     value = object.createdAt;
     if (value != null) {
       result
         ..add('createdAt')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GTimestamptzComparisonExp),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GTimestamptzComparisonExp)));
     }
     value = object.email;
     if (value != null) {
       result
         ..add('email')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GStringComparisonExp),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GStringComparisonExp)));
     }
     value = object.id;
     if (value != null) {
       result
         ..add('id')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GStringComparisonExp),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GStringComparisonExp)));
     }
     value = object.lastSeen;
     if (value != null) {
       result
         ..add('lastSeen')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GTimestamptzComparisonExp),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GTimestamptzComparisonExp)));
     }
     value = object.nickname;
     if (value != null) {
       result
         ..add('nickname')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GStringComparisonExp),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GStringComparisonExp)));
     }
     value = object.picture;
     if (value != null) {
       result
         ..add('picture')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GStringComparisonExp),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GStringComparisonExp)));
     }
     value = object.updatedAt;
     if (value != null) {
       result
         ..add('updatedAt')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GTimestamptzComparisonExp),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GTimestamptzComparisonExp)));
     }
     value = object.username;
     if (value != null) {
       result
         ..add('username')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GStringComparisonExp),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GStringComparisonExp)));
     }
     value = object.website;
     if (value != null) {
       result
         ..add('website')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GStringComparisonExp),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GStringComparisonExp)));
     }
     return result;
   }
 
   @override
   GUsersBoolExp deserialize(
-    Serializers serializers,
-    Iterable<Object?> serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = new GUsersBoolExpBuilder();
 
     final iterator = serialized.iterator;
@@ -9338,116 +6986,65 @@ class _$GUsersBoolExpSerializer implements StructuredSerializer<GUsersBoolExp> {
       final Object? value = iterator.current;
       switch (key) {
         case '_and':
-          result.G_and.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(BuiltList, const [
-                    const FullType(GUsersBoolExp),
-                  ]),
-                )!
-                as BuiltList<Object?>,
-          );
+          result.G_and.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(
+                      BuiltList, const [const FullType(GUsersBoolExp)]))!
+              as BuiltList<Object?>);
           break;
         case '_not':
-          result.G_not.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(GUsersBoolExp),
-                )!
-                as GUsersBoolExp,
-          );
+          result.G_not.replace(serializers.deserialize(value,
+              specifiedType: const FullType(GUsersBoolExp))! as GUsersBoolExp);
           break;
         case '_or':
-          result.G_or.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(BuiltList, const [
-                    const FullType(GUsersBoolExp),
-                  ]),
-                )!
-                as BuiltList<Object?>,
-          );
+          result.G_or.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(
+                      BuiltList, const [const FullType(GUsersBoolExp)]))!
+              as BuiltList<Object?>);
           break;
         case 'createdAt':
-          result.createdAt.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(GTimestamptzComparisonExp),
-                )!
-                as GTimestamptzComparisonExp,
-          );
+          result.createdAt.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(GTimestamptzComparisonExp))!
+              as GTimestamptzComparisonExp);
           break;
         case 'email':
-          result.email.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(GStringComparisonExp),
-                )!
-                as GStringComparisonExp,
-          );
+          result.email.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(GStringComparisonExp))!
+              as GStringComparisonExp);
           break;
         case 'id':
-          result.id.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(GStringComparisonExp),
-                )!
-                as GStringComparisonExp,
-          );
+          result.id.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(GStringComparisonExp))!
+              as GStringComparisonExp);
           break;
         case 'lastSeen':
-          result.lastSeen.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(GTimestamptzComparisonExp),
-                )!
-                as GTimestamptzComparisonExp,
-          );
+          result.lastSeen.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(GTimestamptzComparisonExp))!
+              as GTimestamptzComparisonExp);
           break;
         case 'nickname':
-          result.nickname.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(GStringComparisonExp),
-                )!
-                as GStringComparisonExp,
-          );
+          result.nickname.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(GStringComparisonExp))!
+              as GStringComparisonExp);
           break;
         case 'picture':
-          result.picture.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(GStringComparisonExp),
-                )!
-                as GStringComparisonExp,
-          );
+          result.picture.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(GStringComparisonExp))!
+              as GStringComparisonExp);
           break;
         case 'updatedAt':
-          result.updatedAt.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(GTimestamptzComparisonExp),
-                )!
-                as GTimestamptzComparisonExp,
-          );
+          result.updatedAt.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(GTimestamptzComparisonExp))!
+              as GTimestamptzComparisonExp);
           break;
         case 'username':
-          result.username.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(GStringComparisonExp),
-                )!
-                as GStringComparisonExp,
-          );
+          result.username.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(GStringComparisonExp))!
+              as GStringComparisonExp);
           break;
         case 'website':
-          result.website.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(GStringComparisonExp),
-                )!
-                as GStringComparisonExp,
-          );
+          result.website.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(GStringComparisonExp))!
+              as GStringComparisonExp);
           break;
       }
     }
@@ -9463,94 +7060,80 @@ class _$GUsersOrderBySerializer implements StructuredSerializer<GUsersOrderBy> {
   final String wireName = 'GUsersOrderBy';
 
   @override
-  Iterable<Object?> serialize(
-    Serializers serializers,
-    GUsersOrderBy object, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+  Iterable<Object?> serialize(Serializers serializers, GUsersOrderBy object,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[];
     Object? value;
     value = object.createdAt;
     if (value != null) {
       result
         ..add('createdAt')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(GOrderBy)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GOrderBy)));
     }
     value = object.email;
     if (value != null) {
       result
         ..add('email')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(GOrderBy)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GOrderBy)));
     }
     value = object.id;
     if (value != null) {
       result
         ..add('id')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(GOrderBy)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GOrderBy)));
     }
     value = object.lastSeen;
     if (value != null) {
       result
         ..add('lastSeen')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(GOrderBy)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GOrderBy)));
     }
     value = object.nickname;
     if (value != null) {
       result
         ..add('nickname')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(GOrderBy)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GOrderBy)));
     }
     value = object.picture;
     if (value != null) {
       result
         ..add('picture')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(GOrderBy)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GOrderBy)));
     }
     value = object.updatedAt;
     if (value != null) {
       result
         ..add('updatedAt')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(GOrderBy)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GOrderBy)));
     }
     value = object.username;
     if (value != null) {
       result
         ..add('username')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(GOrderBy)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GOrderBy)));
     }
     value = object.website;
     if (value != null) {
       result
         ..add('website')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(GOrderBy)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GOrderBy)));
     }
     return result;
   }
 
   @override
   GUsersOrderBy deserialize(
-    Serializers serializers,
-    Iterable<Object?> serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = new GUsersOrderByBuilder();
 
     final iterator = serialized.iterator;
@@ -9560,76 +7143,40 @@ class _$GUsersOrderBySerializer implements StructuredSerializer<GUsersOrderBy> {
       final Object? value = iterator.current;
       switch (key) {
         case 'createdAt':
-          result.createdAt =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(GOrderBy),
-                  )
-                  as GOrderBy?;
+          result.createdAt = serializers.deserialize(value,
+              specifiedType: const FullType(GOrderBy)) as GOrderBy?;
           break;
         case 'email':
-          result.email =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(GOrderBy),
-                  )
-                  as GOrderBy?;
+          result.email = serializers.deserialize(value,
+              specifiedType: const FullType(GOrderBy)) as GOrderBy?;
           break;
         case 'id':
-          result.id =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(GOrderBy),
-                  )
-                  as GOrderBy?;
+          result.id = serializers.deserialize(value,
+              specifiedType: const FullType(GOrderBy)) as GOrderBy?;
           break;
         case 'lastSeen':
-          result.lastSeen =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(GOrderBy),
-                  )
-                  as GOrderBy?;
+          result.lastSeen = serializers.deserialize(value,
+              specifiedType: const FullType(GOrderBy)) as GOrderBy?;
           break;
         case 'nickname':
-          result.nickname =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(GOrderBy),
-                  )
-                  as GOrderBy?;
+          result.nickname = serializers.deserialize(value,
+              specifiedType: const FullType(GOrderBy)) as GOrderBy?;
           break;
         case 'picture':
-          result.picture =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(GOrderBy),
-                  )
-                  as GOrderBy?;
+          result.picture = serializers.deserialize(value,
+              specifiedType: const FullType(GOrderBy)) as GOrderBy?;
           break;
         case 'updatedAt':
-          result.updatedAt =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(GOrderBy),
-                  )
-                  as GOrderBy?;
+          result.updatedAt = serializers.deserialize(value,
+              specifiedType: const FullType(GOrderBy)) as GOrderBy?;
           break;
         case 'username':
-          result.username =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(GOrderBy),
-                  )
-                  as GOrderBy?;
+          result.username = serializers.deserialize(value,
+              specifiedType: const FullType(GOrderBy)) as GOrderBy?;
           break;
         case 'website':
-          result.website =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(GOrderBy),
-                  )
-                  as GOrderBy?;
+          result.website = serializers.deserialize(value,
+              specifiedType: const FullType(GOrderBy)) as GOrderBy?;
           break;
       }
     }
@@ -9646,18 +7193,14 @@ class _$GUsersSelectColumnSerializer
   final String wireName = 'GUsersSelectColumn';
 
   @override
-  Object serialize(
-    Serializers serializers,
-    GUsersSelectColumn object, {
-    FullType specifiedType = FullType.unspecified,
-  }) => object.name;
+  Object serialize(Serializers serializers, GUsersSelectColumn object,
+          {FullType specifiedType = FullType.unspecified}) =>
+      object.name;
 
   @override
-  GUsersSelectColumn deserialize(
-    Serializers serializers,
-    Object serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) => GUsersSelectColumn.valueOf(serialized as String);
+  GUsersSelectColumn deserialize(Serializers serializers, Object serialized,
+          {FullType specifiedType = FullType.unspecified}) =>
+      GUsersSelectColumn.valueOf(serialized as String);
 }
 
 class _$GUsersStreamCursorInputSerializer
@@ -9665,45 +7208,35 @@ class _$GUsersStreamCursorInputSerializer
   @override
   final Iterable<Type> types = const [
     GUsersStreamCursorInput,
-    _$GUsersStreamCursorInput,
+    _$GUsersStreamCursorInput
   ];
   @override
   final String wireName = 'GUsersStreamCursorInput';
 
   @override
   Iterable<Object?> serialize(
-    Serializers serializers,
-    GUsersStreamCursorInput object, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, GUsersStreamCursorInput object,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[
       'initialValue',
-      serializers.serialize(
-        object.initialValue,
-        specifiedType: const FullType(GUsersStreamCursorValueInput),
-      ),
+      serializers.serialize(object.initialValue,
+          specifiedType: const FullType(GUsersStreamCursorValueInput)),
     ];
     Object? value;
     value = object.ordering;
     if (value != null) {
       result
         ..add('ordering')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(GCursorOrdering),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(GCursorOrdering)));
     }
     return result;
   }
 
   @override
   GUsersStreamCursorInput deserialize(
-    Serializers serializers,
-    Iterable<Object?> serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = new GUsersStreamCursorInputBuilder();
 
     final iterator = serialized.iterator;
@@ -9713,21 +7246,14 @@ class _$GUsersStreamCursorInputSerializer
       final Object? value = iterator.current;
       switch (key) {
         case 'initialValue':
-          result.initialValue.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(GUsersStreamCursorValueInput),
-                )!
-                as GUsersStreamCursorValueInput,
-          );
+          result.initialValue.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(GUsersStreamCursorValueInput))!
+              as GUsersStreamCursorValueInput);
           break;
         case 'ordering':
-          result.ordering =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(GCursorOrdering),
-                  )
-                  as GCursorOrdering?;
+          result.ordering = serializers.deserialize(value,
+                  specifiedType: const FullType(GCursorOrdering))
+              as GCursorOrdering?;
           break;
       }
     }
@@ -9741,100 +7267,87 @@ class _$GUsersStreamCursorValueInputSerializer
   @override
   final Iterable<Type> types = const [
     GUsersStreamCursorValueInput,
-    _$GUsersStreamCursorValueInput,
+    _$GUsersStreamCursorValueInput
   ];
   @override
   final String wireName = 'GUsersStreamCursorValueInput';
 
   @override
   Iterable<Object?> serialize(
-    Serializers serializers,
-    GUsersStreamCursorValueInput object, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, GUsersStreamCursorValueInput object,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[];
     Object? value;
     value = object.createdAt;
     if (value != null) {
       result
         ..add('createdAt')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(DateTime)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(DateTime)));
     }
     value = object.email;
     if (value != null) {
       result
         ..add('email')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(String)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
     }
     value = object.id;
     if (value != null) {
       result
         ..add('id')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(String)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
     }
     value = object.lastSeen;
     if (value != null) {
       result
         ..add('lastSeen')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(DateTime)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(DateTime)));
     }
     value = object.nickname;
     if (value != null) {
       result
         ..add('nickname')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(String)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
     }
     value = object.picture;
     if (value != null) {
       result
         ..add('picture')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(String)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
     }
     value = object.updatedAt;
     if (value != null) {
       result
         ..add('updatedAt')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(DateTime)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(DateTime)));
     }
     value = object.username;
     if (value != null) {
       result
         ..add('username')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(String)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
     }
     value = object.website;
     if (value != null) {
       result
         ..add('website')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(String)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
     }
     return result;
   }
 
   @override
   GUsersStreamCursorValueInput deserialize(
-    Serializers serializers,
-    Iterable<Object?> serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = new GUsersStreamCursorValueInputBuilder();
 
     final iterator = serialized.iterator;
@@ -9844,76 +7357,40 @@ class _$GUsersStreamCursorValueInputSerializer
       final Object? value = iterator.current;
       switch (key) {
         case 'createdAt':
-          result.createdAt =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(DateTime),
-                  )
-                  as DateTime?;
+          result.createdAt = serializers.deserialize(value,
+              specifiedType: const FullType(DateTime)) as DateTime?;
           break;
         case 'email':
-          result.email =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )
-                  as String?;
+          result.email = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
           break;
         case 'id':
-          result.id =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )
-                  as String?;
+          result.id = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
           break;
         case 'lastSeen':
-          result.lastSeen =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(DateTime),
-                  )
-                  as DateTime?;
+          result.lastSeen = serializers.deserialize(value,
+              specifiedType: const FullType(DateTime)) as DateTime?;
           break;
         case 'nickname':
-          result.nickname =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )
-                  as String?;
+          result.nickname = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
           break;
         case 'picture':
-          result.picture =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )
-                  as String?;
+          result.picture = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
           break;
         case 'updatedAt':
-          result.updatedAt =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(DateTime),
-                  )
-                  as DateTime?;
+          result.updatedAt = serializers.deserialize(value,
+              specifiedType: const FullType(DateTime)) as DateTime?;
           break;
         case 'username':
-          result.username =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )
-                  as String?;
+          result.username = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
           break;
         case 'website':
-          result.website =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )
-                  as String?;
+          result.website = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
           break;
       }
     }
@@ -9931,103 +7408,82 @@ class _$GUuidComparisonExpSerializer
 
   @override
   Iterable<Object?> serialize(
-    Serializers serializers,
-    GUuidComparisonExp object, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, GUuidComparisonExp object,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[];
     Object? value;
     value = object.G_eq;
     if (value != null) {
       result
         ..add('_eq')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(String)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
     }
     value = object.G_gt;
     if (value != null) {
       result
         ..add('_gt')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(String)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
     }
     value = object.G_gte;
     if (value != null) {
       result
         ..add('_gte')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(String)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
     }
     value = object.G_in;
     if (value != null) {
       result
         ..add('_in')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(BuiltList, const [
-              const FullType(String),
-            ]),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType:
+                const FullType(BuiltList, const [const FullType(String)])));
     }
     value = object.G_isNull;
     if (value != null) {
       result
         ..add('_isNull')
         ..add(
-          serializers.serialize(value, specifiedType: const FullType(bool)),
-        );
+            serializers.serialize(value, specifiedType: const FullType(bool)));
     }
     value = object.G_lt;
     if (value != null) {
       result
         ..add('_lt')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(String)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
     }
     value = object.G_lte;
     if (value != null) {
       result
         ..add('_lte')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(String)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
     }
     value = object.G_neq;
     if (value != null) {
       result
         ..add('_neq')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(String)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
     }
     value = object.G_nin;
     if (value != null) {
       result
         ..add('_nin')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(BuiltList, const [
-              const FullType(String),
-            ]),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType:
+                const FullType(BuiltList, const [const FullType(String)])));
     }
     return result;
   }
 
   @override
   GUuidComparisonExp deserialize(
-    Serializers serializers,
-    Iterable<Object?> serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = new GUuidComparisonExpBuilder();
 
     final iterator = serialized.iterator;
@@ -10037,82 +7493,44 @@ class _$GUuidComparisonExpSerializer
       final Object? value = iterator.current;
       switch (key) {
         case '_eq':
-          result.G_eq =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )
-                  as String?;
+          result.G_eq = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
           break;
         case '_gt':
-          result.G_gt =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )
-                  as String?;
+          result.G_gt = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
           break;
         case '_gte':
-          result.G_gte =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )
-                  as String?;
+          result.G_gte = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
           break;
         case '_in':
-          result.G_in.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(BuiltList, const [
-                    const FullType(String),
-                  ]),
-                )!
-                as BuiltList<Object?>,
-          );
+          result.G_in.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(
+                      BuiltList, const [const FullType(String)]))!
+              as BuiltList<Object?>);
           break;
         case '_isNull':
-          result.G_isNull =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(bool),
-                  )
-                  as bool?;
+          result.G_isNull = serializers.deserialize(value,
+              specifiedType: const FullType(bool)) as bool?;
           break;
         case '_lt':
-          result.G_lt =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )
-                  as String?;
+          result.G_lt = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
           break;
         case '_lte':
-          result.G_lte =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )
-                  as String?;
+          result.G_lte = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
           break;
         case '_neq':
-          result.G_neq =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )
-                  as String?;
+          result.G_neq = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
           break;
         case '_nin':
-          result.G_nin.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(BuiltList, const [
-                    const FullType(String),
-                  ]),
-                )!
-                as BuiltList<Object?>,
-          );
+          result.G_nin.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(
+                      BuiltList, const [const FullType(String)]))!
+              as BuiltList<Object?>);
           break;
       }
     }
@@ -10139,25 +7557,25 @@ class _$GAchievementsBoolExp extends GAchievementsBoolExp {
   @override
   final GTimestamptzComparisonExp? updatedAt;
 
-  factory _$GAchievementsBoolExp([
-    void Function(GAchievementsBoolExpBuilder)? updates,
-  ]) => (new GAchievementsBoolExpBuilder()..update(updates))._build();
+  factory _$GAchievementsBoolExp(
+          [void Function(GAchievementsBoolExpBuilder)? updates]) =>
+      (new GAchievementsBoolExpBuilder()..update(updates))._build();
 
-  _$GAchievementsBoolExp._({
-    this.G_and,
-    this.G_not,
-    this.G_or,
-    this.createdAt,
-    this.description,
-    this.id,
-    this.name,
-    this.updatedAt,
-  }) : super._();
+  _$GAchievementsBoolExp._(
+      {this.G_and,
+      this.G_not,
+      this.G_or,
+      this.createdAt,
+      this.description,
+      this.id,
+      this.name,
+      this.updatedAt})
+      : super._();
 
   @override
   GAchievementsBoolExp rebuild(
-    void Function(GAchievementsBoolExpBuilder) updates,
-  ) => (toBuilder()..update(updates)).build();
+          void Function(GAchievementsBoolExpBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
 
   @override
   GAchievementsBoolExpBuilder toBuilder() =>
@@ -10289,8 +7707,7 @@ class GAchievementsBoolExpBuilder
   _$GAchievementsBoolExp _build() {
     _$GAchievementsBoolExp _$result;
     try {
-      _$result =
-          _$v ??
+      _$result = _$v ??
           new _$GAchievementsBoolExp._(
             G_and: _G_and?.build(),
             G_not: _G_not?.build(),
@@ -10322,10 +7739,7 @@ class GAchievementsBoolExpBuilder
         _updatedAt?.build();
       } catch (e) {
         throw new BuiltValueNestedFieldError(
-          r'GAchievementsBoolExp',
-          _$failedField,
-          e.toString(),
-        );
+            r'GAchievementsBoolExp', _$failedField, e.toString());
       }
       rethrow;
     }
@@ -10346,22 +7760,18 @@ class _$GAchievementsOrderBy extends GAchievementsOrderBy {
   @override
   final GOrderBy? updatedAt;
 
-  factory _$GAchievementsOrderBy([
-    void Function(GAchievementsOrderByBuilder)? updates,
-  ]) => (new GAchievementsOrderByBuilder()..update(updates))._build();
+  factory _$GAchievementsOrderBy(
+          [void Function(GAchievementsOrderByBuilder)? updates]) =>
+      (new GAchievementsOrderByBuilder()..update(updates))._build();
 
-  _$GAchievementsOrderBy._({
-    this.createdAt,
-    this.description,
-    this.id,
-    this.name,
-    this.updatedAt,
-  }) : super._();
+  _$GAchievementsOrderBy._(
+      {this.createdAt, this.description, this.id, this.name, this.updatedAt})
+      : super._();
 
   @override
   GAchievementsOrderBy rebuild(
-    void Function(GAchievementsOrderByBuilder) updates,
-  ) => (toBuilder()..update(updates)).build();
+          void Function(GAchievementsOrderByBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
 
   @override
   GAchievementsOrderByBuilder toBuilder() =>
@@ -10456,8 +7866,7 @@ class GAchievementsOrderByBuilder
   GAchievementsOrderBy build() => _build();
 
   _$GAchievementsOrderBy _build() {
-    final _$result =
-        _$v ??
+    final _$result = _$v ??
         new _$GAchievementsOrderBy._(
           createdAt: createdAt,
           description: description,
@@ -10476,25 +7885,21 @@ class _$GAchievementsStreamCursorInput extends GAchievementsStreamCursorInput {
   @override
   final GCursorOrdering? ordering;
 
-  factory _$GAchievementsStreamCursorInput([
-    void Function(GAchievementsStreamCursorInputBuilder)? updates,
-  ]) => (new GAchievementsStreamCursorInputBuilder()..update(updates))._build();
+  factory _$GAchievementsStreamCursorInput(
+          [void Function(GAchievementsStreamCursorInputBuilder)? updates]) =>
+      (new GAchievementsStreamCursorInputBuilder()..update(updates))._build();
 
-  _$GAchievementsStreamCursorInput._({
-    required this.initialValue,
-    this.ordering,
-  }) : super._() {
+  _$GAchievementsStreamCursorInput._(
+      {required this.initialValue, this.ordering})
+      : super._() {
     BuiltValueNullFieldError.checkNotNull(
-      initialValue,
-      r'GAchievementsStreamCursorInput',
-      'initialValue',
-    );
+        initialValue, r'GAchievementsStreamCursorInput', 'initialValue');
   }
 
   @override
   GAchievementsStreamCursorInput rebuild(
-    void Function(GAchievementsStreamCursorInputBuilder) updates,
-  ) => (toBuilder()..update(updates)).build();
+          void Function(GAchievementsStreamCursorInputBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
 
   @override
   GAchievementsStreamCursorInputBuilder toBuilder() =>
@@ -10528,10 +7933,8 @@ class _$GAchievementsStreamCursorInput extends GAchievementsStreamCursorInput {
 
 class GAchievementsStreamCursorInputBuilder
     implements
-        Builder<
-          GAchievementsStreamCursorInput,
-          GAchievementsStreamCursorInputBuilder
-        > {
+        Builder<GAchievementsStreamCursorInput,
+            GAchievementsStreamCursorInputBuilder> {
   _$GAchievementsStreamCursorInput? _$v;
 
   GAchievementsStreamCursorValueInputBuilder? _initialValue;
@@ -10573,8 +7976,7 @@ class GAchievementsStreamCursorInputBuilder
   _$GAchievementsStreamCursorInput _build() {
     _$GAchievementsStreamCursorInput _$result;
     try {
-      _$result =
-          _$v ??
+      _$result = _$v ??
           new _$GAchievementsStreamCursorInput._(
             initialValue: initialValue.build(),
             ordering: ordering,
@@ -10586,10 +7988,7 @@ class GAchievementsStreamCursorInputBuilder
         initialValue.build();
       } catch (e) {
         throw new BuiltValueNestedFieldError(
-          r'GAchievementsStreamCursorInput',
-          _$failedField,
-          e.toString(),
-        );
+            r'GAchievementsStreamCursorInput', _$failedField, e.toString());
       }
       rethrow;
     }
@@ -10611,23 +8010,20 @@ class _$GAchievementsStreamCursorValueInput
   @override
   final DateTime? updatedAt;
 
-  factory _$GAchievementsStreamCursorValueInput([
-    void Function(GAchievementsStreamCursorValueInputBuilder)? updates,
-  ]) => (new GAchievementsStreamCursorValueInputBuilder()..update(updates))
-      ._build();
+  factory _$GAchievementsStreamCursorValueInput(
+          [void Function(GAchievementsStreamCursorValueInputBuilder)?
+              updates]) =>
+      (new GAchievementsStreamCursorValueInputBuilder()..update(updates))
+          ._build();
 
-  _$GAchievementsStreamCursorValueInput._({
-    this.createdAt,
-    this.description,
-    this.id,
-    this.name,
-    this.updatedAt,
-  }) : super._();
+  _$GAchievementsStreamCursorValueInput._(
+      {this.createdAt, this.description, this.id, this.name, this.updatedAt})
+      : super._();
 
   @override
   GAchievementsStreamCursorValueInput rebuild(
-    void Function(GAchievementsStreamCursorValueInputBuilder) updates,
-  ) => (toBuilder()..update(updates)).build();
+          void Function(GAchievementsStreamCursorValueInputBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
 
   @override
   GAchievementsStreamCursorValueInputBuilder toBuilder() =>
@@ -10670,10 +8066,8 @@ class _$GAchievementsStreamCursorValueInput
 
 class GAchievementsStreamCursorValueInputBuilder
     implements
-        Builder<
-          GAchievementsStreamCursorValueInput,
-          GAchievementsStreamCursorValueInputBuilder
-        > {
+        Builder<GAchievementsStreamCursorValueInput,
+            GAchievementsStreamCursorValueInputBuilder> {
   _$GAchievementsStreamCursorValueInput? _$v;
 
   DateTime? _createdAt;
@@ -10719,8 +8113,7 @@ class GAchievementsStreamCursorValueInputBuilder
 
   @override
   void update(
-    void Function(GAchievementsStreamCursorValueInputBuilder)? updates,
-  ) {
+      void Function(GAchievementsStreamCursorValueInputBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
@@ -10728,8 +8121,7 @@ class GAchievementsStreamCursorValueInputBuilder
   GAchievementsStreamCursorValueInput build() => _build();
 
   _$GAchievementsStreamCursorValueInput _build() {
-    final _$result =
-        _$v ??
+    final _$result = _$v ??
         new _$GAchievementsStreamCursorValueInput._(
           createdAt: createdAt,
           description: description,
@@ -10762,21 +8154,21 @@ class _$GIntComparisonExp extends GIntComparisonExp {
   @override
   final BuiltList<int>? G_nin;
 
-  factory _$GIntComparisonExp([
-    void Function(GIntComparisonExpBuilder)? updates,
-  ]) => (new GIntComparisonExpBuilder()..update(updates))._build();
+  factory _$GIntComparisonExp(
+          [void Function(GIntComparisonExpBuilder)? updates]) =>
+      (new GIntComparisonExpBuilder()..update(updates))._build();
 
-  _$GIntComparisonExp._({
-    this.G_eq,
-    this.G_gt,
-    this.G_gte,
-    this.G_in,
-    this.G_isNull,
-    this.G_lt,
-    this.G_lte,
-    this.G_neq,
-    this.G_nin,
-  }) : super._();
+  _$GIntComparisonExp._(
+      {this.G_eq,
+      this.G_gt,
+      this.G_gte,
+      this.G_in,
+      this.G_isNull,
+      this.G_lt,
+      this.G_lte,
+      this.G_neq,
+      this.G_nin})
+      : super._();
 
   @override
   GIntComparisonExp rebuild(void Function(GIntComparisonExpBuilder) updates) =>
@@ -10909,8 +8301,7 @@ class GIntComparisonExpBuilder
   _$GIntComparisonExp _build() {
     _$GIntComparisonExp _$result;
     try {
-      _$result =
-          _$v ??
+      _$result = _$v ??
           new _$GIntComparisonExp._(
             G_eq: G_eq,
             G_gt: G_gt,
@@ -10932,10 +8323,7 @@ class GIntComparisonExpBuilder
         _G_nin?.build();
       } catch (e) {
         throw new BuiltValueNestedFieldError(
-          r'GIntComparisonExp',
-          _$failedField,
-          e.toString(),
-        );
+            r'GIntComparisonExp', _$failedField, e.toString());
       }
       rethrow;
     }
@@ -10956,22 +8344,22 @@ class _$GMainQuestRelationsBoolExp extends GMainQuestRelationsBoolExp {
   @override
   final GUuidComparisonExp? parentQuestId;
 
-  factory _$GMainQuestRelationsBoolExp([
-    void Function(GMainQuestRelationsBoolExpBuilder)? updates,
-  ]) => (new GMainQuestRelationsBoolExpBuilder()..update(updates))._build();
+  factory _$GMainQuestRelationsBoolExp(
+          [void Function(GMainQuestRelationsBoolExpBuilder)? updates]) =>
+      (new GMainQuestRelationsBoolExpBuilder()..update(updates))._build();
 
-  _$GMainQuestRelationsBoolExp._({
-    this.G_and,
-    this.G_not,
-    this.G_or,
-    this.childQuestId,
-    this.parentQuestId,
-  }) : super._();
+  _$GMainQuestRelationsBoolExp._(
+      {this.G_and,
+      this.G_not,
+      this.G_or,
+      this.childQuestId,
+      this.parentQuestId})
+      : super._();
 
   @override
   GMainQuestRelationsBoolExp rebuild(
-    void Function(GMainQuestRelationsBoolExpBuilder) updates,
-  ) => (toBuilder()..update(updates)).build();
+          void Function(GMainQuestRelationsBoolExpBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
 
   @override
   GMainQuestRelationsBoolExpBuilder toBuilder() =>
@@ -11078,8 +8466,7 @@ class GMainQuestRelationsBoolExpBuilder
   _$GMainQuestRelationsBoolExp _build() {
     _$GMainQuestRelationsBoolExp _$result;
     try {
-      _$result =
-          _$v ??
+      _$result = _$v ??
           new _$GMainQuestRelationsBoolExp._(
             G_and: _G_and?.build(),
             G_not: _G_not?.build(),
@@ -11102,10 +8489,7 @@ class GMainQuestRelationsBoolExpBuilder
         _parentQuestId?.build();
       } catch (e) {
         throw new BuiltValueNestedFieldError(
-          r'GMainQuestRelationsBoolExp',
-          _$failedField,
-          e.toString(),
-        );
+            r'GMainQuestRelationsBoolExp', _$failedField, e.toString());
       }
       rethrow;
     }
@@ -11120,17 +8504,17 @@ class _$GMainQuestRelationsInsertInput extends GMainQuestRelationsInsertInput {
   @override
   final String? parentQuestId;
 
-  factory _$GMainQuestRelationsInsertInput([
-    void Function(GMainQuestRelationsInsertInputBuilder)? updates,
-  ]) => (new GMainQuestRelationsInsertInputBuilder()..update(updates))._build();
+  factory _$GMainQuestRelationsInsertInput(
+          [void Function(GMainQuestRelationsInsertInputBuilder)? updates]) =>
+      (new GMainQuestRelationsInsertInputBuilder()..update(updates))._build();
 
   _$GMainQuestRelationsInsertInput._({this.childQuestId, this.parentQuestId})
-    : super._();
+      : super._();
 
   @override
   GMainQuestRelationsInsertInput rebuild(
-    void Function(GMainQuestRelationsInsertInputBuilder) updates,
-  ) => (toBuilder()..update(updates)).build();
+          void Function(GMainQuestRelationsInsertInputBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
 
   @override
   GMainQuestRelationsInsertInputBuilder toBuilder() =>
@@ -11164,10 +8548,8 @@ class _$GMainQuestRelationsInsertInput extends GMainQuestRelationsInsertInput {
 
 class GMainQuestRelationsInsertInputBuilder
     implements
-        Builder<
-          GMainQuestRelationsInsertInput,
-          GMainQuestRelationsInsertInputBuilder
-        > {
+        Builder<GMainQuestRelationsInsertInput,
+            GMainQuestRelationsInsertInputBuilder> {
   _$GMainQuestRelationsInsertInput? _$v;
 
   String? _childQuestId;
@@ -11206,8 +8588,7 @@ class GMainQuestRelationsInsertInputBuilder
   GMainQuestRelationsInsertInput build() => _build();
 
   _$GMainQuestRelationsInsertInput _build() {
-    final _$result =
-        _$v ??
+    final _$result = _$v ??
         new _$GMainQuestRelationsInsertInput._(
           childQuestId: childQuestId,
           parentQuestId: parentQuestId,
@@ -11225,31 +8606,23 @@ class _$GMainQuestRelationsOnConflict extends GMainQuestRelationsOnConflict {
   @override
   final GMainQuestRelationsBoolExp? where;
 
-  factory _$GMainQuestRelationsOnConflict([
-    void Function(GMainQuestRelationsOnConflictBuilder)? updates,
-  ]) => (new GMainQuestRelationsOnConflictBuilder()..update(updates))._build();
+  factory _$GMainQuestRelationsOnConflict(
+          [void Function(GMainQuestRelationsOnConflictBuilder)? updates]) =>
+      (new GMainQuestRelationsOnConflictBuilder()..update(updates))._build();
 
-  _$GMainQuestRelationsOnConflict._({
-    required this.constraint,
-    required this.updateColumns,
-    this.where,
-  }) : super._() {
+  _$GMainQuestRelationsOnConflict._(
+      {required this.constraint, required this.updateColumns, this.where})
+      : super._() {
     BuiltValueNullFieldError.checkNotNull(
-      constraint,
-      r'GMainQuestRelationsOnConflict',
-      'constraint',
-    );
+        constraint, r'GMainQuestRelationsOnConflict', 'constraint');
     BuiltValueNullFieldError.checkNotNull(
-      updateColumns,
-      r'GMainQuestRelationsOnConflict',
-      'updateColumns',
-    );
+        updateColumns, r'GMainQuestRelationsOnConflict', 'updateColumns');
   }
 
   @override
   GMainQuestRelationsOnConflict rebuild(
-    void Function(GMainQuestRelationsOnConflictBuilder) updates,
-  ) => (toBuilder()..update(updates)).build();
+          void Function(GMainQuestRelationsOnConflictBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
 
   @override
   GMainQuestRelationsOnConflictBuilder toBuilder() =>
@@ -11286,10 +8659,8 @@ class _$GMainQuestRelationsOnConflict extends GMainQuestRelationsOnConflict {
 
 class GMainQuestRelationsOnConflictBuilder
     implements
-        Builder<
-          GMainQuestRelationsOnConflict,
-          GMainQuestRelationsOnConflictBuilder
-        > {
+        Builder<GMainQuestRelationsOnConflict,
+            GMainQuestRelationsOnConflictBuilder> {
   _$GMainQuestRelationsOnConflict? _$v;
 
   GMainQuestRelationsConstraint? _constraint;
@@ -11302,8 +8673,8 @@ class GMainQuestRelationsOnConflictBuilder
       _$this._updateColumns ??=
           new ListBuilder<GMainQuestRelationsUpdateColumn>();
   set updateColumns(
-    ListBuilder<GMainQuestRelationsUpdateColumn>? updateColumns,
-  ) => _$this._updateColumns = updateColumns;
+          ListBuilder<GMainQuestRelationsUpdateColumn>? updateColumns) =>
+      _$this._updateColumns = updateColumns;
 
   GMainQuestRelationsBoolExpBuilder? _where;
   GMainQuestRelationsBoolExpBuilder get where =>
@@ -11340,14 +8711,10 @@ class GMainQuestRelationsOnConflictBuilder
   _$GMainQuestRelationsOnConflict _build() {
     _$GMainQuestRelationsOnConflict _$result;
     try {
-      _$result =
-          _$v ??
+      _$result = _$v ??
           new _$GMainQuestRelationsOnConflict._(
             constraint: BuiltValueNullFieldError.checkNotNull(
-              constraint,
-              r'GMainQuestRelationsOnConflict',
-              'constraint',
-            ),
+                constraint, r'GMainQuestRelationsOnConflict', 'constraint'),
             updateColumns: updateColumns.build(),
             where: _where?.build(),
           );
@@ -11360,10 +8727,7 @@ class GMainQuestRelationsOnConflictBuilder
         _where?.build();
       } catch (e) {
         throw new BuiltValueNestedFieldError(
-          r'GMainQuestRelationsOnConflict',
-          _$failedField,
-          e.toString(),
-        );
+            r'GMainQuestRelationsOnConflict', _$failedField, e.toString());
       }
       rethrow;
     }
@@ -11378,17 +8742,17 @@ class _$GMainQuestRelationsOrderBy extends GMainQuestRelationsOrderBy {
   @override
   final GOrderBy? parentQuestId;
 
-  factory _$GMainQuestRelationsOrderBy([
-    void Function(GMainQuestRelationsOrderByBuilder)? updates,
-  ]) => (new GMainQuestRelationsOrderByBuilder()..update(updates))._build();
+  factory _$GMainQuestRelationsOrderBy(
+          [void Function(GMainQuestRelationsOrderByBuilder)? updates]) =>
+      (new GMainQuestRelationsOrderByBuilder()..update(updates))._build();
 
   _$GMainQuestRelationsOrderBy._({this.childQuestId, this.parentQuestId})
-    : super._();
+      : super._();
 
   @override
   GMainQuestRelationsOrderBy rebuild(
-    void Function(GMainQuestRelationsOrderByBuilder) updates,
-  ) => (toBuilder()..update(updates)).build();
+          void Function(GMainQuestRelationsOrderByBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
 
   @override
   GMainQuestRelationsOrderByBuilder toBuilder() =>
@@ -11462,8 +8826,7 @@ class GMainQuestRelationsOrderByBuilder
   GMainQuestRelationsOrderBy build() => _build();
 
   _$GMainQuestRelationsOrderBy _build() {
-    final _$result =
-        _$v ??
+    final _$result = _$v ??
         new _$GMainQuestRelationsOrderBy._(
           childQuestId: childQuestId,
           parentQuestId: parentQuestId,
@@ -11480,31 +8843,24 @@ class _$GMainQuestRelationsPkColumnsInput
   @override
   final String parentQuestId;
 
-  factory _$GMainQuestRelationsPkColumnsInput([
-    void Function(GMainQuestRelationsPkColumnsInputBuilder)? updates,
-  ]) => (new GMainQuestRelationsPkColumnsInputBuilder()..update(updates))
-      ._build();
+  factory _$GMainQuestRelationsPkColumnsInput(
+          [void Function(GMainQuestRelationsPkColumnsInputBuilder)? updates]) =>
+      (new GMainQuestRelationsPkColumnsInputBuilder()..update(updates))
+          ._build();
 
-  _$GMainQuestRelationsPkColumnsInput._({
-    required this.childQuestId,
-    required this.parentQuestId,
-  }) : super._() {
+  _$GMainQuestRelationsPkColumnsInput._(
+      {required this.childQuestId, required this.parentQuestId})
+      : super._() {
     BuiltValueNullFieldError.checkNotNull(
-      childQuestId,
-      r'GMainQuestRelationsPkColumnsInput',
-      'childQuestId',
-    );
+        childQuestId, r'GMainQuestRelationsPkColumnsInput', 'childQuestId');
     BuiltValueNullFieldError.checkNotNull(
-      parentQuestId,
-      r'GMainQuestRelationsPkColumnsInput',
-      'parentQuestId',
-    );
+        parentQuestId, r'GMainQuestRelationsPkColumnsInput', 'parentQuestId');
   }
 
   @override
   GMainQuestRelationsPkColumnsInput rebuild(
-    void Function(GMainQuestRelationsPkColumnsInputBuilder) updates,
-  ) => (toBuilder()..update(updates)).build();
+          void Function(GMainQuestRelationsPkColumnsInputBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
 
   @override
   GMainQuestRelationsPkColumnsInputBuilder toBuilder() =>
@@ -11538,10 +8894,8 @@ class _$GMainQuestRelationsPkColumnsInput
 
 class GMainQuestRelationsPkColumnsInputBuilder
     implements
-        Builder<
-          GMainQuestRelationsPkColumnsInput,
-          GMainQuestRelationsPkColumnsInputBuilder
-        > {
+        Builder<GMainQuestRelationsPkColumnsInput,
+            GMainQuestRelationsPkColumnsInputBuilder> {
   _$GMainQuestRelationsPkColumnsInput? _$v;
 
   String? _childQuestId;
@@ -11573,8 +8927,7 @@ class GMainQuestRelationsPkColumnsInputBuilder
 
   @override
   void update(
-    void Function(GMainQuestRelationsPkColumnsInputBuilder)? updates,
-  ) {
+      void Function(GMainQuestRelationsPkColumnsInputBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
@@ -11582,19 +8935,12 @@ class GMainQuestRelationsPkColumnsInputBuilder
   GMainQuestRelationsPkColumnsInput build() => _build();
 
   _$GMainQuestRelationsPkColumnsInput _build() {
-    final _$result =
-        _$v ??
+    final _$result = _$v ??
         new _$GMainQuestRelationsPkColumnsInput._(
-          childQuestId: BuiltValueNullFieldError.checkNotNull(
-            childQuestId,
-            r'GMainQuestRelationsPkColumnsInput',
-            'childQuestId',
-          ),
-          parentQuestId: BuiltValueNullFieldError.checkNotNull(
-            parentQuestId,
-            r'GMainQuestRelationsPkColumnsInput',
-            'parentQuestId',
-          ),
+          childQuestId: BuiltValueNullFieldError.checkNotNull(childQuestId,
+              r'GMainQuestRelationsPkColumnsInput', 'childQuestId'),
+          parentQuestId: BuiltValueNullFieldError.checkNotNull(parentQuestId,
+              r'GMainQuestRelationsPkColumnsInput', 'parentQuestId'),
         );
     replace(_$result);
     return _$result;
@@ -11607,17 +8953,17 @@ class _$GMainQuestRelationsSetInput extends GMainQuestRelationsSetInput {
   @override
   final String? parentQuestId;
 
-  factory _$GMainQuestRelationsSetInput([
-    void Function(GMainQuestRelationsSetInputBuilder)? updates,
-  ]) => (new GMainQuestRelationsSetInputBuilder()..update(updates))._build();
+  factory _$GMainQuestRelationsSetInput(
+          [void Function(GMainQuestRelationsSetInputBuilder)? updates]) =>
+      (new GMainQuestRelationsSetInputBuilder()..update(updates))._build();
 
   _$GMainQuestRelationsSetInput._({this.childQuestId, this.parentQuestId})
-    : super._();
+      : super._();
 
   @override
   GMainQuestRelationsSetInput rebuild(
-    void Function(GMainQuestRelationsSetInputBuilder) updates,
-  ) => (toBuilder()..update(updates)).build();
+          void Function(GMainQuestRelationsSetInputBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
 
   @override
   GMainQuestRelationsSetInputBuilder toBuilder() =>
@@ -11651,10 +8997,8 @@ class _$GMainQuestRelationsSetInput extends GMainQuestRelationsSetInput {
 
 class GMainQuestRelationsSetInputBuilder
     implements
-        Builder<
-          GMainQuestRelationsSetInput,
-          GMainQuestRelationsSetInputBuilder
-        > {
+        Builder<GMainQuestRelationsSetInput,
+            GMainQuestRelationsSetInputBuilder> {
   _$GMainQuestRelationsSetInput? _$v;
 
   String? _childQuestId;
@@ -11693,8 +9037,7 @@ class GMainQuestRelationsSetInputBuilder
   GMainQuestRelationsSetInput build() => _build();
 
   _$GMainQuestRelationsSetInput _build() {
-    final _$result =
-        _$v ??
+    final _$result = _$v ??
         new _$GMainQuestRelationsSetInput._(
           childQuestId: childQuestId,
           parentQuestId: parentQuestId,
@@ -11711,26 +9054,23 @@ class _$GMainQuestRelationsStreamCursorInput
   @override
   final GCursorOrdering? ordering;
 
-  factory _$GMainQuestRelationsStreamCursorInput([
-    void Function(GMainQuestRelationsStreamCursorInputBuilder)? updates,
-  ]) => (new GMainQuestRelationsStreamCursorInputBuilder()..update(updates))
-      ._build();
+  factory _$GMainQuestRelationsStreamCursorInput(
+          [void Function(GMainQuestRelationsStreamCursorInputBuilder)?
+              updates]) =>
+      (new GMainQuestRelationsStreamCursorInputBuilder()..update(updates))
+          ._build();
 
-  _$GMainQuestRelationsStreamCursorInput._({
-    required this.initialValue,
-    this.ordering,
-  }) : super._() {
+  _$GMainQuestRelationsStreamCursorInput._(
+      {required this.initialValue, this.ordering})
+      : super._() {
     BuiltValueNullFieldError.checkNotNull(
-      initialValue,
-      r'GMainQuestRelationsStreamCursorInput',
-      'initialValue',
-    );
+        initialValue, r'GMainQuestRelationsStreamCursorInput', 'initialValue');
   }
 
   @override
   GMainQuestRelationsStreamCursorInput rebuild(
-    void Function(GMainQuestRelationsStreamCursorInputBuilder) updates,
-  ) => (toBuilder()..update(updates)).build();
+          void Function(GMainQuestRelationsStreamCursorInputBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
 
   @override
   GMainQuestRelationsStreamCursorInputBuilder toBuilder() =>
@@ -11764,10 +9104,8 @@ class _$GMainQuestRelationsStreamCursorInput
 
 class GMainQuestRelationsStreamCursorInputBuilder
     implements
-        Builder<
-          GMainQuestRelationsStreamCursorInput,
-          GMainQuestRelationsStreamCursorInputBuilder
-        > {
+        Builder<GMainQuestRelationsStreamCursorInput,
+            GMainQuestRelationsStreamCursorInputBuilder> {
   _$GMainQuestRelationsStreamCursorInput? _$v;
 
   GMainQuestRelationsStreamCursorValueInputBuilder? _initialValue;
@@ -11775,8 +9113,8 @@ class GMainQuestRelationsStreamCursorInputBuilder
       _$this._initialValue ??=
           new GMainQuestRelationsStreamCursorValueInputBuilder();
   set initialValue(
-    GMainQuestRelationsStreamCursorValueInputBuilder? initialValue,
-  ) => _$this._initialValue = initialValue;
+          GMainQuestRelationsStreamCursorValueInputBuilder? initialValue) =>
+      _$this._initialValue = initialValue;
 
   GCursorOrdering? _ordering;
   GCursorOrdering? get ordering => _$this._ordering;
@@ -11802,8 +9140,7 @@ class GMainQuestRelationsStreamCursorInputBuilder
 
   @override
   void update(
-    void Function(GMainQuestRelationsStreamCursorInputBuilder)? updates,
-  ) {
+      void Function(GMainQuestRelationsStreamCursorInputBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
@@ -11813,8 +9150,7 @@ class GMainQuestRelationsStreamCursorInputBuilder
   _$GMainQuestRelationsStreamCursorInput _build() {
     _$GMainQuestRelationsStreamCursorInput _$result;
     try {
-      _$result =
-          _$v ??
+      _$result = _$v ??
           new _$GMainQuestRelationsStreamCursorInput._(
             initialValue: initialValue.build(),
             ordering: ordering,
@@ -11826,10 +9162,9 @@ class GMainQuestRelationsStreamCursorInputBuilder
         initialValue.build();
       } catch (e) {
         throw new BuiltValueNestedFieldError(
-          r'GMainQuestRelationsStreamCursorInput',
-          _$failedField,
-          e.toString(),
-        );
+            r'GMainQuestRelationsStreamCursorInput',
+            _$failedField,
+            e.toString());
       }
       rethrow;
     }
@@ -11845,21 +9180,21 @@ class _$GMainQuestRelationsStreamCursorValueInput
   @override
   final String? parentQuestId;
 
-  factory _$GMainQuestRelationsStreamCursorValueInput([
-    void Function(GMainQuestRelationsStreamCursorValueInputBuilder)? updates,
-  ]) =>
+  factory _$GMainQuestRelationsStreamCursorValueInput(
+          [void Function(GMainQuestRelationsStreamCursorValueInputBuilder)?
+              updates]) =>
       (new GMainQuestRelationsStreamCursorValueInputBuilder()..update(updates))
           ._build();
 
-  _$GMainQuestRelationsStreamCursorValueInput._({
-    this.childQuestId,
-    this.parentQuestId,
-  }) : super._();
+  _$GMainQuestRelationsStreamCursorValueInput._(
+      {this.childQuestId, this.parentQuestId})
+      : super._();
 
   @override
   GMainQuestRelationsStreamCursorValueInput rebuild(
-    void Function(GMainQuestRelationsStreamCursorValueInputBuilder) updates,
-  ) => (toBuilder()..update(updates)).build();
+          void Function(GMainQuestRelationsStreamCursorValueInputBuilder)
+              updates) =>
+      (toBuilder()..update(updates)).build();
 
   @override
   GMainQuestRelationsStreamCursorValueInputBuilder toBuilder() =>
@@ -11885,8 +9220,7 @@ class _$GMainQuestRelationsStreamCursorValueInput
   @override
   String toString() {
     return (newBuiltValueToStringHelper(
-            r'GMainQuestRelationsStreamCursorValueInput',
-          )
+            r'GMainQuestRelationsStreamCursorValueInput')
           ..add('childQuestId', childQuestId)
           ..add('parentQuestId', parentQuestId))
         .toString();
@@ -11895,10 +9229,8 @@ class _$GMainQuestRelationsStreamCursorValueInput
 
 class GMainQuestRelationsStreamCursorValueInputBuilder
     implements
-        Builder<
-          GMainQuestRelationsStreamCursorValueInput,
-          GMainQuestRelationsStreamCursorValueInputBuilder
-        > {
+        Builder<GMainQuestRelationsStreamCursorValueInput,
+            GMainQuestRelationsStreamCursorValueInputBuilder> {
   _$GMainQuestRelationsStreamCursorValueInput? _$v;
 
   String? _childQuestId;
@@ -11930,8 +9262,8 @@ class GMainQuestRelationsStreamCursorValueInputBuilder
 
   @override
   void update(
-    void Function(GMainQuestRelationsStreamCursorValueInputBuilder)? updates,
-  ) {
+      void Function(GMainQuestRelationsStreamCursorValueInputBuilder)?
+          updates) {
     if (updates != null) updates(this);
   }
 
@@ -11939,8 +9271,7 @@ class GMainQuestRelationsStreamCursorValueInputBuilder
   GMainQuestRelationsStreamCursorValueInput build() => _build();
 
   _$GMainQuestRelationsStreamCursorValueInput _build() {
-    final _$result =
-        _$v ??
+    final _$result = _$v ??
         new _$GMainQuestRelationsStreamCursorValueInput._(
           childQuestId: childQuestId,
           parentQuestId: parentQuestId,
@@ -11956,23 +9287,20 @@ class _$GMainQuestRelationsUpdates extends GMainQuestRelationsUpdates {
   @override
   final GMainQuestRelationsBoolExp where;
 
-  factory _$GMainQuestRelationsUpdates([
-    void Function(GMainQuestRelationsUpdatesBuilder)? updates,
-  ]) => (new GMainQuestRelationsUpdatesBuilder()..update(updates))._build();
+  factory _$GMainQuestRelationsUpdates(
+          [void Function(GMainQuestRelationsUpdatesBuilder)? updates]) =>
+      (new GMainQuestRelationsUpdatesBuilder()..update(updates))._build();
 
   _$GMainQuestRelationsUpdates._({this.G_set, required this.where})
-    : super._() {
+      : super._() {
     BuiltValueNullFieldError.checkNotNull(
-      where,
-      r'GMainQuestRelationsUpdates',
-      'where',
-    );
+        where, r'GMainQuestRelationsUpdates', 'where');
   }
 
   @override
   GMainQuestRelationsUpdates rebuild(
-    void Function(GMainQuestRelationsUpdatesBuilder) updates,
-  ) => (toBuilder()..update(updates)).build();
+          void Function(GMainQuestRelationsUpdatesBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
 
   @override
   GMainQuestRelationsUpdatesBuilder toBuilder() =>
@@ -12048,8 +9376,7 @@ class GMainQuestRelationsUpdatesBuilder
   _$GMainQuestRelationsUpdates _build() {
     _$GMainQuestRelationsUpdates _$result;
     try {
-      _$result =
-          _$v ??
+      _$result = _$v ??
           new _$GMainQuestRelationsUpdates._(
             G_set: _G_set?.build(),
             where: where.build(),
@@ -12063,10 +9390,7 @@ class GMainQuestRelationsUpdatesBuilder
         where.build();
       } catch (e) {
         throw new BuiltValueNestedFieldError(
-          r'GMainQuestRelationsUpdates',
-          _$failedField,
-          e.toString(),
-        );
+            r'GMainQuestRelationsUpdates', _$failedField, e.toString());
       }
       rethrow;
     }
@@ -12109,33 +9433,33 @@ class _$GMainQuestsBoolExp extends GMainQuestsBoolExp {
   @override
   final GStringComparisonExp? userId;
 
-  factory _$GMainQuestsBoolExp([
-    void Function(GMainQuestsBoolExpBuilder)? updates,
-  ]) => (new GMainQuestsBoolExpBuilder()..update(updates))._build();
+  factory _$GMainQuestsBoolExp(
+          [void Function(GMainQuestsBoolExpBuilder)? updates]) =>
+      (new GMainQuestsBoolExpBuilder()..update(updates))._build();
 
-  _$GMainQuestsBoolExp._({
-    this.G_and,
-    this.G_not,
-    this.G_or,
-    this.begunAt,
-    this.categoryId,
-    this.coverImageUrl,
-    this.createdAt,
-    this.deletedAt,
-    this.description,
-    this.endedAt,
-    this.id,
-    this.note,
-    this.status,
-    this.title,
-    this.updatedAt,
-    this.userId,
-  }) : super._();
+  _$GMainQuestsBoolExp._(
+      {this.G_and,
+      this.G_not,
+      this.G_or,
+      this.begunAt,
+      this.categoryId,
+      this.coverImageUrl,
+      this.createdAt,
+      this.deletedAt,
+      this.description,
+      this.endedAt,
+      this.id,
+      this.note,
+      this.status,
+      this.title,
+      this.updatedAt,
+      this.userId})
+      : super._();
 
   @override
   GMainQuestsBoolExp rebuild(
-    void Function(GMainQuestsBoolExpBuilder) updates,
-  ) => (toBuilder()..update(updates)).build();
+          void Function(GMainQuestsBoolExpBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
 
   @override
   GMainQuestsBoolExpBuilder toBuilder() =>
@@ -12345,8 +9669,7 @@ class GMainQuestsBoolExpBuilder
   _$GMainQuestsBoolExp _build() {
     _$GMainQuestsBoolExp _$result;
     try {
-      _$result =
-          _$v ??
+      _$result = _$v ??
           new _$GMainQuestsBoolExp._(
             G_and: _G_and?.build(),
             G_not: _G_not?.build(),
@@ -12402,10 +9725,7 @@ class GMainQuestsBoolExpBuilder
         _userId?.build();
       } catch (e) {
         throw new BuiltValueNestedFieldError(
-          r'GMainQuestsBoolExp',
-          _$failedField,
-          e.toString(),
-        );
+            r'GMainQuestsBoolExp', _$failedField, e.toString());
       }
       rethrow;
     }
@@ -12442,30 +9762,30 @@ class _$GMainQuestsInsertInput extends GMainQuestsInsertInput {
   @override
   final String? userId;
 
-  factory _$GMainQuestsInsertInput([
-    void Function(GMainQuestsInsertInputBuilder)? updates,
-  ]) => (new GMainQuestsInsertInputBuilder()..update(updates))._build();
+  factory _$GMainQuestsInsertInput(
+          [void Function(GMainQuestsInsertInputBuilder)? updates]) =>
+      (new GMainQuestsInsertInputBuilder()..update(updates))._build();
 
-  _$GMainQuestsInsertInput._({
-    this.begunAt,
-    this.categoryId,
-    this.coverImageUrl,
-    this.createdAt,
-    this.deletedAt,
-    this.description,
-    this.endedAt,
-    this.id,
-    this.note,
-    this.status,
-    this.title,
-    this.updatedAt,
-    this.userId,
-  }) : super._();
+  _$GMainQuestsInsertInput._(
+      {this.begunAt,
+      this.categoryId,
+      this.coverImageUrl,
+      this.createdAt,
+      this.deletedAt,
+      this.description,
+      this.endedAt,
+      this.id,
+      this.note,
+      this.status,
+      this.title,
+      this.updatedAt,
+      this.userId})
+      : super._();
 
   @override
   GMainQuestsInsertInput rebuild(
-    void Function(GMainQuestsInsertInputBuilder) updates,
-  ) => (toBuilder()..update(updates)).build();
+          void Function(GMainQuestsInsertInputBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
 
   @override
   GMainQuestsInsertInputBuilder toBuilder() =>
@@ -12625,8 +9945,7 @@ class GMainQuestsInsertInputBuilder
   GMainQuestsInsertInput build() => _build();
 
   _$GMainQuestsInsertInput _build() {
-    final _$result =
-        _$v ??
+    final _$result = _$v ??
         new _$GMainQuestsInsertInput._(
           begunAt: begunAt,
           categoryId: categoryId,
@@ -12655,31 +9974,23 @@ class _$GMainQuestsOnConflict extends GMainQuestsOnConflict {
   @override
   final GMainQuestsBoolExp? where;
 
-  factory _$GMainQuestsOnConflict([
-    void Function(GMainQuestsOnConflictBuilder)? updates,
-  ]) => (new GMainQuestsOnConflictBuilder()..update(updates))._build();
+  factory _$GMainQuestsOnConflict(
+          [void Function(GMainQuestsOnConflictBuilder)? updates]) =>
+      (new GMainQuestsOnConflictBuilder()..update(updates))._build();
 
-  _$GMainQuestsOnConflict._({
-    required this.constraint,
-    required this.updateColumns,
-    this.where,
-  }) : super._() {
+  _$GMainQuestsOnConflict._(
+      {required this.constraint, required this.updateColumns, this.where})
+      : super._() {
     BuiltValueNullFieldError.checkNotNull(
-      constraint,
-      r'GMainQuestsOnConflict',
-      'constraint',
-    );
+        constraint, r'GMainQuestsOnConflict', 'constraint');
     BuiltValueNullFieldError.checkNotNull(
-      updateColumns,
-      r'GMainQuestsOnConflict',
-      'updateColumns',
-    );
+        updateColumns, r'GMainQuestsOnConflict', 'updateColumns');
   }
 
   @override
   GMainQuestsOnConflict rebuild(
-    void Function(GMainQuestsOnConflictBuilder) updates,
-  ) => (toBuilder()..update(updates)).build();
+          void Function(GMainQuestsOnConflictBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
 
   @override
   GMainQuestsOnConflictBuilder toBuilder() =>
@@ -12764,14 +10075,10 @@ class GMainQuestsOnConflictBuilder
   _$GMainQuestsOnConflict _build() {
     _$GMainQuestsOnConflict _$result;
     try {
-      _$result =
-          _$v ??
+      _$result = _$v ??
           new _$GMainQuestsOnConflict._(
             constraint: BuiltValueNullFieldError.checkNotNull(
-              constraint,
-              r'GMainQuestsOnConflict',
-              'constraint',
-            ),
+                constraint, r'GMainQuestsOnConflict', 'constraint'),
             updateColumns: updateColumns.build(),
             where: _where?.build(),
           );
@@ -12784,10 +10091,7 @@ class GMainQuestsOnConflictBuilder
         _where?.build();
       } catch (e) {
         throw new BuiltValueNestedFieldError(
-          r'GMainQuestsOnConflict',
-          _$failedField,
-          e.toString(),
-        );
+            r'GMainQuestsOnConflict', _$failedField, e.toString());
       }
       rethrow;
     }
@@ -12824,30 +10128,30 @@ class _$GMainQuestsOrderBy extends GMainQuestsOrderBy {
   @override
   final GOrderBy? userId;
 
-  factory _$GMainQuestsOrderBy([
-    void Function(GMainQuestsOrderByBuilder)? updates,
-  ]) => (new GMainQuestsOrderByBuilder()..update(updates))._build();
+  factory _$GMainQuestsOrderBy(
+          [void Function(GMainQuestsOrderByBuilder)? updates]) =>
+      (new GMainQuestsOrderByBuilder()..update(updates))._build();
 
-  _$GMainQuestsOrderBy._({
-    this.begunAt,
-    this.categoryId,
-    this.coverImageUrl,
-    this.createdAt,
-    this.deletedAt,
-    this.description,
-    this.endedAt,
-    this.id,
-    this.note,
-    this.status,
-    this.title,
-    this.updatedAt,
-    this.userId,
-  }) : super._();
+  _$GMainQuestsOrderBy._(
+      {this.begunAt,
+      this.categoryId,
+      this.coverImageUrl,
+      this.createdAt,
+      this.deletedAt,
+      this.description,
+      this.endedAt,
+      this.id,
+      this.note,
+      this.status,
+      this.title,
+      this.updatedAt,
+      this.userId})
+      : super._();
 
   @override
   GMainQuestsOrderBy rebuild(
-    void Function(GMainQuestsOrderByBuilder) updates,
-  ) => (toBuilder()..update(updates)).build();
+          void Function(GMainQuestsOrderByBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
 
   @override
   GMainQuestsOrderByBuilder toBuilder() =>
@@ -13007,8 +10311,7 @@ class GMainQuestsOrderByBuilder
   GMainQuestsOrderBy build() => _build();
 
   _$GMainQuestsOrderBy _build() {
-    final _$result =
-        _$v ??
+    final _$result = _$v ??
         new _$GMainQuestsOrderBy._(
           begunAt: begunAt,
           categoryId: categoryId,
@@ -13033,22 +10336,19 @@ class _$GMainQuestsPkColumnsInput extends GMainQuestsPkColumnsInput {
   @override
   final String id;
 
-  factory _$GMainQuestsPkColumnsInput([
-    void Function(GMainQuestsPkColumnsInputBuilder)? updates,
-  ]) => (new GMainQuestsPkColumnsInputBuilder()..update(updates))._build();
+  factory _$GMainQuestsPkColumnsInput(
+          [void Function(GMainQuestsPkColumnsInputBuilder)? updates]) =>
+      (new GMainQuestsPkColumnsInputBuilder()..update(updates))._build();
 
   _$GMainQuestsPkColumnsInput._({required this.id}) : super._() {
     BuiltValueNullFieldError.checkNotNull(
-      id,
-      r'GMainQuestsPkColumnsInput',
-      'id',
-    );
+        id, r'GMainQuestsPkColumnsInput', 'id');
   }
 
   @override
   GMainQuestsPkColumnsInput rebuild(
-    void Function(GMainQuestsPkColumnsInputBuilder) updates,
-  ) => (toBuilder()..update(updates)).build();
+          void Function(GMainQuestsPkColumnsInputBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
 
   @override
   GMainQuestsPkColumnsInputBuilder toBuilder() =>
@@ -13070,9 +10370,9 @@ class _$GMainQuestsPkColumnsInput extends GMainQuestsPkColumnsInput {
 
   @override
   String toString() {
-    return (newBuiltValueToStringHelper(
-      r'GMainQuestsPkColumnsInput',
-    )..add('id', id)).toString();
+    return (newBuiltValueToStringHelper(r'GMainQuestsPkColumnsInput')
+          ..add('id', id))
+        .toString();
   }
 }
 
@@ -13111,14 +10411,10 @@ class GMainQuestsPkColumnsInputBuilder
   GMainQuestsPkColumnsInput build() => _build();
 
   _$GMainQuestsPkColumnsInput _build() {
-    final _$result =
-        _$v ??
+    final _$result = _$v ??
         new _$GMainQuestsPkColumnsInput._(
           id: BuiltValueNullFieldError.checkNotNull(
-            id,
-            r'GMainQuestsPkColumnsInput',
-            'id',
-          ),
+              id, r'GMainQuestsPkColumnsInput', 'id'),
         );
     replace(_$result);
     return _$result;
@@ -13153,30 +10449,30 @@ class _$GMainQuestsSetInput extends GMainQuestsSetInput {
   @override
   final String? userId;
 
-  factory _$GMainQuestsSetInput([
-    void Function(GMainQuestsSetInputBuilder)? updates,
-  ]) => (new GMainQuestsSetInputBuilder()..update(updates))._build();
+  factory _$GMainQuestsSetInput(
+          [void Function(GMainQuestsSetInputBuilder)? updates]) =>
+      (new GMainQuestsSetInputBuilder()..update(updates))._build();
 
-  _$GMainQuestsSetInput._({
-    this.begunAt,
-    this.categoryId,
-    this.coverImageUrl,
-    this.createdAt,
-    this.deletedAt,
-    this.description,
-    this.endedAt,
-    this.id,
-    this.note,
-    this.status,
-    this.title,
-    this.updatedAt,
-    this.userId,
-  }) : super._();
+  _$GMainQuestsSetInput._(
+      {this.begunAt,
+      this.categoryId,
+      this.coverImageUrl,
+      this.createdAt,
+      this.deletedAt,
+      this.description,
+      this.endedAt,
+      this.id,
+      this.note,
+      this.status,
+      this.title,
+      this.updatedAt,
+      this.userId})
+      : super._();
 
   @override
   GMainQuestsSetInput rebuild(
-    void Function(GMainQuestsSetInputBuilder) updates,
-  ) => (toBuilder()..update(updates)).build();
+          void Function(GMainQuestsSetInputBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
 
   @override
   GMainQuestsSetInputBuilder toBuilder() =>
@@ -13336,8 +10632,7 @@ class GMainQuestsSetInputBuilder
   GMainQuestsSetInput build() => _build();
 
   _$GMainQuestsSetInput _build() {
-    final _$result =
-        _$v ??
+    final _$result = _$v ??
         new _$GMainQuestsSetInput._(
           begunAt: begunAt,
           categoryId: categoryId,
@@ -13364,23 +10659,20 @@ class _$GMainQuestsStreamCursorInput extends GMainQuestsStreamCursorInput {
   @override
   final GCursorOrdering? ordering;
 
-  factory _$GMainQuestsStreamCursorInput([
-    void Function(GMainQuestsStreamCursorInputBuilder)? updates,
-  ]) => (new GMainQuestsStreamCursorInputBuilder()..update(updates))._build();
+  factory _$GMainQuestsStreamCursorInput(
+          [void Function(GMainQuestsStreamCursorInputBuilder)? updates]) =>
+      (new GMainQuestsStreamCursorInputBuilder()..update(updates))._build();
 
   _$GMainQuestsStreamCursorInput._({required this.initialValue, this.ordering})
-    : super._() {
+      : super._() {
     BuiltValueNullFieldError.checkNotNull(
-      initialValue,
-      r'GMainQuestsStreamCursorInput',
-      'initialValue',
-    );
+        initialValue, r'GMainQuestsStreamCursorInput', 'initialValue');
   }
 
   @override
   GMainQuestsStreamCursorInput rebuild(
-    void Function(GMainQuestsStreamCursorInputBuilder) updates,
-  ) => (toBuilder()..update(updates)).build();
+          void Function(GMainQuestsStreamCursorInputBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
 
   @override
   GMainQuestsStreamCursorInputBuilder toBuilder() =>
@@ -13414,10 +10706,8 @@ class _$GMainQuestsStreamCursorInput extends GMainQuestsStreamCursorInput {
 
 class GMainQuestsStreamCursorInputBuilder
     implements
-        Builder<
-          GMainQuestsStreamCursorInput,
-          GMainQuestsStreamCursorInputBuilder
-        > {
+        Builder<GMainQuestsStreamCursorInput,
+            GMainQuestsStreamCursorInputBuilder> {
   _$GMainQuestsStreamCursorInput? _$v;
 
   GMainQuestsStreamCursorValueInputBuilder? _initialValue;
@@ -13459,8 +10749,7 @@ class GMainQuestsStreamCursorInputBuilder
   _$GMainQuestsStreamCursorInput _build() {
     _$GMainQuestsStreamCursorInput _$result;
     try {
-      _$result =
-          _$v ??
+      _$result = _$v ??
           new _$GMainQuestsStreamCursorInput._(
             initialValue: initialValue.build(),
             ordering: ordering,
@@ -13472,10 +10761,7 @@ class GMainQuestsStreamCursorInputBuilder
         initialValue.build();
       } catch (e) {
         throw new BuiltValueNestedFieldError(
-          r'GMainQuestsStreamCursorInput',
-          _$failedField,
-          e.toString(),
-        );
+            r'GMainQuestsStreamCursorInput', _$failedField, e.toString());
       }
       rethrow;
     }
@@ -13513,31 +10799,31 @@ class _$GMainQuestsStreamCursorValueInput
   @override
   final String? userId;
 
-  factory _$GMainQuestsStreamCursorValueInput([
-    void Function(GMainQuestsStreamCursorValueInputBuilder)? updates,
-  ]) => (new GMainQuestsStreamCursorValueInputBuilder()..update(updates))
-      ._build();
+  factory _$GMainQuestsStreamCursorValueInput(
+          [void Function(GMainQuestsStreamCursorValueInputBuilder)? updates]) =>
+      (new GMainQuestsStreamCursorValueInputBuilder()..update(updates))
+          ._build();
 
-  _$GMainQuestsStreamCursorValueInput._({
-    this.begunAt,
-    this.categoryId,
-    this.coverImageUrl,
-    this.createdAt,
-    this.deletedAt,
-    this.description,
-    this.endedAt,
-    this.id,
-    this.note,
-    this.status,
-    this.title,
-    this.updatedAt,
-    this.userId,
-  }) : super._();
+  _$GMainQuestsStreamCursorValueInput._(
+      {this.begunAt,
+      this.categoryId,
+      this.coverImageUrl,
+      this.createdAt,
+      this.deletedAt,
+      this.description,
+      this.endedAt,
+      this.id,
+      this.note,
+      this.status,
+      this.title,
+      this.updatedAt,
+      this.userId})
+      : super._();
 
   @override
   GMainQuestsStreamCursorValueInput rebuild(
-    void Function(GMainQuestsStreamCursorValueInputBuilder) updates,
-  ) => (toBuilder()..update(updates)).build();
+          void Function(GMainQuestsStreamCursorValueInputBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
 
   @override
   GMainQuestsStreamCursorValueInputBuilder toBuilder() =>
@@ -13604,10 +10890,8 @@ class _$GMainQuestsStreamCursorValueInput
 
 class GMainQuestsStreamCursorValueInputBuilder
     implements
-        Builder<
-          GMainQuestsStreamCursorValueInput,
-          GMainQuestsStreamCursorValueInputBuilder
-        > {
+        Builder<GMainQuestsStreamCursorValueInput,
+            GMainQuestsStreamCursorValueInputBuilder> {
   _$GMainQuestsStreamCursorValueInput? _$v;
 
   DateTime? _begunAt;
@@ -13694,8 +10978,7 @@ class GMainQuestsStreamCursorValueInputBuilder
 
   @override
   void update(
-    void Function(GMainQuestsStreamCursorValueInputBuilder)? updates,
-  ) {
+      void Function(GMainQuestsStreamCursorValueInputBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
@@ -13703,8 +10986,7 @@ class GMainQuestsStreamCursorValueInputBuilder
   GMainQuestsStreamCursorValueInput build() => _build();
 
   _$GMainQuestsStreamCursorValueInput _build() {
-    final _$result =
-        _$v ??
+    final _$result = _$v ??
         new _$GMainQuestsStreamCursorValueInput._(
           begunAt: begunAt,
           categoryId: categoryId,
@@ -13731,22 +11013,19 @@ class _$GMainQuestsUpdates extends GMainQuestsUpdates {
   @override
   final GMainQuestsBoolExp where;
 
-  factory _$GMainQuestsUpdates([
-    void Function(GMainQuestsUpdatesBuilder)? updates,
-  ]) => (new GMainQuestsUpdatesBuilder()..update(updates))._build();
+  factory _$GMainQuestsUpdates(
+          [void Function(GMainQuestsUpdatesBuilder)? updates]) =>
+      (new GMainQuestsUpdatesBuilder()..update(updates))._build();
 
   _$GMainQuestsUpdates._({this.G_set, required this.where}) : super._() {
     BuiltValueNullFieldError.checkNotNull(
-      where,
-      r'GMainQuestsUpdates',
-      'where',
-    );
+        where, r'GMainQuestsUpdates', 'where');
   }
 
   @override
   GMainQuestsUpdates rebuild(
-    void Function(GMainQuestsUpdatesBuilder) updates,
-  ) => (toBuilder()..update(updates)).build();
+          void Function(GMainQuestsUpdatesBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
 
   @override
   GMainQuestsUpdatesBuilder toBuilder() =>
@@ -13821,8 +11100,7 @@ class GMainQuestsUpdatesBuilder
   _$GMainQuestsUpdates _build() {
     _$GMainQuestsUpdates _$result;
     try {
-      _$result =
-          _$v ??
+      _$result = _$v ??
           new _$GMainQuestsUpdates._(
             G_set: _G_set?.build(),
             where: where.build(),
@@ -13836,10 +11114,7 @@ class GMainQuestsUpdatesBuilder
         where.build();
       } catch (e) {
         throw new BuiltValueNestedFieldError(
-          r'GMainQuestsUpdates',
-          _$failedField,
-          e.toString(),
-        );
+            r'GMainQuestsUpdates', _$failedField, e.toString());
       }
       rethrow;
     }
@@ -13881,22 +11156,22 @@ class _$GNewsBoolExp extends GNewsBoolExp {
   factory _$GNewsBoolExp([void Function(GNewsBoolExpBuilder)? updates]) =>
       (new GNewsBoolExpBuilder()..update(updates))._build();
 
-  _$GNewsBoolExp._({
-    this.G_and,
-    this.G_not,
-    this.G_or,
-    this.content,
-    this.coverImageUrl,
-    this.createdAt,
-    this.excerpt,
-    this.id,
-    this.publishedAt,
-    this.seo,
-    this.seoId,
-    this.slug,
-    this.title,
-    this.updatedAt,
-  }) : super._();
+  _$GNewsBoolExp._(
+      {this.G_and,
+      this.G_not,
+      this.G_or,
+      this.content,
+      this.coverImageUrl,
+      this.createdAt,
+      this.excerpt,
+      this.id,
+      this.publishedAt,
+      this.seo,
+      this.seoId,
+      this.slug,
+      this.title,
+      this.updatedAt})
+      : super._();
 
   @override
   GNewsBoolExp rebuild(void Function(GNewsBoolExpBuilder) updates) =>
@@ -14086,8 +11361,7 @@ class GNewsBoolExpBuilder
   _$GNewsBoolExp _build() {
     _$GNewsBoolExp _$result;
     try {
-      _$result =
-          _$v ??
+      _$result = _$v ??
           new _$GNewsBoolExp._(
             G_and: _G_and?.build(),
             G_not: _G_not?.build(),
@@ -14137,10 +11411,7 @@ class GNewsBoolExpBuilder
         _updatedAt?.build();
       } catch (e) {
         throw new BuiltValueNestedFieldError(
-          r'GNewsBoolExp',
-          _$failedField,
-          e.toString(),
-        );
+            r'GNewsBoolExp', _$failedField, e.toString());
       }
       rethrow;
     }
@@ -14176,19 +11447,19 @@ class _$GNewsOrderBy extends GNewsOrderBy {
   factory _$GNewsOrderBy([void Function(GNewsOrderByBuilder)? updates]) =>
       (new GNewsOrderByBuilder()..update(updates))._build();
 
-  _$GNewsOrderBy._({
-    this.content,
-    this.coverImageUrl,
-    this.createdAt,
-    this.excerpt,
-    this.id,
-    this.publishedAt,
-    this.seo,
-    this.seoId,
-    this.slug,
-    this.title,
-    this.updatedAt,
-  }) : super._();
+  _$GNewsOrderBy._(
+      {this.content,
+      this.coverImageUrl,
+      this.createdAt,
+      this.excerpt,
+      this.id,
+      this.publishedAt,
+      this.seo,
+      this.seoId,
+      this.slug,
+      this.title,
+      this.updatedAt})
+      : super._();
 
   @override
   GNewsOrderBy rebuild(void Function(GNewsOrderByBuilder) updates) =>
@@ -14337,8 +11608,7 @@ class GNewsOrderByBuilder
   _$GNewsOrderBy _build() {
     _$GNewsOrderBy _$result;
     try {
-      _$result =
-          _$v ??
+      _$result = _$v ??
           new _$GNewsOrderBy._(
             content: content,
             coverImageUrl: coverImageUrl,
@@ -14359,10 +11629,7 @@ class GNewsOrderByBuilder
         _seo?.build();
       } catch (e) {
         throw new BuiltValueNestedFieldError(
-          r'GNewsOrderBy',
-          _$failedField,
-          e.toString(),
-        );
+            r'GNewsOrderBy', _$failedField, e.toString());
       }
       rethrow;
     }
@@ -14377,23 +11644,20 @@ class _$GNewsStreamCursorInput extends GNewsStreamCursorInput {
   @override
   final GCursorOrdering? ordering;
 
-  factory _$GNewsStreamCursorInput([
-    void Function(GNewsStreamCursorInputBuilder)? updates,
-  ]) => (new GNewsStreamCursorInputBuilder()..update(updates))._build();
+  factory _$GNewsStreamCursorInput(
+          [void Function(GNewsStreamCursorInputBuilder)? updates]) =>
+      (new GNewsStreamCursorInputBuilder()..update(updates))._build();
 
   _$GNewsStreamCursorInput._({required this.initialValue, this.ordering})
-    : super._() {
+      : super._() {
     BuiltValueNullFieldError.checkNotNull(
-      initialValue,
-      r'GNewsStreamCursorInput',
-      'initialValue',
-    );
+        initialValue, r'GNewsStreamCursorInput', 'initialValue');
   }
 
   @override
   GNewsStreamCursorInput rebuild(
-    void Function(GNewsStreamCursorInputBuilder) updates,
-  ) => (toBuilder()..update(updates)).build();
+          void Function(GNewsStreamCursorInputBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
 
   @override
   GNewsStreamCursorInputBuilder toBuilder() =>
@@ -14468,8 +11732,7 @@ class GNewsStreamCursorInputBuilder
   _$GNewsStreamCursorInput _build() {
     _$GNewsStreamCursorInput _$result;
     try {
-      _$result =
-          _$v ??
+      _$result = _$v ??
           new _$GNewsStreamCursorInput._(
             initialValue: initialValue.build(),
             ordering: ordering,
@@ -14481,10 +11744,7 @@ class GNewsStreamCursorInputBuilder
         initialValue.build();
       } catch (e) {
         throw new BuiltValueNestedFieldError(
-          r'GNewsStreamCursorInput',
-          _$failedField,
-          e.toString(),
-        );
+            r'GNewsStreamCursorInput', _$failedField, e.toString());
       }
       rethrow;
     }
@@ -14515,27 +11775,27 @@ class _$GNewsStreamCursorValueInput extends GNewsStreamCursorValueInput {
   @override
   final DateTime? updatedAt;
 
-  factory _$GNewsStreamCursorValueInput([
-    void Function(GNewsStreamCursorValueInputBuilder)? updates,
-  ]) => (new GNewsStreamCursorValueInputBuilder()..update(updates))._build();
+  factory _$GNewsStreamCursorValueInput(
+          [void Function(GNewsStreamCursorValueInputBuilder)? updates]) =>
+      (new GNewsStreamCursorValueInputBuilder()..update(updates))._build();
 
-  _$GNewsStreamCursorValueInput._({
-    this.content,
-    this.coverImageUrl,
-    this.createdAt,
-    this.excerpt,
-    this.id,
-    this.publishedAt,
-    this.seoId,
-    this.slug,
-    this.title,
-    this.updatedAt,
-  }) : super._();
+  _$GNewsStreamCursorValueInput._(
+      {this.content,
+      this.coverImageUrl,
+      this.createdAt,
+      this.excerpt,
+      this.id,
+      this.publishedAt,
+      this.seoId,
+      this.slug,
+      this.title,
+      this.updatedAt})
+      : super._();
 
   @override
   GNewsStreamCursorValueInput rebuild(
-    void Function(GNewsStreamCursorValueInputBuilder) updates,
-  ) => (toBuilder()..update(updates)).build();
+          void Function(GNewsStreamCursorValueInputBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
 
   @override
   GNewsStreamCursorValueInputBuilder toBuilder() =>
@@ -14593,10 +11853,8 @@ class _$GNewsStreamCursorValueInput extends GNewsStreamCursorValueInput {
 
 class GNewsStreamCursorValueInputBuilder
     implements
-        Builder<
-          GNewsStreamCursorValueInput,
-          GNewsStreamCursorValueInputBuilder
-        > {
+        Builder<GNewsStreamCursorValueInput,
+            GNewsStreamCursorValueInputBuilder> {
   _$GNewsStreamCursorValueInput? _$v;
 
   String? _content;
@@ -14675,8 +11933,7 @@ class GNewsStreamCursorValueInputBuilder
   GNewsStreamCursorValueInput build() => _build();
 
   _$GNewsStreamCursorValueInput _build() {
-    final _$result =
-        _$v ??
+    final _$result = _$v ??
         new _$GNewsStreamCursorValueInput._(
           content: content,
           coverImageUrl: coverImageUrl,
@@ -14722,30 +11979,30 @@ class _$GNotificationsBoolExp extends GNotificationsBoolExp {
   @override
   final GStringComparisonExp? userId;
 
-  factory _$GNotificationsBoolExp([
-    void Function(GNotificationsBoolExpBuilder)? updates,
-  ]) => (new GNotificationsBoolExpBuilder()..update(updates))._build();
+  factory _$GNotificationsBoolExp(
+          [void Function(GNotificationsBoolExpBuilder)? updates]) =>
+      (new GNotificationsBoolExpBuilder()..update(updates))._build();
 
-  _$GNotificationsBoolExp._({
-    this.G_and,
-    this.G_not,
-    this.G_or,
-    this.content,
-    this.coverImageUrl,
-    this.createdAt,
-    this.excerpt,
-    this.firstOpenedAt,
-    this.id,
-    this.publishedAt,
-    this.title,
-    this.updatedAt,
-    this.userId,
-  }) : super._();
+  _$GNotificationsBoolExp._(
+      {this.G_and,
+      this.G_not,
+      this.G_or,
+      this.content,
+      this.coverImageUrl,
+      this.createdAt,
+      this.excerpt,
+      this.firstOpenedAt,
+      this.id,
+      this.publishedAt,
+      this.title,
+      this.updatedAt,
+      this.userId})
+      : super._();
 
   @override
   GNotificationsBoolExp rebuild(
-    void Function(GNotificationsBoolExpBuilder) updates,
-  ) => (toBuilder()..update(updates)).build();
+          void Function(GNotificationsBoolExpBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
 
   @override
   GNotificationsBoolExpBuilder toBuilder() =>
@@ -14926,8 +12183,7 @@ class GNotificationsBoolExpBuilder
   _$GNotificationsBoolExp _build() {
     _$GNotificationsBoolExp _$result;
     try {
-      _$result =
-          _$v ??
+      _$result = _$v ??
           new _$GNotificationsBoolExp._(
             G_and: _G_and?.build(),
             G_not: _G_not?.build(),
@@ -14974,10 +12230,7 @@ class GNotificationsBoolExpBuilder
         _userId?.build();
       } catch (e) {
         throw new BuiltValueNestedFieldError(
-          r'GNotificationsBoolExp',
-          _$failedField,
-          e.toString(),
-        );
+            r'GNotificationsBoolExp', _$failedField, e.toString());
       }
       rethrow;
     }
@@ -15008,27 +12261,27 @@ class _$GNotificationsOrderBy extends GNotificationsOrderBy {
   @override
   final GOrderBy? userId;
 
-  factory _$GNotificationsOrderBy([
-    void Function(GNotificationsOrderByBuilder)? updates,
-  ]) => (new GNotificationsOrderByBuilder()..update(updates))._build();
+  factory _$GNotificationsOrderBy(
+          [void Function(GNotificationsOrderByBuilder)? updates]) =>
+      (new GNotificationsOrderByBuilder()..update(updates))._build();
 
-  _$GNotificationsOrderBy._({
-    this.content,
-    this.coverImageUrl,
-    this.createdAt,
-    this.excerpt,
-    this.firstOpenedAt,
-    this.id,
-    this.publishedAt,
-    this.title,
-    this.updatedAt,
-    this.userId,
-  }) : super._();
+  _$GNotificationsOrderBy._(
+      {this.content,
+      this.coverImageUrl,
+      this.createdAt,
+      this.excerpt,
+      this.firstOpenedAt,
+      this.id,
+      this.publishedAt,
+      this.title,
+      this.updatedAt,
+      this.userId})
+      : super._();
 
   @override
   GNotificationsOrderBy rebuild(
-    void Function(GNotificationsOrderByBuilder) updates,
-  ) => (toBuilder()..update(updates)).build();
+          void Function(GNotificationsOrderByBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
 
   @override
   GNotificationsOrderByBuilder toBuilder() =>
@@ -15165,8 +12418,7 @@ class GNotificationsOrderByBuilder
   GNotificationsOrderBy build() => _build();
 
   _$GNotificationsOrderBy _build() {
-    final _$result =
-        _$v ??
+    final _$result = _$v ??
         new _$GNotificationsOrderBy._(
           content: content,
           coverImageUrl: coverImageUrl,
@@ -15191,26 +12443,21 @@ class _$GNotificationsStreamCursorInput
   @override
   final GCursorOrdering? ordering;
 
-  factory _$GNotificationsStreamCursorInput([
-    void Function(GNotificationsStreamCursorInputBuilder)? updates,
-  ]) =>
+  factory _$GNotificationsStreamCursorInput(
+          [void Function(GNotificationsStreamCursorInputBuilder)? updates]) =>
       (new GNotificationsStreamCursorInputBuilder()..update(updates))._build();
 
-  _$GNotificationsStreamCursorInput._({
-    required this.initialValue,
-    this.ordering,
-  }) : super._() {
+  _$GNotificationsStreamCursorInput._(
+      {required this.initialValue, this.ordering})
+      : super._() {
     BuiltValueNullFieldError.checkNotNull(
-      initialValue,
-      r'GNotificationsStreamCursorInput',
-      'initialValue',
-    );
+        initialValue, r'GNotificationsStreamCursorInput', 'initialValue');
   }
 
   @override
   GNotificationsStreamCursorInput rebuild(
-    void Function(GNotificationsStreamCursorInputBuilder) updates,
-  ) => (toBuilder()..update(updates)).build();
+          void Function(GNotificationsStreamCursorInputBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
 
   @override
   GNotificationsStreamCursorInputBuilder toBuilder() =>
@@ -15244,10 +12491,8 @@ class _$GNotificationsStreamCursorInput
 
 class GNotificationsStreamCursorInputBuilder
     implements
-        Builder<
-          GNotificationsStreamCursorInput,
-          GNotificationsStreamCursorInputBuilder
-        > {
+        Builder<GNotificationsStreamCursorInput,
+            GNotificationsStreamCursorInputBuilder> {
   _$GNotificationsStreamCursorInput? _$v;
 
   GNotificationsStreamCursorValueInputBuilder? _initialValue;
@@ -15290,8 +12535,7 @@ class GNotificationsStreamCursorInputBuilder
   _$GNotificationsStreamCursorInput _build() {
     _$GNotificationsStreamCursorInput _$result;
     try {
-      _$result =
-          _$v ??
+      _$result = _$v ??
           new _$GNotificationsStreamCursorInput._(
             initialValue: initialValue.build(),
             ordering: ordering,
@@ -15303,10 +12547,7 @@ class GNotificationsStreamCursorInputBuilder
         initialValue.build();
       } catch (e) {
         throw new BuiltValueNestedFieldError(
-          r'GNotificationsStreamCursorInput',
-          _$failedField,
-          e.toString(),
-        );
+            r'GNotificationsStreamCursorInput', _$failedField, e.toString());
       }
       rethrow;
     }
@@ -15338,28 +12579,29 @@ class _$GNotificationsStreamCursorValueInput
   @override
   final String? userId;
 
-  factory _$GNotificationsStreamCursorValueInput([
-    void Function(GNotificationsStreamCursorValueInputBuilder)? updates,
-  ]) => (new GNotificationsStreamCursorValueInputBuilder()..update(updates))
-      ._build();
+  factory _$GNotificationsStreamCursorValueInput(
+          [void Function(GNotificationsStreamCursorValueInputBuilder)?
+              updates]) =>
+      (new GNotificationsStreamCursorValueInputBuilder()..update(updates))
+          ._build();
 
-  _$GNotificationsStreamCursorValueInput._({
-    this.content,
-    this.coverImageUrl,
-    this.createdAt,
-    this.excerpt,
-    this.firstOpenedAt,
-    this.id,
-    this.publishedAt,
-    this.title,
-    this.updatedAt,
-    this.userId,
-  }) : super._();
+  _$GNotificationsStreamCursorValueInput._(
+      {this.content,
+      this.coverImageUrl,
+      this.createdAt,
+      this.excerpt,
+      this.firstOpenedAt,
+      this.id,
+      this.publishedAt,
+      this.title,
+      this.updatedAt,
+      this.userId})
+      : super._();
 
   @override
   GNotificationsStreamCursorValueInput rebuild(
-    void Function(GNotificationsStreamCursorValueInputBuilder) updates,
-  ) => (toBuilder()..update(updates)).build();
+          void Function(GNotificationsStreamCursorValueInputBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
 
   @override
   GNotificationsStreamCursorValueInputBuilder toBuilder() =>
@@ -15417,10 +12659,8 @@ class _$GNotificationsStreamCursorValueInput
 
 class GNotificationsStreamCursorValueInputBuilder
     implements
-        Builder<
-          GNotificationsStreamCursorValueInput,
-          GNotificationsStreamCursorValueInputBuilder
-        > {
+        Builder<GNotificationsStreamCursorValueInput,
+            GNotificationsStreamCursorValueInputBuilder> {
   _$GNotificationsStreamCursorValueInput? _$v;
 
   String? _content;
@@ -15493,8 +12733,7 @@ class GNotificationsStreamCursorValueInputBuilder
 
   @override
   void update(
-    void Function(GNotificationsStreamCursorValueInputBuilder)? updates,
-  ) {
+      void Function(GNotificationsStreamCursorValueInputBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
@@ -15502,8 +12741,7 @@ class GNotificationsStreamCursorValueInputBuilder
   GNotificationsStreamCursorValueInput build() => _build();
 
   _$GNotificationsStreamCursorValueInput _build() {
-    final _$result =
-        _$v ??
+    final _$result = _$v ??
         new _$GNotificationsStreamCursorValueInput._(
           content: content,
           coverImageUrl: coverImageUrl,
@@ -15541,26 +12779,26 @@ class _$GQuestCategoriesBoolExp extends GQuestCategoriesBoolExp {
   @override
   final GTimestamptzComparisonExp? updatedAt;
 
-  factory _$GQuestCategoriesBoolExp([
-    void Function(GQuestCategoriesBoolExpBuilder)? updates,
-  ]) => (new GQuestCategoriesBoolExpBuilder()..update(updates))._build();
+  factory _$GQuestCategoriesBoolExp(
+          [void Function(GQuestCategoriesBoolExpBuilder)? updates]) =>
+      (new GQuestCategoriesBoolExpBuilder()..update(updates))._build();
 
-  _$GQuestCategoriesBoolExp._({
-    this.G_and,
-    this.G_not,
-    this.G_or,
-    this.createdAt,
-    this.description,
-    this.id,
-    this.name,
-    this.sortNumber,
-    this.updatedAt,
-  }) : super._();
+  _$GQuestCategoriesBoolExp._(
+      {this.G_and,
+      this.G_not,
+      this.G_or,
+      this.createdAt,
+      this.description,
+      this.id,
+      this.name,
+      this.sortNumber,
+      this.updatedAt})
+      : super._();
 
   @override
   GQuestCategoriesBoolExp rebuild(
-    void Function(GQuestCategoriesBoolExpBuilder) updates,
-  ) => (toBuilder()..update(updates)).build();
+          void Function(GQuestCategoriesBoolExpBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
 
   @override
   GQuestCategoriesBoolExpBuilder toBuilder() =>
@@ -15704,8 +12942,7 @@ class GQuestCategoriesBoolExpBuilder
   _$GQuestCategoriesBoolExp _build() {
     _$GQuestCategoriesBoolExp _$result;
     try {
-      _$result =
-          _$v ??
+      _$result = _$v ??
           new _$GQuestCategoriesBoolExp._(
             G_and: _G_and?.build(),
             G_not: _G_not?.build(),
@@ -15740,10 +12977,7 @@ class GQuestCategoriesBoolExpBuilder
         _updatedAt?.build();
       } catch (e) {
         throw new BuiltValueNestedFieldError(
-          r'GQuestCategoriesBoolExp',
-          _$failedField,
-          e.toString(),
-        );
+            r'GQuestCategoriesBoolExp', _$failedField, e.toString());
       }
       rethrow;
     }
@@ -15766,23 +13000,23 @@ class _$GQuestCategoriesOrderBy extends GQuestCategoriesOrderBy {
   @override
   final GOrderBy? updatedAt;
 
-  factory _$GQuestCategoriesOrderBy([
-    void Function(GQuestCategoriesOrderByBuilder)? updates,
-  ]) => (new GQuestCategoriesOrderByBuilder()..update(updates))._build();
+  factory _$GQuestCategoriesOrderBy(
+          [void Function(GQuestCategoriesOrderByBuilder)? updates]) =>
+      (new GQuestCategoriesOrderByBuilder()..update(updates))._build();
 
-  _$GQuestCategoriesOrderBy._({
-    this.createdAt,
-    this.description,
-    this.id,
-    this.name,
-    this.sortNumber,
-    this.updatedAt,
-  }) : super._();
+  _$GQuestCategoriesOrderBy._(
+      {this.createdAt,
+      this.description,
+      this.id,
+      this.name,
+      this.sortNumber,
+      this.updatedAt})
+      : super._();
 
   @override
   GQuestCategoriesOrderBy rebuild(
-    void Function(GQuestCategoriesOrderByBuilder) updates,
-  ) => (toBuilder()..update(updates)).build();
+          void Function(GQuestCategoriesOrderByBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
 
   @override
   GQuestCategoriesOrderByBuilder toBuilder() =>
@@ -15886,8 +13120,7 @@ class GQuestCategoriesOrderByBuilder
   GQuestCategoriesOrderBy build() => _build();
 
   _$GQuestCategoriesOrderBy _build() {
-    final _$result =
-        _$v ??
+    final _$result = _$v ??
         new _$GQuestCategoriesOrderBy._(
           createdAt: createdAt,
           description: description,
@@ -15908,26 +13141,22 @@ class _$GQuestCategoriesStreamCursorInput
   @override
   final GCursorOrdering? ordering;
 
-  factory _$GQuestCategoriesStreamCursorInput([
-    void Function(GQuestCategoriesStreamCursorInputBuilder)? updates,
-  ]) => (new GQuestCategoriesStreamCursorInputBuilder()..update(updates))
-      ._build();
+  factory _$GQuestCategoriesStreamCursorInput(
+          [void Function(GQuestCategoriesStreamCursorInputBuilder)? updates]) =>
+      (new GQuestCategoriesStreamCursorInputBuilder()..update(updates))
+          ._build();
 
-  _$GQuestCategoriesStreamCursorInput._({
-    required this.initialValue,
-    this.ordering,
-  }) : super._() {
+  _$GQuestCategoriesStreamCursorInput._(
+      {required this.initialValue, this.ordering})
+      : super._() {
     BuiltValueNullFieldError.checkNotNull(
-      initialValue,
-      r'GQuestCategoriesStreamCursorInput',
-      'initialValue',
-    );
+        initialValue, r'GQuestCategoriesStreamCursorInput', 'initialValue');
   }
 
   @override
   GQuestCategoriesStreamCursorInput rebuild(
-    void Function(GQuestCategoriesStreamCursorInputBuilder) updates,
-  ) => (toBuilder()..update(updates)).build();
+          void Function(GQuestCategoriesStreamCursorInputBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
 
   @override
   GQuestCategoriesStreamCursorInputBuilder toBuilder() =>
@@ -15961,10 +13190,8 @@ class _$GQuestCategoriesStreamCursorInput
 
 class GQuestCategoriesStreamCursorInputBuilder
     implements
-        Builder<
-          GQuestCategoriesStreamCursorInput,
-          GQuestCategoriesStreamCursorInputBuilder
-        > {
+        Builder<GQuestCategoriesStreamCursorInput,
+            GQuestCategoriesStreamCursorInputBuilder> {
   _$GQuestCategoriesStreamCursorInput? _$v;
 
   GQuestCategoriesStreamCursorValueInputBuilder? _initialValue;
@@ -15972,8 +13199,8 @@ class GQuestCategoriesStreamCursorInputBuilder
       _$this._initialValue ??=
           new GQuestCategoriesStreamCursorValueInputBuilder();
   set initialValue(
-    GQuestCategoriesStreamCursorValueInputBuilder? initialValue,
-  ) => _$this._initialValue = initialValue;
+          GQuestCategoriesStreamCursorValueInputBuilder? initialValue) =>
+      _$this._initialValue = initialValue;
 
   GCursorOrdering? _ordering;
   GCursorOrdering? get ordering => _$this._ordering;
@@ -15999,8 +13226,7 @@ class GQuestCategoriesStreamCursorInputBuilder
 
   @override
   void update(
-    void Function(GQuestCategoriesStreamCursorInputBuilder)? updates,
-  ) {
+      void Function(GQuestCategoriesStreamCursorInputBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
@@ -16010,8 +13236,7 @@ class GQuestCategoriesStreamCursorInputBuilder
   _$GQuestCategoriesStreamCursorInput _build() {
     _$GQuestCategoriesStreamCursorInput _$result;
     try {
-      _$result =
-          _$v ??
+      _$result = _$v ??
           new _$GQuestCategoriesStreamCursorInput._(
             initialValue: initialValue.build(),
             ordering: ordering,
@@ -16023,10 +13248,7 @@ class GQuestCategoriesStreamCursorInputBuilder
         initialValue.build();
       } catch (e) {
         throw new BuiltValueNestedFieldError(
-          r'GQuestCategoriesStreamCursorInput',
-          _$failedField,
-          e.toString(),
-        );
+            r'GQuestCategoriesStreamCursorInput', _$failedField, e.toString());
       }
       rethrow;
     }
@@ -16050,24 +13272,26 @@ class _$GQuestCategoriesStreamCursorValueInput
   @override
   final DateTime? updatedAt;
 
-  factory _$GQuestCategoriesStreamCursorValueInput([
-    void Function(GQuestCategoriesStreamCursorValueInputBuilder)? updates,
-  ]) => (new GQuestCategoriesStreamCursorValueInputBuilder()..update(updates))
-      ._build();
+  factory _$GQuestCategoriesStreamCursorValueInput(
+          [void Function(GQuestCategoriesStreamCursorValueInputBuilder)?
+              updates]) =>
+      (new GQuestCategoriesStreamCursorValueInputBuilder()..update(updates))
+          ._build();
 
-  _$GQuestCategoriesStreamCursorValueInput._({
-    this.createdAt,
-    this.description,
-    this.id,
-    this.name,
-    this.sortNumber,
-    this.updatedAt,
-  }) : super._();
+  _$GQuestCategoriesStreamCursorValueInput._(
+      {this.createdAt,
+      this.description,
+      this.id,
+      this.name,
+      this.sortNumber,
+      this.updatedAt})
+      : super._();
 
   @override
   GQuestCategoriesStreamCursorValueInput rebuild(
-    void Function(GQuestCategoriesStreamCursorValueInputBuilder) updates,
-  ) => (toBuilder()..update(updates)).build();
+          void Function(GQuestCategoriesStreamCursorValueInputBuilder)
+              updates) =>
+      (toBuilder()..update(updates)).build();
 
   @override
   GQuestCategoriesStreamCursorValueInputBuilder toBuilder() =>
@@ -16101,8 +13325,7 @@ class _$GQuestCategoriesStreamCursorValueInput
   @override
   String toString() {
     return (newBuiltValueToStringHelper(
-            r'GQuestCategoriesStreamCursorValueInput',
-          )
+            r'GQuestCategoriesStreamCursorValueInput')
           ..add('createdAt', createdAt)
           ..add('description', description)
           ..add('id', id)
@@ -16115,10 +13338,8 @@ class _$GQuestCategoriesStreamCursorValueInput
 
 class GQuestCategoriesStreamCursorValueInputBuilder
     implements
-        Builder<
-          GQuestCategoriesStreamCursorValueInput,
-          GQuestCategoriesStreamCursorValueInputBuilder
-        > {
+        Builder<GQuestCategoriesStreamCursorValueInput,
+            GQuestCategoriesStreamCursorValueInputBuilder> {
   _$GQuestCategoriesStreamCursorValueInput? _$v;
 
   DateTime? _createdAt;
@@ -16169,8 +13390,7 @@ class GQuestCategoriesStreamCursorValueInputBuilder
 
   @override
   void update(
-    void Function(GQuestCategoriesStreamCursorValueInputBuilder)? updates,
-  ) {
+      void Function(GQuestCategoriesStreamCursorValueInputBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
@@ -16178,8 +13398,7 @@ class GQuestCategoriesStreamCursorValueInputBuilder
   GQuestCategoriesStreamCursorValueInput build() => _build();
 
   _$GQuestCategoriesStreamCursorValueInput _build() {
-    final _$result =
-        _$v ??
+    final _$result = _$v ??
         new _$GQuestCategoriesStreamCursorValueInput._(
           createdAt: createdAt,
           description: description,
@@ -16203,17 +13422,17 @@ class _$GQuestStatusBoolExp extends GQuestStatusBoolExp {
   @override
   final GStringComparisonExp? value;
 
-  factory _$GQuestStatusBoolExp([
-    void Function(GQuestStatusBoolExpBuilder)? updates,
-  ]) => (new GQuestStatusBoolExpBuilder()..update(updates))._build();
+  factory _$GQuestStatusBoolExp(
+          [void Function(GQuestStatusBoolExpBuilder)? updates]) =>
+      (new GQuestStatusBoolExpBuilder()..update(updates))._build();
 
   _$GQuestStatusBoolExp._({this.G_and, this.G_not, this.G_or, this.value})
-    : super._();
+      : super._();
 
   @override
   GQuestStatusBoolExp rebuild(
-    void Function(GQuestStatusBoolExpBuilder) updates,
-  ) => (toBuilder()..update(updates)).build();
+          void Function(GQuestStatusBoolExpBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
 
   @override
   GQuestStatusBoolExpBuilder toBuilder() =>
@@ -16306,8 +13525,7 @@ class GQuestStatusBoolExpBuilder
   _$GQuestStatusBoolExp _build() {
     _$GQuestStatusBoolExp _$result;
     try {
-      _$result =
-          _$v ??
+      _$result = _$v ??
           new _$GQuestStatusBoolExp._(
             G_and: _G_and?.build(),
             G_not: _G_not?.build(),
@@ -16327,10 +13545,7 @@ class GQuestStatusBoolExpBuilder
         _value?.build();
       } catch (e) {
         throw new BuiltValueNestedFieldError(
-          r'GQuestStatusBoolExp',
-          _$failedField,
-          e.toString(),
-        );
+            r'GQuestStatusBoolExp', _$failedField, e.toString());
       }
       rethrow;
     }
@@ -16351,22 +13566,18 @@ class _$GQuestStatusEnumComparisonExp extends GQuestStatusEnumComparisonExp {
   @override
   final BuiltList<GQuestStatusEnum>? G_nin;
 
-  factory _$GQuestStatusEnumComparisonExp([
-    void Function(GQuestStatusEnumComparisonExpBuilder)? updates,
-  ]) => (new GQuestStatusEnumComparisonExpBuilder()..update(updates))._build();
+  factory _$GQuestStatusEnumComparisonExp(
+          [void Function(GQuestStatusEnumComparisonExpBuilder)? updates]) =>
+      (new GQuestStatusEnumComparisonExpBuilder()..update(updates))._build();
 
-  _$GQuestStatusEnumComparisonExp._({
-    this.G_eq,
-    this.G_in,
-    this.G_isNull,
-    this.G_neq,
-    this.G_nin,
-  }) : super._();
+  _$GQuestStatusEnumComparisonExp._(
+      {this.G_eq, this.G_in, this.G_isNull, this.G_neq, this.G_nin})
+      : super._();
 
   @override
   GQuestStatusEnumComparisonExp rebuild(
-    void Function(GQuestStatusEnumComparisonExpBuilder) updates,
-  ) => (toBuilder()..update(updates)).build();
+          void Function(GQuestStatusEnumComparisonExpBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
 
   @override
   GQuestStatusEnumComparisonExpBuilder toBuilder() =>
@@ -16409,10 +13620,8 @@ class _$GQuestStatusEnumComparisonExp extends GQuestStatusEnumComparisonExp {
 
 class GQuestStatusEnumComparisonExpBuilder
     implements
-        Builder<
-          GQuestStatusEnumComparisonExp,
-          GQuestStatusEnumComparisonExpBuilder
-        > {
+        Builder<GQuestStatusEnumComparisonExp,
+            GQuestStatusEnumComparisonExpBuilder> {
   _$GQuestStatusEnumComparisonExp? _$v;
 
   GQuestStatusEnum? _G_eq;
@@ -16469,8 +13678,7 @@ class GQuestStatusEnumComparisonExpBuilder
   _$GQuestStatusEnumComparisonExp _build() {
     _$GQuestStatusEnumComparisonExp _$result;
     try {
-      _$result =
-          _$v ??
+      _$result = _$v ??
           new _$GQuestStatusEnumComparisonExp._(
             G_eq: G_eq,
             G_in: _G_in?.build(),
@@ -16488,10 +13696,7 @@ class GQuestStatusEnumComparisonExpBuilder
         _G_nin?.build();
       } catch (e) {
         throw new BuiltValueNestedFieldError(
-          r'GQuestStatusEnumComparisonExp',
-          _$failedField,
-          e.toString(),
-        );
+            r'GQuestStatusEnumComparisonExp', _$failedField, e.toString());
       }
       rethrow;
     }
@@ -16504,16 +13709,16 @@ class _$GQuestStatusOrderBy extends GQuestStatusOrderBy {
   @override
   final GOrderBy? value;
 
-  factory _$GQuestStatusOrderBy([
-    void Function(GQuestStatusOrderByBuilder)? updates,
-  ]) => (new GQuestStatusOrderByBuilder()..update(updates))._build();
+  factory _$GQuestStatusOrderBy(
+          [void Function(GQuestStatusOrderByBuilder)? updates]) =>
+      (new GQuestStatusOrderByBuilder()..update(updates))._build();
 
   _$GQuestStatusOrderBy._({this.value}) : super._();
 
   @override
   GQuestStatusOrderBy rebuild(
-    void Function(GQuestStatusOrderByBuilder) updates,
-  ) => (toBuilder()..update(updates)).build();
+          void Function(GQuestStatusOrderByBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
 
   @override
   GQuestStatusOrderByBuilder toBuilder() =>
@@ -16535,9 +13740,9 @@ class _$GQuestStatusOrderBy extends GQuestStatusOrderBy {
 
   @override
   String toString() {
-    return (newBuiltValueToStringHelper(
-      r'GQuestStatusOrderBy',
-    )..add('value', value)).toString();
+    return (newBuiltValueToStringHelper(r'GQuestStatusOrderBy')
+          ..add('value', value))
+        .toString();
   }
 }
 
@@ -16575,7 +13780,10 @@ class GQuestStatusOrderByBuilder
   GQuestStatusOrderBy build() => _build();
 
   _$GQuestStatusOrderBy _build() {
-    final _$result = _$v ?? new _$GQuestStatusOrderBy._(value: value);
+    final _$result = _$v ??
+        new _$GQuestStatusOrderBy._(
+          value: value,
+        );
     replace(_$result);
     return _$result;
   }
@@ -16587,23 +13795,20 @@ class _$GQuestStatusStreamCursorInput extends GQuestStatusStreamCursorInput {
   @override
   final GCursorOrdering? ordering;
 
-  factory _$GQuestStatusStreamCursorInput([
-    void Function(GQuestStatusStreamCursorInputBuilder)? updates,
-  ]) => (new GQuestStatusStreamCursorInputBuilder()..update(updates))._build();
+  factory _$GQuestStatusStreamCursorInput(
+          [void Function(GQuestStatusStreamCursorInputBuilder)? updates]) =>
+      (new GQuestStatusStreamCursorInputBuilder()..update(updates))._build();
 
   _$GQuestStatusStreamCursorInput._({required this.initialValue, this.ordering})
-    : super._() {
+      : super._() {
     BuiltValueNullFieldError.checkNotNull(
-      initialValue,
-      r'GQuestStatusStreamCursorInput',
-      'initialValue',
-    );
+        initialValue, r'GQuestStatusStreamCursorInput', 'initialValue');
   }
 
   @override
   GQuestStatusStreamCursorInput rebuild(
-    void Function(GQuestStatusStreamCursorInputBuilder) updates,
-  ) => (toBuilder()..update(updates)).build();
+          void Function(GQuestStatusStreamCursorInputBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
 
   @override
   GQuestStatusStreamCursorInputBuilder toBuilder() =>
@@ -16637,10 +13842,8 @@ class _$GQuestStatusStreamCursorInput extends GQuestStatusStreamCursorInput {
 
 class GQuestStatusStreamCursorInputBuilder
     implements
-        Builder<
-          GQuestStatusStreamCursorInput,
-          GQuestStatusStreamCursorInputBuilder
-        > {
+        Builder<GQuestStatusStreamCursorInput,
+            GQuestStatusStreamCursorInputBuilder> {
   _$GQuestStatusStreamCursorInput? _$v;
 
   GQuestStatusStreamCursorValueInputBuilder? _initialValue;
@@ -16682,8 +13885,7 @@ class GQuestStatusStreamCursorInputBuilder
   _$GQuestStatusStreamCursorInput _build() {
     _$GQuestStatusStreamCursorInput _$result;
     try {
-      _$result =
-          _$v ??
+      _$result = _$v ??
           new _$GQuestStatusStreamCursorInput._(
             initialValue: initialValue.build(),
             ordering: ordering,
@@ -16695,10 +13897,7 @@ class GQuestStatusStreamCursorInputBuilder
         initialValue.build();
       } catch (e) {
         throw new BuiltValueNestedFieldError(
-          r'GQuestStatusStreamCursorInput',
-          _$failedField,
-          e.toString(),
-        );
+            r'GQuestStatusStreamCursorInput', _$failedField, e.toString());
       }
       rethrow;
     }
@@ -16712,17 +13911,18 @@ class _$GQuestStatusStreamCursorValueInput
   @override
   final String? value;
 
-  factory _$GQuestStatusStreamCursorValueInput([
-    void Function(GQuestStatusStreamCursorValueInputBuilder)? updates,
-  ]) => (new GQuestStatusStreamCursorValueInputBuilder()..update(updates))
-      ._build();
+  factory _$GQuestStatusStreamCursorValueInput(
+          [void Function(GQuestStatusStreamCursorValueInputBuilder)?
+              updates]) =>
+      (new GQuestStatusStreamCursorValueInputBuilder()..update(updates))
+          ._build();
 
   _$GQuestStatusStreamCursorValueInput._({this.value}) : super._();
 
   @override
   GQuestStatusStreamCursorValueInput rebuild(
-    void Function(GQuestStatusStreamCursorValueInputBuilder) updates,
-  ) => (toBuilder()..update(updates)).build();
+          void Function(GQuestStatusStreamCursorValueInputBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
 
   @override
   GQuestStatusStreamCursorValueInputBuilder toBuilder() =>
@@ -16744,18 +13944,16 @@ class _$GQuestStatusStreamCursorValueInput
 
   @override
   String toString() {
-    return (newBuiltValueToStringHelper(
-      r'GQuestStatusStreamCursorValueInput',
-    )..add('value', value)).toString();
+    return (newBuiltValueToStringHelper(r'GQuestStatusStreamCursorValueInput')
+          ..add('value', value))
+        .toString();
   }
 }
 
 class GQuestStatusStreamCursorValueInputBuilder
     implements
-        Builder<
-          GQuestStatusStreamCursorValueInput,
-          GQuestStatusStreamCursorValueInputBuilder
-        > {
+        Builder<GQuestStatusStreamCursorValueInput,
+            GQuestStatusStreamCursorValueInputBuilder> {
   _$GQuestStatusStreamCursorValueInput? _$v;
 
   String? _value;
@@ -16781,8 +13979,7 @@ class GQuestStatusStreamCursorValueInputBuilder
 
   @override
   void update(
-    void Function(GQuestStatusStreamCursorValueInputBuilder)? updates,
-  ) {
+      void Function(GQuestStatusStreamCursorValueInputBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
@@ -16790,8 +13987,10 @@ class GQuestStatusStreamCursorValueInputBuilder
   GQuestStatusStreamCursorValueInput build() => _build();
 
   _$GQuestStatusStreamCursorValueInput _build() {
-    final _$result =
-        _$v ?? new _$GQuestStatusStreamCursorValueInput._(value: value);
+    final _$result = _$v ??
+        new _$GQuestStatusStreamCursorValueInput._(
+          value: value,
+        );
     replace(_$result);
     return _$result;
   }
@@ -16820,17 +14019,17 @@ class _$GSeosBoolExp extends GSeosBoolExp {
   factory _$GSeosBoolExp([void Function(GSeosBoolExpBuilder)? updates]) =>
       (new GSeosBoolExpBuilder()..update(updates))._build();
 
-  _$GSeosBoolExp._({
-    this.G_and,
-    this.G_not,
-    this.G_or,
-    this.createdAt,
-    this.description,
-    this.id,
-    this.ogImageUrl,
-    this.title,
-    this.updatedAt,
-  }) : super._();
+  _$GSeosBoolExp._(
+      {this.G_and,
+      this.G_not,
+      this.G_or,
+      this.createdAt,
+      this.description,
+      this.id,
+      this.ogImageUrl,
+      this.title,
+      this.updatedAt})
+      : super._();
 
   @override
   GSeosBoolExp rebuild(void Function(GSeosBoolExpBuilder) updates) =>
@@ -16974,8 +14173,7 @@ class GSeosBoolExpBuilder
   _$GSeosBoolExp _build() {
     _$GSeosBoolExp _$result;
     try {
-      _$result =
-          _$v ??
+      _$result = _$v ??
           new _$GSeosBoolExp._(
             G_and: _G_and?.build(),
             G_not: _G_not?.build(),
@@ -17010,10 +14208,7 @@ class GSeosBoolExpBuilder
         _updatedAt?.build();
       } catch (e) {
         throw new BuiltValueNestedFieldError(
-          r'GSeosBoolExp',
-          _$failedField,
-          e.toString(),
-        );
+            r'GSeosBoolExp', _$failedField, e.toString());
       }
       rethrow;
     }
@@ -17039,14 +14234,14 @@ class _$GSeosOrderBy extends GSeosOrderBy {
   factory _$GSeosOrderBy([void Function(GSeosOrderByBuilder)? updates]) =>
       (new GSeosOrderByBuilder()..update(updates))._build();
 
-  _$GSeosOrderBy._({
-    this.createdAt,
-    this.description,
-    this.id,
-    this.ogImageUrl,
-    this.title,
-    this.updatedAt,
-  }) : super._();
+  _$GSeosOrderBy._(
+      {this.createdAt,
+      this.description,
+      this.id,
+      this.ogImageUrl,
+      this.title,
+      this.updatedAt})
+      : super._();
 
   @override
   GSeosOrderBy rebuild(void Function(GSeosOrderByBuilder) updates) =>
@@ -17152,8 +14347,7 @@ class GSeosOrderByBuilder
   GSeosOrderBy build() => _build();
 
   _$GSeosOrderBy _build() {
-    final _$result =
-        _$v ??
+    final _$result = _$v ??
         new _$GSeosOrderBy._(
           createdAt: createdAt,
           description: description,
@@ -17173,23 +14367,20 @@ class _$GSeosStreamCursorInput extends GSeosStreamCursorInput {
   @override
   final GCursorOrdering? ordering;
 
-  factory _$GSeosStreamCursorInput([
-    void Function(GSeosStreamCursorInputBuilder)? updates,
-  ]) => (new GSeosStreamCursorInputBuilder()..update(updates))._build();
+  factory _$GSeosStreamCursorInput(
+          [void Function(GSeosStreamCursorInputBuilder)? updates]) =>
+      (new GSeosStreamCursorInputBuilder()..update(updates))._build();
 
   _$GSeosStreamCursorInput._({required this.initialValue, this.ordering})
-    : super._() {
+      : super._() {
     BuiltValueNullFieldError.checkNotNull(
-      initialValue,
-      r'GSeosStreamCursorInput',
-      'initialValue',
-    );
+        initialValue, r'GSeosStreamCursorInput', 'initialValue');
   }
 
   @override
   GSeosStreamCursorInput rebuild(
-    void Function(GSeosStreamCursorInputBuilder) updates,
-  ) => (toBuilder()..update(updates)).build();
+          void Function(GSeosStreamCursorInputBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
 
   @override
   GSeosStreamCursorInputBuilder toBuilder() =>
@@ -17264,8 +14455,7 @@ class GSeosStreamCursorInputBuilder
   _$GSeosStreamCursorInput _build() {
     _$GSeosStreamCursorInput _$result;
     try {
-      _$result =
-          _$v ??
+      _$result = _$v ??
           new _$GSeosStreamCursorInput._(
             initialValue: initialValue.build(),
             ordering: ordering,
@@ -17277,10 +14467,7 @@ class GSeosStreamCursorInputBuilder
         initialValue.build();
       } catch (e) {
         throw new BuiltValueNestedFieldError(
-          r'GSeosStreamCursorInput',
-          _$failedField,
-          e.toString(),
-        );
+            r'GSeosStreamCursorInput', _$failedField, e.toString());
       }
       rethrow;
     }
@@ -17303,23 +14490,23 @@ class _$GSeosStreamCursorValueInput extends GSeosStreamCursorValueInput {
   @override
   final DateTime? updatedAt;
 
-  factory _$GSeosStreamCursorValueInput([
-    void Function(GSeosStreamCursorValueInputBuilder)? updates,
-  ]) => (new GSeosStreamCursorValueInputBuilder()..update(updates))._build();
+  factory _$GSeosStreamCursorValueInput(
+          [void Function(GSeosStreamCursorValueInputBuilder)? updates]) =>
+      (new GSeosStreamCursorValueInputBuilder()..update(updates))._build();
 
-  _$GSeosStreamCursorValueInput._({
-    this.createdAt,
-    this.description,
-    this.id,
-    this.ogImageUrl,
-    this.title,
-    this.updatedAt,
-  }) : super._();
+  _$GSeosStreamCursorValueInput._(
+      {this.createdAt,
+      this.description,
+      this.id,
+      this.ogImageUrl,
+      this.title,
+      this.updatedAt})
+      : super._();
 
   @override
   GSeosStreamCursorValueInput rebuild(
-    void Function(GSeosStreamCursorValueInputBuilder) updates,
-  ) => (toBuilder()..update(updates)).build();
+          void Function(GSeosStreamCursorValueInputBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
 
   @override
   GSeosStreamCursorValueInputBuilder toBuilder() =>
@@ -17365,10 +14552,8 @@ class _$GSeosStreamCursorValueInput extends GSeosStreamCursorValueInput {
 
 class GSeosStreamCursorValueInputBuilder
     implements
-        Builder<
-          GSeosStreamCursorValueInput,
-          GSeosStreamCursorValueInputBuilder
-        > {
+        Builder<GSeosStreamCursorValueInput,
+            GSeosStreamCursorValueInputBuilder> {
   _$GSeosStreamCursorValueInput? _$v;
 
   DateTime? _createdAt;
@@ -17426,8 +14611,7 @@ class GSeosStreamCursorValueInputBuilder
   GSeosStreamCursorValueInput build() => _build();
 
   _$GSeosStreamCursorValueInput _build() {
-    final _$result =
-        _$v ??
+    final _$result = _$v ??
         new _$GSeosStreamCursorValueInput._(
           createdAt: createdAt,
           description: description,
@@ -17481,36 +14665,36 @@ class _$GStringComparisonExp extends GStringComparisonExp {
   @override
   final String? G_similar;
 
-  factory _$GStringComparisonExp([
-    void Function(GStringComparisonExpBuilder)? updates,
-  ]) => (new GStringComparisonExpBuilder()..update(updates))._build();
+  factory _$GStringComparisonExp(
+          [void Function(GStringComparisonExpBuilder)? updates]) =>
+      (new GStringComparisonExpBuilder()..update(updates))._build();
 
-  _$GStringComparisonExp._({
-    this.G_eq,
-    this.G_gt,
-    this.G_gte,
-    this.G_ilike,
-    this.G_in,
-    this.G_iregex,
-    this.G_isNull,
-    this.G_like,
-    this.G_lt,
-    this.G_lte,
-    this.G_neq,
-    this.G_nilike,
-    this.G_nin,
-    this.G_niregex,
-    this.G_nlike,
-    this.G_nregex,
-    this.G_nsimilar,
-    this.G_regex,
-    this.G_similar,
-  }) : super._();
+  _$GStringComparisonExp._(
+      {this.G_eq,
+      this.G_gt,
+      this.G_gte,
+      this.G_ilike,
+      this.G_in,
+      this.G_iregex,
+      this.G_isNull,
+      this.G_like,
+      this.G_lt,
+      this.G_lte,
+      this.G_neq,
+      this.G_nilike,
+      this.G_nin,
+      this.G_niregex,
+      this.G_nlike,
+      this.G_nregex,
+      this.G_nsimilar,
+      this.G_regex,
+      this.G_similar})
+      : super._();
 
   @override
   GStringComparisonExp rebuild(
-    void Function(GStringComparisonExpBuilder) updates,
-  ) => (toBuilder()..update(updates)).build();
+          void Function(GStringComparisonExpBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
 
   @override
   GStringComparisonExpBuilder toBuilder() =>
@@ -17719,8 +14903,7 @@ class GStringComparisonExpBuilder
   _$GStringComparisonExp _build() {
     _$GStringComparisonExp _$result;
     try {
-      _$result =
-          _$v ??
+      _$result = _$v ??
           new _$GStringComparisonExp._(
             G_eq: G_eq,
             G_gt: G_gt,
@@ -17752,10 +14935,7 @@ class GStringComparisonExpBuilder
         _G_nin?.build();
       } catch (e) {
         throw new BuiltValueNestedFieldError(
-          r'GStringComparisonExp',
-          _$failedField,
-          e.toString(),
-        );
+            r'GStringComparisonExp', _$failedField, e.toString());
       }
       rethrow;
     }
@@ -17785,16 +14965,16 @@ class _$GTagsBoolExp extends GTagsBoolExp {
   factory _$GTagsBoolExp([void Function(GTagsBoolExpBuilder)? updates]) =>
       (new GTagsBoolExpBuilder()..update(updates))._build();
 
-  _$GTagsBoolExp._({
-    this.G_and,
-    this.G_not,
-    this.G_or,
-    this.createdAt,
-    this.description,
-    this.id,
-    this.tag,
-    this.updatedAt,
-  }) : super._();
+  _$GTagsBoolExp._(
+      {this.G_and,
+      this.G_not,
+      this.G_or,
+      this.createdAt,
+      this.description,
+      this.id,
+      this.tag,
+      this.updatedAt})
+      : super._();
 
   @override
   GTagsBoolExp rebuild(void Function(GTagsBoolExpBuilder) updates) =>
@@ -17928,8 +15108,7 @@ class GTagsBoolExpBuilder
   _$GTagsBoolExp _build() {
     _$GTagsBoolExp _$result;
     try {
-      _$result =
-          _$v ??
+      _$result = _$v ??
           new _$GTagsBoolExp._(
             G_and: _G_and?.build(),
             G_not: _G_not?.build(),
@@ -17961,10 +15140,7 @@ class GTagsBoolExpBuilder
         _updatedAt?.build();
       } catch (e) {
         throw new BuiltValueNestedFieldError(
-          r'GTagsBoolExp',
-          _$failedField,
-          e.toString(),
-        );
+            r'GTagsBoolExp', _$failedField, e.toString());
       }
       rethrow;
     }
@@ -17988,13 +15164,9 @@ class _$GTagsOrderBy extends GTagsOrderBy {
   factory _$GTagsOrderBy([void Function(GTagsOrderByBuilder)? updates]) =>
       (new GTagsOrderByBuilder()..update(updates))._build();
 
-  _$GTagsOrderBy._({
-    this.createdAt,
-    this.description,
-    this.id,
-    this.tag,
-    this.updatedAt,
-  }) : super._();
+  _$GTagsOrderBy._(
+      {this.createdAt, this.description, this.id, this.tag, this.updatedAt})
+      : super._();
 
   @override
   GTagsOrderBy rebuild(void Function(GTagsOrderByBuilder) updates) =>
@@ -18092,8 +15264,7 @@ class GTagsOrderByBuilder
   GTagsOrderBy build() => _build();
 
   _$GTagsOrderBy _build() {
-    final _$result =
-        _$v ??
+    final _$result = _$v ??
         new _$GTagsOrderBy._(
           createdAt: createdAt,
           description: description,
@@ -18112,23 +15283,20 @@ class _$GTagsStreamCursorInput extends GTagsStreamCursorInput {
   @override
   final GCursorOrdering? ordering;
 
-  factory _$GTagsStreamCursorInput([
-    void Function(GTagsStreamCursorInputBuilder)? updates,
-  ]) => (new GTagsStreamCursorInputBuilder()..update(updates))._build();
+  factory _$GTagsStreamCursorInput(
+          [void Function(GTagsStreamCursorInputBuilder)? updates]) =>
+      (new GTagsStreamCursorInputBuilder()..update(updates))._build();
 
   _$GTagsStreamCursorInput._({required this.initialValue, this.ordering})
-    : super._() {
+      : super._() {
     BuiltValueNullFieldError.checkNotNull(
-      initialValue,
-      r'GTagsStreamCursorInput',
-      'initialValue',
-    );
+        initialValue, r'GTagsStreamCursorInput', 'initialValue');
   }
 
   @override
   GTagsStreamCursorInput rebuild(
-    void Function(GTagsStreamCursorInputBuilder) updates,
-  ) => (toBuilder()..update(updates)).build();
+          void Function(GTagsStreamCursorInputBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
 
   @override
   GTagsStreamCursorInputBuilder toBuilder() =>
@@ -18203,8 +15371,7 @@ class GTagsStreamCursorInputBuilder
   _$GTagsStreamCursorInput _build() {
     _$GTagsStreamCursorInput _$result;
     try {
-      _$result =
-          _$v ??
+      _$result = _$v ??
           new _$GTagsStreamCursorInput._(
             initialValue: initialValue.build(),
             ordering: ordering,
@@ -18216,10 +15383,7 @@ class GTagsStreamCursorInputBuilder
         initialValue.build();
       } catch (e) {
         throw new BuiltValueNestedFieldError(
-          r'GTagsStreamCursorInput',
-          _$failedField,
-          e.toString(),
-        );
+            r'GTagsStreamCursorInput', _$failedField, e.toString());
       }
       rethrow;
     }
@@ -18240,22 +15404,18 @@ class _$GTagsStreamCursorValueInput extends GTagsStreamCursorValueInput {
   @override
   final DateTime? updatedAt;
 
-  factory _$GTagsStreamCursorValueInput([
-    void Function(GTagsStreamCursorValueInputBuilder)? updates,
-  ]) => (new GTagsStreamCursorValueInputBuilder()..update(updates))._build();
+  factory _$GTagsStreamCursorValueInput(
+          [void Function(GTagsStreamCursorValueInputBuilder)? updates]) =>
+      (new GTagsStreamCursorValueInputBuilder()..update(updates))._build();
 
-  _$GTagsStreamCursorValueInput._({
-    this.createdAt,
-    this.description,
-    this.id,
-    this.tag,
-    this.updatedAt,
-  }) : super._();
+  _$GTagsStreamCursorValueInput._(
+      {this.createdAt, this.description, this.id, this.tag, this.updatedAt})
+      : super._();
 
   @override
   GTagsStreamCursorValueInput rebuild(
-    void Function(GTagsStreamCursorValueInputBuilder) updates,
-  ) => (toBuilder()..update(updates)).build();
+          void Function(GTagsStreamCursorValueInputBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
 
   @override
   GTagsStreamCursorValueInputBuilder toBuilder() =>
@@ -18298,10 +15458,8 @@ class _$GTagsStreamCursorValueInput extends GTagsStreamCursorValueInput {
 
 class GTagsStreamCursorValueInputBuilder
     implements
-        Builder<
-          GTagsStreamCursorValueInput,
-          GTagsStreamCursorValueInputBuilder
-        > {
+        Builder<GTagsStreamCursorValueInput,
+            GTagsStreamCursorValueInputBuilder> {
   _$GTagsStreamCursorValueInput? _$v;
 
   DateTime? _createdAt;
@@ -18354,8 +15512,7 @@ class GTagsStreamCursorValueInputBuilder
   GTagsStreamCursorValueInput build() => _build();
 
   _$GTagsStreamCursorValueInput _build() {
-    final _$result =
-        _$v ??
+    final _$result = _$v ??
         new _$GTagsStreamCursorValueInput._(
           createdAt: createdAt,
           description: description,
@@ -18388,26 +15545,26 @@ class _$GTimestamptzComparisonExp extends GTimestamptzComparisonExp {
   @override
   final BuiltList<DateTime>? G_nin;
 
-  factory _$GTimestamptzComparisonExp([
-    void Function(GTimestamptzComparisonExpBuilder)? updates,
-  ]) => (new GTimestamptzComparisonExpBuilder()..update(updates))._build();
+  factory _$GTimestamptzComparisonExp(
+          [void Function(GTimestamptzComparisonExpBuilder)? updates]) =>
+      (new GTimestamptzComparisonExpBuilder()..update(updates))._build();
 
-  _$GTimestamptzComparisonExp._({
-    this.G_eq,
-    this.G_gt,
-    this.G_gte,
-    this.G_in,
-    this.G_isNull,
-    this.G_lt,
-    this.G_lte,
-    this.G_neq,
-    this.G_nin,
-  }) : super._();
+  _$GTimestamptzComparisonExp._(
+      {this.G_eq,
+      this.G_gt,
+      this.G_gte,
+      this.G_in,
+      this.G_isNull,
+      this.G_lt,
+      this.G_lte,
+      this.G_neq,
+      this.G_nin})
+      : super._();
 
   @override
   GTimestamptzComparisonExp rebuild(
-    void Function(GTimestamptzComparisonExpBuilder) updates,
-  ) => (toBuilder()..update(updates)).build();
+          void Function(GTimestamptzComparisonExpBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
 
   @override
   GTimestamptzComparisonExpBuilder toBuilder() =>
@@ -18539,8 +15696,7 @@ class GTimestamptzComparisonExpBuilder
   _$GTimestamptzComparisonExp _build() {
     _$GTimestamptzComparisonExp _$result;
     try {
-      _$result =
-          _$v ??
+      _$result = _$v ??
           new _$GTimestamptzComparisonExp._(
             G_eq: G_eq,
             G_gt: G_gt,
@@ -18562,10 +15718,7 @@ class GTimestamptzComparisonExpBuilder
         _G_nin?.build();
       } catch (e) {
         throw new BuiltValueNestedFieldError(
-          r'GTimestamptzComparisonExp',
-          _$failedField,
-          e.toString(),
-        );
+            r'GTimestamptzComparisonExp', _$failedField, e.toString());
       }
       rethrow;
     }
@@ -18586,22 +15739,18 @@ class _$GUserAchievementsBoolExp extends GUserAchievementsBoolExp {
   @override
   final GStringComparisonExp? userId;
 
-  factory _$GUserAchievementsBoolExp([
-    void Function(GUserAchievementsBoolExpBuilder)? updates,
-  ]) => (new GUserAchievementsBoolExpBuilder()..update(updates))._build();
+  factory _$GUserAchievementsBoolExp(
+          [void Function(GUserAchievementsBoolExpBuilder)? updates]) =>
+      (new GUserAchievementsBoolExpBuilder()..update(updates))._build();
 
-  _$GUserAchievementsBoolExp._({
-    this.G_and,
-    this.G_not,
-    this.G_or,
-    this.achievementId,
-    this.userId,
-  }) : super._();
+  _$GUserAchievementsBoolExp._(
+      {this.G_and, this.G_not, this.G_or, this.achievementId, this.userId})
+      : super._();
 
   @override
   GUserAchievementsBoolExp rebuild(
-    void Function(GUserAchievementsBoolExpBuilder) updates,
-  ) => (toBuilder()..update(updates)).build();
+          void Function(GUserAchievementsBoolExpBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
 
   @override
   GUserAchievementsBoolExpBuilder toBuilder() =>
@@ -18706,8 +15855,7 @@ class GUserAchievementsBoolExpBuilder
   _$GUserAchievementsBoolExp _build() {
     _$GUserAchievementsBoolExp _$result;
     try {
-      _$result =
-          _$v ??
+      _$result = _$v ??
           new _$GUserAchievementsBoolExp._(
             G_and: _G_and?.build(),
             G_not: _G_not?.build(),
@@ -18730,10 +15878,7 @@ class GUserAchievementsBoolExpBuilder
         _userId?.build();
       } catch (e) {
         throw new BuiltValueNestedFieldError(
-          r'GUserAchievementsBoolExp',
-          _$failedField,
-          e.toString(),
-        );
+            r'GUserAchievementsBoolExp', _$failedField, e.toString());
       }
       rethrow;
     }
@@ -18748,16 +15893,16 @@ class _$GUserAchievementsOrderBy extends GUserAchievementsOrderBy {
   @override
   final GOrderBy? userId;
 
-  factory _$GUserAchievementsOrderBy([
-    void Function(GUserAchievementsOrderByBuilder)? updates,
-  ]) => (new GUserAchievementsOrderByBuilder()..update(updates))._build();
+  factory _$GUserAchievementsOrderBy(
+          [void Function(GUserAchievementsOrderByBuilder)? updates]) =>
+      (new GUserAchievementsOrderByBuilder()..update(updates))._build();
 
   _$GUserAchievementsOrderBy._({this.achievementId, this.userId}) : super._();
 
   @override
   GUserAchievementsOrderBy rebuild(
-    void Function(GUserAchievementsOrderByBuilder) updates,
-  ) => (toBuilder()..update(updates)).build();
+          void Function(GUserAchievementsOrderByBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
 
   @override
   GUserAchievementsOrderByBuilder toBuilder() =>
@@ -18830,8 +15975,7 @@ class GUserAchievementsOrderByBuilder
   GUserAchievementsOrderBy build() => _build();
 
   _$GUserAchievementsOrderBy _build() {
-    final _$result =
-        _$v ??
+    final _$result = _$v ??
         new _$GUserAchievementsOrderBy._(
           achievementId: achievementId,
           userId: userId,
@@ -18848,26 +15992,23 @@ class _$GUserAchievementsStreamCursorInput
   @override
   final GCursorOrdering? ordering;
 
-  factory _$GUserAchievementsStreamCursorInput([
-    void Function(GUserAchievementsStreamCursorInputBuilder)? updates,
-  ]) => (new GUserAchievementsStreamCursorInputBuilder()..update(updates))
-      ._build();
+  factory _$GUserAchievementsStreamCursorInput(
+          [void Function(GUserAchievementsStreamCursorInputBuilder)?
+              updates]) =>
+      (new GUserAchievementsStreamCursorInputBuilder()..update(updates))
+          ._build();
 
-  _$GUserAchievementsStreamCursorInput._({
-    required this.initialValue,
-    this.ordering,
-  }) : super._() {
+  _$GUserAchievementsStreamCursorInput._(
+      {required this.initialValue, this.ordering})
+      : super._() {
     BuiltValueNullFieldError.checkNotNull(
-      initialValue,
-      r'GUserAchievementsStreamCursorInput',
-      'initialValue',
-    );
+        initialValue, r'GUserAchievementsStreamCursorInput', 'initialValue');
   }
 
   @override
   GUserAchievementsStreamCursorInput rebuild(
-    void Function(GUserAchievementsStreamCursorInputBuilder) updates,
-  ) => (toBuilder()..update(updates)).build();
+          void Function(GUserAchievementsStreamCursorInputBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
 
   @override
   GUserAchievementsStreamCursorInputBuilder toBuilder() =>
@@ -18901,10 +16042,8 @@ class _$GUserAchievementsStreamCursorInput
 
 class GUserAchievementsStreamCursorInputBuilder
     implements
-        Builder<
-          GUserAchievementsStreamCursorInput,
-          GUserAchievementsStreamCursorInputBuilder
-        > {
+        Builder<GUserAchievementsStreamCursorInput,
+            GUserAchievementsStreamCursorInputBuilder> {
   _$GUserAchievementsStreamCursorInput? _$v;
 
   GUserAchievementsStreamCursorValueInputBuilder? _initialValue;
@@ -18912,8 +16051,8 @@ class GUserAchievementsStreamCursorInputBuilder
       _$this._initialValue ??=
           new GUserAchievementsStreamCursorValueInputBuilder();
   set initialValue(
-    GUserAchievementsStreamCursorValueInputBuilder? initialValue,
-  ) => _$this._initialValue = initialValue;
+          GUserAchievementsStreamCursorValueInputBuilder? initialValue) =>
+      _$this._initialValue = initialValue;
 
   GCursorOrdering? _ordering;
   GCursorOrdering? get ordering => _$this._ordering;
@@ -18939,8 +16078,7 @@ class GUserAchievementsStreamCursorInputBuilder
 
   @override
   void update(
-    void Function(GUserAchievementsStreamCursorInputBuilder)? updates,
-  ) {
+      void Function(GUserAchievementsStreamCursorInputBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
@@ -18950,8 +16088,7 @@ class GUserAchievementsStreamCursorInputBuilder
   _$GUserAchievementsStreamCursorInput _build() {
     _$GUserAchievementsStreamCursorInput _$result;
     try {
-      _$result =
-          _$v ??
+      _$result = _$v ??
           new _$GUserAchievementsStreamCursorInput._(
             initialValue: initialValue.build(),
             ordering: ordering,
@@ -18963,10 +16100,7 @@ class GUserAchievementsStreamCursorInputBuilder
         initialValue.build();
       } catch (e) {
         throw new BuiltValueNestedFieldError(
-          r'GUserAchievementsStreamCursorInput',
-          _$failedField,
-          e.toString(),
-        );
+            r'GUserAchievementsStreamCursorInput', _$failedField, e.toString());
       }
       rethrow;
     }
@@ -18982,18 +16116,20 @@ class _$GUserAchievementsStreamCursorValueInput
   @override
   final String? userId;
 
-  factory _$GUserAchievementsStreamCursorValueInput([
-    void Function(GUserAchievementsStreamCursorValueInputBuilder)? updates,
-  ]) => (new GUserAchievementsStreamCursorValueInputBuilder()..update(updates))
-      ._build();
+  factory _$GUserAchievementsStreamCursorValueInput(
+          [void Function(GUserAchievementsStreamCursorValueInputBuilder)?
+              updates]) =>
+      (new GUserAchievementsStreamCursorValueInputBuilder()..update(updates))
+          ._build();
 
   _$GUserAchievementsStreamCursorValueInput._({this.achievementId, this.userId})
-    : super._();
+      : super._();
 
   @override
   GUserAchievementsStreamCursorValueInput rebuild(
-    void Function(GUserAchievementsStreamCursorValueInputBuilder) updates,
-  ) => (toBuilder()..update(updates)).build();
+          void Function(GUserAchievementsStreamCursorValueInputBuilder)
+              updates) =>
+      (toBuilder()..update(updates)).build();
 
   @override
   GUserAchievementsStreamCursorValueInputBuilder toBuilder() =>
@@ -19019,8 +16155,7 @@ class _$GUserAchievementsStreamCursorValueInput
   @override
   String toString() {
     return (newBuiltValueToStringHelper(
-            r'GUserAchievementsStreamCursorValueInput',
-          )
+            r'GUserAchievementsStreamCursorValueInput')
           ..add('achievementId', achievementId)
           ..add('userId', userId))
         .toString();
@@ -19029,10 +16164,8 @@ class _$GUserAchievementsStreamCursorValueInput
 
 class GUserAchievementsStreamCursorValueInputBuilder
     implements
-        Builder<
-          GUserAchievementsStreamCursorValueInput,
-          GUserAchievementsStreamCursorValueInputBuilder
-        > {
+        Builder<GUserAchievementsStreamCursorValueInput,
+            GUserAchievementsStreamCursorValueInputBuilder> {
   _$GUserAchievementsStreamCursorValueInput? _$v;
 
   String? _achievementId;
@@ -19064,8 +16197,7 @@ class GUserAchievementsStreamCursorValueInputBuilder
 
   @override
   void update(
-    void Function(GUserAchievementsStreamCursorValueInputBuilder)? updates,
-  ) {
+      void Function(GUserAchievementsStreamCursorValueInputBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
@@ -19073,8 +16205,7 @@ class GUserAchievementsStreamCursorValueInputBuilder
   GUserAchievementsStreamCursorValueInput build() => _build();
 
   _$GUserAchievementsStreamCursorValueInput _build() {
-    final _$result =
-        _$v ??
+    final _$result = _$v ??
         new _$GUserAchievementsStreamCursorValueInput._(
           achievementId: achievementId,
           userId: userId,
@@ -19113,20 +16244,20 @@ class _$GUsersBoolExp extends GUsersBoolExp {
   factory _$GUsersBoolExp([void Function(GUsersBoolExpBuilder)? updates]) =>
       (new GUsersBoolExpBuilder()..update(updates))._build();
 
-  _$GUsersBoolExp._({
-    this.G_and,
-    this.G_not,
-    this.G_or,
-    this.createdAt,
-    this.email,
-    this.id,
-    this.lastSeen,
-    this.nickname,
-    this.picture,
-    this.updatedAt,
-    this.username,
-    this.website,
-  }) : super._();
+  _$GUsersBoolExp._(
+      {this.G_and,
+      this.G_not,
+      this.G_or,
+      this.createdAt,
+      this.email,
+      this.id,
+      this.lastSeen,
+      this.nickname,
+      this.picture,
+      this.updatedAt,
+      this.username,
+      this.website})
+      : super._();
 
   @override
   GUsersBoolExp rebuild(void Function(GUsersBoolExpBuilder) updates) =>
@@ -19301,8 +16432,7 @@ class GUsersBoolExpBuilder
   _$GUsersBoolExp _build() {
     _$GUsersBoolExp _$result;
     try {
-      _$result =
-          _$v ??
+      _$result = _$v ??
           new _$GUsersBoolExp._(
             G_and: _G_and?.build(),
             G_not: _G_not?.build(),
@@ -19346,10 +16476,7 @@ class GUsersBoolExpBuilder
         _website?.build();
       } catch (e) {
         throw new BuiltValueNestedFieldError(
-          r'GUsersBoolExp',
-          _$failedField,
-          e.toString(),
-        );
+            r'GUsersBoolExp', _$failedField, e.toString());
       }
       rethrow;
     }
@@ -19381,17 +16508,17 @@ class _$GUsersOrderBy extends GUsersOrderBy {
   factory _$GUsersOrderBy([void Function(GUsersOrderByBuilder)? updates]) =>
       (new GUsersOrderByBuilder()..update(updates))._build();
 
-  _$GUsersOrderBy._({
-    this.createdAt,
-    this.email,
-    this.id,
-    this.lastSeen,
-    this.nickname,
-    this.picture,
-    this.updatedAt,
-    this.username,
-    this.website,
-  }) : super._();
+  _$GUsersOrderBy._(
+      {this.createdAt,
+      this.email,
+      this.id,
+      this.lastSeen,
+      this.nickname,
+      this.picture,
+      this.updatedAt,
+      this.username,
+      this.website})
+      : super._();
 
   @override
   GUsersOrderBy rebuild(void Function(GUsersOrderByBuilder) updates) =>
@@ -19521,8 +16648,7 @@ class GUsersOrderByBuilder
   GUsersOrderBy build() => _build();
 
   _$GUsersOrderBy _build() {
-    final _$result =
-        _$v ??
+    final _$result = _$v ??
         new _$GUsersOrderBy._(
           createdAt: createdAt,
           email: email,
@@ -19545,23 +16671,20 @@ class _$GUsersStreamCursorInput extends GUsersStreamCursorInput {
   @override
   final GCursorOrdering? ordering;
 
-  factory _$GUsersStreamCursorInput([
-    void Function(GUsersStreamCursorInputBuilder)? updates,
-  ]) => (new GUsersStreamCursorInputBuilder()..update(updates))._build();
+  factory _$GUsersStreamCursorInput(
+          [void Function(GUsersStreamCursorInputBuilder)? updates]) =>
+      (new GUsersStreamCursorInputBuilder()..update(updates))._build();
 
   _$GUsersStreamCursorInput._({required this.initialValue, this.ordering})
-    : super._() {
+      : super._() {
     BuiltValueNullFieldError.checkNotNull(
-      initialValue,
-      r'GUsersStreamCursorInput',
-      'initialValue',
-    );
+        initialValue, r'GUsersStreamCursorInput', 'initialValue');
   }
 
   @override
   GUsersStreamCursorInput rebuild(
-    void Function(GUsersStreamCursorInputBuilder) updates,
-  ) => (toBuilder()..update(updates)).build();
+          void Function(GUsersStreamCursorInputBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
 
   @override
   GUsersStreamCursorInputBuilder toBuilder() =>
@@ -19637,8 +16760,7 @@ class GUsersStreamCursorInputBuilder
   _$GUsersStreamCursorInput _build() {
     _$GUsersStreamCursorInput _$result;
     try {
-      _$result =
-          _$v ??
+      _$result = _$v ??
           new _$GUsersStreamCursorInput._(
             initialValue: initialValue.build(),
             ordering: ordering,
@@ -19650,10 +16772,7 @@ class GUsersStreamCursorInputBuilder
         initialValue.build();
       } catch (e) {
         throw new BuiltValueNestedFieldError(
-          r'GUsersStreamCursorInput',
-          _$failedField,
-          e.toString(),
-        );
+            r'GUsersStreamCursorInput', _$failedField, e.toString());
       }
       rethrow;
     }
@@ -19682,26 +16801,26 @@ class _$GUsersStreamCursorValueInput extends GUsersStreamCursorValueInput {
   @override
   final String? website;
 
-  factory _$GUsersStreamCursorValueInput([
-    void Function(GUsersStreamCursorValueInputBuilder)? updates,
-  ]) => (new GUsersStreamCursorValueInputBuilder()..update(updates))._build();
+  factory _$GUsersStreamCursorValueInput(
+          [void Function(GUsersStreamCursorValueInputBuilder)? updates]) =>
+      (new GUsersStreamCursorValueInputBuilder()..update(updates))._build();
 
-  _$GUsersStreamCursorValueInput._({
-    this.createdAt,
-    this.email,
-    this.id,
-    this.lastSeen,
-    this.nickname,
-    this.picture,
-    this.updatedAt,
-    this.username,
-    this.website,
-  }) : super._();
+  _$GUsersStreamCursorValueInput._(
+      {this.createdAt,
+      this.email,
+      this.id,
+      this.lastSeen,
+      this.nickname,
+      this.picture,
+      this.updatedAt,
+      this.username,
+      this.website})
+      : super._();
 
   @override
   GUsersStreamCursorValueInput rebuild(
-    void Function(GUsersStreamCursorValueInputBuilder) updates,
-  ) => (toBuilder()..update(updates)).build();
+          void Function(GUsersStreamCursorValueInputBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
 
   @override
   GUsersStreamCursorValueInputBuilder toBuilder() =>
@@ -19756,10 +16875,8 @@ class _$GUsersStreamCursorValueInput extends GUsersStreamCursorValueInput {
 
 class GUsersStreamCursorValueInputBuilder
     implements
-        Builder<
-          GUsersStreamCursorValueInput,
-          GUsersStreamCursorValueInputBuilder
-        > {
+        Builder<GUsersStreamCursorValueInput,
+            GUsersStreamCursorValueInputBuilder> {
   _$GUsersStreamCursorValueInput? _$v;
 
   DateTime? _createdAt;
@@ -19832,8 +16949,7 @@ class GUsersStreamCursorValueInputBuilder
   GUsersStreamCursorValueInput build() => _build();
 
   _$GUsersStreamCursorValueInput _build() {
-    final _$result =
-        _$v ??
+    final _$result = _$v ??
         new _$GUsersStreamCursorValueInput._(
           createdAt: createdAt,
           email: email,
@@ -19870,26 +16986,26 @@ class _$GUuidComparisonExp extends GUuidComparisonExp {
   @override
   final BuiltList<String>? G_nin;
 
-  factory _$GUuidComparisonExp([
-    void Function(GUuidComparisonExpBuilder)? updates,
-  ]) => (new GUuidComparisonExpBuilder()..update(updates))._build();
+  factory _$GUuidComparisonExp(
+          [void Function(GUuidComparisonExpBuilder)? updates]) =>
+      (new GUuidComparisonExpBuilder()..update(updates))._build();
 
-  _$GUuidComparisonExp._({
-    this.G_eq,
-    this.G_gt,
-    this.G_gte,
-    this.G_in,
-    this.G_isNull,
-    this.G_lt,
-    this.G_lte,
-    this.G_neq,
-    this.G_nin,
-  }) : super._();
+  _$GUuidComparisonExp._(
+      {this.G_eq,
+      this.G_gt,
+      this.G_gte,
+      this.G_in,
+      this.G_isNull,
+      this.G_lt,
+      this.G_lte,
+      this.G_neq,
+      this.G_nin})
+      : super._();
 
   @override
   GUuidComparisonExp rebuild(
-    void Function(GUuidComparisonExpBuilder) updates,
-  ) => (toBuilder()..update(updates)).build();
+          void Function(GUuidComparisonExpBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
 
   @override
   GUuidComparisonExpBuilder toBuilder() =>
@@ -20018,8 +17134,7 @@ class GUuidComparisonExpBuilder
   _$GUuidComparisonExp _build() {
     _$GUuidComparisonExp _$result;
     try {
-      _$result =
-          _$v ??
+      _$result = _$v ??
           new _$GUuidComparisonExp._(
             G_eq: G_eq,
             G_gt: G_gt,
@@ -20041,10 +17156,7 @@ class GUuidComparisonExpBuilder
         _G_nin?.build();
       } catch (e) {
         throw new BuiltValueNestedFieldError(
-          r'GUuidComparisonExp',
-          _$failedField,
-          e.toString(),
-        );
+            r'GUuidComparisonExp', _$failedField, e.toString());
       }
       rethrow;
     }

--- a/app/backend/lib/graphql/__generated__/serializers.gql.g.dart
+++ b/app/backend/lib/graphql/__generated__/serializers.gql.g.dart
@@ -6,278 +6,220 @@ part of 'serializers.gql.dart';
 // BuiltValueGenerator
 // **************************************************************************
 
-Serializers _$serializers =
-    (new Serializers().toBuilder()
-          ..add(FetchPolicy.serializer)
-          ..add(GAchievementsBoolExp.serializer)
-          ..add(GAchievementsOrderBy.serializer)
-          ..add(GAchievementsSelectColumn.serializer)
-          ..add(GAchievementsStreamCursorInput.serializer)
-          ..add(GAchievementsStreamCursorValueInput.serializer)
-          ..add(GCursorOrdering.serializer)
-          ..add(GGetNewsData.serializer)
-          ..add(GGetNewsData_news.serializer)
-          ..add(GGetNewsReq.serializer)
-          ..add(GGetNewsVars.serializer)
-          ..add(GGetQuestsData.serializer)
-          ..add(GGetQuestsData_mainQuests.serializer)
-          ..add(GGetQuestsReq.serializer)
-          ..add(GGetQuestsVars.serializer)
-          ..add(GInsertMainQuestData.serializer)
-          ..add(GInsertMainQuestData_insertMainQuestsOne.serializer)
-          ..add(GInsertMainQuestReq.serializer)
-          ..add(GInsertMainQuestVars.serializer)
-          ..add(GIntComparisonExp.serializer)
-          ..add(GMainQuestRelationsBoolExp.serializer)
-          ..add(GMainQuestRelationsConstraint.serializer)
-          ..add(GMainQuestRelationsInsertInput.serializer)
-          ..add(GMainQuestRelationsOnConflict.serializer)
-          ..add(GMainQuestRelationsOrderBy.serializer)
-          ..add(GMainQuestRelationsPkColumnsInput.serializer)
-          ..add(GMainQuestRelationsSelectColumn.serializer)
-          ..add(GMainQuestRelationsSetInput.serializer)
-          ..add(GMainQuestRelationsStreamCursorInput.serializer)
-          ..add(GMainQuestRelationsStreamCursorValueInput.serializer)
-          ..add(GMainQuestRelationsUpdateColumn.serializer)
-          ..add(GMainQuestRelationsUpdates.serializer)
-          ..add(GMainQuestsBoolExp.serializer)
-          ..add(GMainQuestsConstraint.serializer)
-          ..add(GMainQuestsInsertInput.serializer)
-          ..add(GMainQuestsOnConflict.serializer)
-          ..add(GMainQuestsOrderBy.serializer)
-          ..add(GMainQuestsPkColumnsInput.serializer)
-          ..add(GMainQuestsSelectColumn.serializer)
-          ..add(GMainQuestsSetInput.serializer)
-          ..add(GMainQuestsStreamCursorInput.serializer)
-          ..add(GMainQuestsStreamCursorValueInput.serializer)
-          ..add(GMainQuestsUpdateColumn.serializer)
-          ..add(GMainQuestsUpdates.serializer)
-          ..add(GNewsBoolExp.serializer)
-          ..add(GNewsOrderBy.serializer)
-          ..add(GNewsSelectColumn.serializer)
-          ..add(GNewsStreamCursorInput.serializer)
-          ..add(GNewsStreamCursorValueInput.serializer)
-          ..add(GNotificationsBoolExp.serializer)
-          ..add(GNotificationsOrderBy.serializer)
-          ..add(GNotificationsSelectColumn.serializer)
-          ..add(GNotificationsStreamCursorInput.serializer)
-          ..add(GNotificationsStreamCursorValueInput.serializer)
-          ..add(GOrderBy.serializer)
-          ..add(GQuestCategoriesBoolExp.serializer)
-          ..add(GQuestCategoriesOrderBy.serializer)
-          ..add(GQuestCategoriesSelectColumn.serializer)
-          ..add(GQuestCategoriesStreamCursorInput.serializer)
-          ..add(GQuestCategoriesStreamCursorValueInput.serializer)
-          ..add(GQuestStatusBoolExp.serializer)
-          ..add(GQuestStatusEnum.serializer)
-          ..add(GQuestStatusEnumComparisonExp.serializer)
-          ..add(GQuestStatusOrderBy.serializer)
-          ..add(GQuestStatusSelectColumn.serializer)
-          ..add(GQuestStatusStreamCursorInput.serializer)
-          ..add(GQuestStatusStreamCursorValueInput.serializer)
-          ..add(GSeosBoolExp.serializer)
-          ..add(GSeosOrderBy.serializer)
-          ..add(GSeosSelectColumn.serializer)
-          ..add(GSeosStreamCursorInput.serializer)
-          ..add(GSeosStreamCursorValueInput.serializer)
-          ..add(GStringComparisonExp.serializer)
-          ..add(GTagsBoolExp.serializer)
-          ..add(GTagsOrderBy.serializer)
-          ..add(GTagsSelectColumn.serializer)
-          ..add(GTagsStreamCursorInput.serializer)
-          ..add(GTagsStreamCursorValueInput.serializer)
-          ..add(GTimestamptzComparisonExp.serializer)
-          ..add(GUserAchievementsBoolExp.serializer)
-          ..add(GUserAchievementsOrderBy.serializer)
-          ..add(GUserAchievementsSelectColumn.serializer)
-          ..add(GUserAchievementsStreamCursorInput.serializer)
-          ..add(GUserAchievementsStreamCursorValueInput.serializer)
-          ..add(GUsersBoolExp.serializer)
-          ..add(GUsersOrderBy.serializer)
-          ..add(GUsersSelectColumn.serializer)
-          ..add(GUsersStreamCursorInput.serializer)
-          ..add(GUsersStreamCursorValueInput.serializer)
-          ..add(GUuidComparisonExp.serializer)
-          ..addBuilderFactory(
-            const FullType(BuiltList, const [const FullType(DateTime)]),
-            () => new ListBuilder<DateTime>(),
-          )
-          ..addBuilderFactory(
-            const FullType(BuiltList, const [const FullType(DateTime)]),
-            () => new ListBuilder<DateTime>(),
-          )
-          ..addBuilderFactory(
-            const FullType(BuiltList, const [
-              const FullType(GAchievementsBoolExp),
-            ]),
-            () => new ListBuilder<GAchievementsBoolExp>(),
-          )
-          ..addBuilderFactory(
-            const FullType(BuiltList, const [
-              const FullType(GAchievementsBoolExp),
-            ]),
-            () => new ListBuilder<GAchievementsBoolExp>(),
-          )
-          ..addBuilderFactory(
-            const FullType(BuiltList, const [
-              const FullType(GGetNewsData_news),
-            ]),
-            () => new ListBuilder<GGetNewsData_news>(),
-          )
-          ..addBuilderFactory(
-            const FullType(BuiltList, const [
-              const FullType(GGetQuestsData_mainQuests),
-            ]),
-            () => new ListBuilder<GGetQuestsData_mainQuests>(),
-          )
-          ..addBuilderFactory(
-            const FullType(BuiltList, const [
-              const FullType(GMainQuestRelationsBoolExp),
-            ]),
-            () => new ListBuilder<GMainQuestRelationsBoolExp>(),
-          )
-          ..addBuilderFactory(
-            const FullType(BuiltList, const [
-              const FullType(GMainQuestRelationsBoolExp),
-            ]),
-            () => new ListBuilder<GMainQuestRelationsBoolExp>(),
-          )
-          ..addBuilderFactory(
-            const FullType(BuiltList, const [
-              const FullType(GMainQuestRelationsUpdateColumn),
-            ]),
-            () => new ListBuilder<GMainQuestRelationsUpdateColumn>(),
-          )
-          ..addBuilderFactory(
-            const FullType(BuiltList, const [
-              const FullType(GMainQuestsBoolExp),
-            ]),
-            () => new ListBuilder<GMainQuestsBoolExp>(),
-          )
-          ..addBuilderFactory(
-            const FullType(BuiltList, const [
-              const FullType(GMainQuestsBoolExp),
-            ]),
-            () => new ListBuilder<GMainQuestsBoolExp>(),
-          )
-          ..addBuilderFactory(
-            const FullType(BuiltList, const [
-              const FullType(GMainQuestsUpdateColumn),
-            ]),
-            () => new ListBuilder<GMainQuestsUpdateColumn>(),
-          )
-          ..addBuilderFactory(
-            const FullType(BuiltList, const [const FullType(GNewsBoolExp)]),
-            () => new ListBuilder<GNewsBoolExp>(),
-          )
-          ..addBuilderFactory(
-            const FullType(BuiltList, const [const FullType(GNewsBoolExp)]),
-            () => new ListBuilder<GNewsBoolExp>(),
-          )
-          ..addBuilderFactory(
-            const FullType(BuiltList, const [
-              const FullType(GNotificationsBoolExp),
-            ]),
-            () => new ListBuilder<GNotificationsBoolExp>(),
-          )
-          ..addBuilderFactory(
-            const FullType(BuiltList, const [
-              const FullType(GNotificationsBoolExp),
-            ]),
-            () => new ListBuilder<GNotificationsBoolExp>(),
-          )
-          ..addBuilderFactory(
-            const FullType(BuiltList, const [
-              const FullType(GQuestCategoriesBoolExp),
-            ]),
-            () => new ListBuilder<GQuestCategoriesBoolExp>(),
-          )
-          ..addBuilderFactory(
-            const FullType(BuiltList, const [
-              const FullType(GQuestCategoriesBoolExp),
-            ]),
-            () => new ListBuilder<GQuestCategoriesBoolExp>(),
-          )
-          ..addBuilderFactory(
-            const FullType(BuiltList, const [
-              const FullType(GQuestStatusBoolExp),
-            ]),
-            () => new ListBuilder<GQuestStatusBoolExp>(),
-          )
-          ..addBuilderFactory(
-            const FullType(BuiltList, const [
-              const FullType(GQuestStatusBoolExp),
-            ]),
-            () => new ListBuilder<GQuestStatusBoolExp>(),
-          )
-          ..addBuilderFactory(
-            const FullType(BuiltList, const [const FullType(GQuestStatusEnum)]),
-            () => new ListBuilder<GQuestStatusEnum>(),
-          )
-          ..addBuilderFactory(
-            const FullType(BuiltList, const [const FullType(GQuestStatusEnum)]),
-            () => new ListBuilder<GQuestStatusEnum>(),
-          )
-          ..addBuilderFactory(
-            const FullType(BuiltList, const [const FullType(GSeosBoolExp)]),
-            () => new ListBuilder<GSeosBoolExp>(),
-          )
-          ..addBuilderFactory(
-            const FullType(BuiltList, const [const FullType(GSeosBoolExp)]),
-            () => new ListBuilder<GSeosBoolExp>(),
-          )
-          ..addBuilderFactory(
-            const FullType(BuiltList, const [const FullType(GTagsBoolExp)]),
-            () => new ListBuilder<GTagsBoolExp>(),
-          )
-          ..addBuilderFactory(
-            const FullType(BuiltList, const [const FullType(GTagsBoolExp)]),
-            () => new ListBuilder<GTagsBoolExp>(),
-          )
-          ..addBuilderFactory(
-            const FullType(BuiltList, const [
-              const FullType(GUserAchievementsBoolExp),
-            ]),
-            () => new ListBuilder<GUserAchievementsBoolExp>(),
-          )
-          ..addBuilderFactory(
-            const FullType(BuiltList, const [
-              const FullType(GUserAchievementsBoolExp),
-            ]),
-            () => new ListBuilder<GUserAchievementsBoolExp>(),
-          )
-          ..addBuilderFactory(
-            const FullType(BuiltList, const [const FullType(GUsersBoolExp)]),
-            () => new ListBuilder<GUsersBoolExp>(),
-          )
-          ..addBuilderFactory(
-            const FullType(BuiltList, const [const FullType(GUsersBoolExp)]),
-            () => new ListBuilder<GUsersBoolExp>(),
-          )
-          ..addBuilderFactory(
-            const FullType(BuiltList, const [const FullType(String)]),
-            () => new ListBuilder<String>(),
-          )
-          ..addBuilderFactory(
-            const FullType(BuiltList, const [const FullType(String)]),
-            () => new ListBuilder<String>(),
-          )
-          ..addBuilderFactory(
-            const FullType(BuiltList, const [const FullType(String)]),
-            () => new ListBuilder<String>(),
-          )
-          ..addBuilderFactory(
-            const FullType(BuiltList, const [const FullType(String)]),
-            () => new ListBuilder<String>(),
-          )
-          ..addBuilderFactory(
-            const FullType(BuiltList, const [const FullType(int)]),
-            () => new ListBuilder<int>(),
-          )
-          ..addBuilderFactory(
-            const FullType(BuiltList, const [const FullType(int)]),
-            () => new ListBuilder<int>(),
-          ))
-        .build();
+Serializers _$serializers = (new Serializers().toBuilder()
+      ..add(FetchPolicy.serializer)
+      ..add(GAchievementsBoolExp.serializer)
+      ..add(GAchievementsOrderBy.serializer)
+      ..add(GAchievementsSelectColumn.serializer)
+      ..add(GAchievementsStreamCursorInput.serializer)
+      ..add(GAchievementsStreamCursorValueInput.serializer)
+      ..add(GCursorOrdering.serializer)
+      ..add(GGetNewsData.serializer)
+      ..add(GGetNewsData_news.serializer)
+      ..add(GGetNewsReq.serializer)
+      ..add(GGetNewsVars.serializer)
+      ..add(GGetQuestsData.serializer)
+      ..add(GGetQuestsData_mainQuests.serializer)
+      ..add(GGetQuestsReq.serializer)
+      ..add(GGetQuestsVars.serializer)
+      ..add(GInsertMainQuestData.serializer)
+      ..add(GInsertMainQuestData_insertMainQuestsOne.serializer)
+      ..add(GInsertMainQuestReq.serializer)
+      ..add(GInsertMainQuestVars.serializer)
+      ..add(GIntComparisonExp.serializer)
+      ..add(GMainQuestRelationsBoolExp.serializer)
+      ..add(GMainQuestRelationsConstraint.serializer)
+      ..add(GMainQuestRelationsInsertInput.serializer)
+      ..add(GMainQuestRelationsOnConflict.serializer)
+      ..add(GMainQuestRelationsOrderBy.serializer)
+      ..add(GMainQuestRelationsPkColumnsInput.serializer)
+      ..add(GMainQuestRelationsSelectColumn.serializer)
+      ..add(GMainQuestRelationsSetInput.serializer)
+      ..add(GMainQuestRelationsStreamCursorInput.serializer)
+      ..add(GMainQuestRelationsStreamCursorValueInput.serializer)
+      ..add(GMainQuestRelationsUpdateColumn.serializer)
+      ..add(GMainQuestRelationsUpdates.serializer)
+      ..add(GMainQuestsBoolExp.serializer)
+      ..add(GMainQuestsConstraint.serializer)
+      ..add(GMainQuestsInsertInput.serializer)
+      ..add(GMainQuestsOnConflict.serializer)
+      ..add(GMainQuestsOrderBy.serializer)
+      ..add(GMainQuestsPkColumnsInput.serializer)
+      ..add(GMainQuestsSelectColumn.serializer)
+      ..add(GMainQuestsSetInput.serializer)
+      ..add(GMainQuestsStreamCursorInput.serializer)
+      ..add(GMainQuestsStreamCursorValueInput.serializer)
+      ..add(GMainQuestsUpdateColumn.serializer)
+      ..add(GMainQuestsUpdates.serializer)
+      ..add(GNewsBoolExp.serializer)
+      ..add(GNewsOrderBy.serializer)
+      ..add(GNewsSelectColumn.serializer)
+      ..add(GNewsStreamCursorInput.serializer)
+      ..add(GNewsStreamCursorValueInput.serializer)
+      ..add(GNotificationsBoolExp.serializer)
+      ..add(GNotificationsOrderBy.serializer)
+      ..add(GNotificationsSelectColumn.serializer)
+      ..add(GNotificationsStreamCursorInput.serializer)
+      ..add(GNotificationsStreamCursorValueInput.serializer)
+      ..add(GOrderBy.serializer)
+      ..add(GQuestCategoriesBoolExp.serializer)
+      ..add(GQuestCategoriesOrderBy.serializer)
+      ..add(GQuestCategoriesSelectColumn.serializer)
+      ..add(GQuestCategoriesStreamCursorInput.serializer)
+      ..add(GQuestCategoriesStreamCursorValueInput.serializer)
+      ..add(GQuestStatusBoolExp.serializer)
+      ..add(GQuestStatusEnum.serializer)
+      ..add(GQuestStatusEnumComparisonExp.serializer)
+      ..add(GQuestStatusOrderBy.serializer)
+      ..add(GQuestStatusSelectColumn.serializer)
+      ..add(GQuestStatusStreamCursorInput.serializer)
+      ..add(GQuestStatusStreamCursorValueInput.serializer)
+      ..add(GSeosBoolExp.serializer)
+      ..add(GSeosOrderBy.serializer)
+      ..add(GSeosSelectColumn.serializer)
+      ..add(GSeosStreamCursorInput.serializer)
+      ..add(GSeosStreamCursorValueInput.serializer)
+      ..add(GStringComparisonExp.serializer)
+      ..add(GTagsBoolExp.serializer)
+      ..add(GTagsOrderBy.serializer)
+      ..add(GTagsSelectColumn.serializer)
+      ..add(GTagsStreamCursorInput.serializer)
+      ..add(GTagsStreamCursorValueInput.serializer)
+      ..add(GTimestamptzComparisonExp.serializer)
+      ..add(GUserAchievementsBoolExp.serializer)
+      ..add(GUserAchievementsOrderBy.serializer)
+      ..add(GUserAchievementsSelectColumn.serializer)
+      ..add(GUserAchievementsStreamCursorInput.serializer)
+      ..add(GUserAchievementsStreamCursorValueInput.serializer)
+      ..add(GUsersBoolExp.serializer)
+      ..add(GUsersOrderBy.serializer)
+      ..add(GUsersSelectColumn.serializer)
+      ..add(GUsersStreamCursorInput.serializer)
+      ..add(GUsersStreamCursorValueInput.serializer)
+      ..add(GUuidComparisonExp.serializer)
+      ..addBuilderFactory(
+          const FullType(BuiltList, const [const FullType(DateTime)]),
+          () => new ListBuilder<DateTime>())
+      ..addBuilderFactory(
+          const FullType(BuiltList, const [const FullType(DateTime)]),
+          () => new ListBuilder<DateTime>())
+      ..addBuilderFactory(
+          const FullType(
+              BuiltList, const [const FullType(GAchievementsBoolExp)]),
+          () => new ListBuilder<GAchievementsBoolExp>())
+      ..addBuilderFactory(
+          const FullType(
+              BuiltList, const [const FullType(GAchievementsBoolExp)]),
+          () => new ListBuilder<GAchievementsBoolExp>())
+      ..addBuilderFactory(
+          const FullType(BuiltList, const [const FullType(GGetNewsData_news)]),
+          () => new ListBuilder<GGetNewsData_news>())
+      ..addBuilderFactory(
+          const FullType(
+              BuiltList, const [const FullType(GGetQuestsData_mainQuests)]),
+          () => new ListBuilder<GGetQuestsData_mainQuests>())
+      ..addBuilderFactory(
+          const FullType(
+              BuiltList, const [const FullType(GMainQuestRelationsBoolExp)]),
+          () => new ListBuilder<GMainQuestRelationsBoolExp>())
+      ..addBuilderFactory(
+          const FullType(
+              BuiltList, const [const FullType(GMainQuestRelationsBoolExp)]),
+          () => new ListBuilder<GMainQuestRelationsBoolExp>())
+      ..addBuilderFactory(
+          const FullType(BuiltList,
+              const [const FullType(GMainQuestRelationsUpdateColumn)]),
+          () => new ListBuilder<GMainQuestRelationsUpdateColumn>())
+      ..addBuilderFactory(
+          const FullType(BuiltList, const [const FullType(GMainQuestsBoolExp)]),
+          () => new ListBuilder<GMainQuestsBoolExp>())
+      ..addBuilderFactory(
+          const FullType(BuiltList, const [const FullType(GMainQuestsBoolExp)]),
+          () => new ListBuilder<GMainQuestsBoolExp>())
+      ..addBuilderFactory(
+          const FullType(
+              BuiltList, const [const FullType(GMainQuestsUpdateColumn)]),
+          () => new ListBuilder<GMainQuestsUpdateColumn>())
+      ..addBuilderFactory(
+          const FullType(BuiltList, const [const FullType(GNewsBoolExp)]),
+          () => new ListBuilder<GNewsBoolExp>())
+      ..addBuilderFactory(
+          const FullType(BuiltList, const [const FullType(GNewsBoolExp)]),
+          () => new ListBuilder<GNewsBoolExp>())
+      ..addBuilderFactory(
+          const FullType(
+              BuiltList, const [const FullType(GNotificationsBoolExp)]),
+          () => new ListBuilder<GNotificationsBoolExp>())
+      ..addBuilderFactory(
+          const FullType(
+              BuiltList, const [const FullType(GNotificationsBoolExp)]),
+          () => new ListBuilder<GNotificationsBoolExp>())
+      ..addBuilderFactory(
+          const FullType(
+              BuiltList, const [const FullType(GQuestCategoriesBoolExp)]),
+          () => new ListBuilder<GQuestCategoriesBoolExp>())
+      ..addBuilderFactory(
+          const FullType(
+              BuiltList, const [const FullType(GQuestCategoriesBoolExp)]),
+          () => new ListBuilder<GQuestCategoriesBoolExp>())
+      ..addBuilderFactory(
+          const FullType(
+              BuiltList, const [const FullType(GQuestStatusBoolExp)]),
+          () => new ListBuilder<GQuestStatusBoolExp>())
+      ..addBuilderFactory(
+          const FullType(
+              BuiltList, const [const FullType(GQuestStatusBoolExp)]),
+          () => new ListBuilder<GQuestStatusBoolExp>())
+      ..addBuilderFactory(
+          const FullType(BuiltList, const [const FullType(GQuestStatusEnum)]),
+          () => new ListBuilder<GQuestStatusEnum>())
+      ..addBuilderFactory(
+          const FullType(BuiltList, const [const FullType(GQuestStatusEnum)]),
+          () => new ListBuilder<GQuestStatusEnum>())
+      ..addBuilderFactory(
+          const FullType(BuiltList, const [const FullType(GSeosBoolExp)]),
+          () => new ListBuilder<GSeosBoolExp>())
+      ..addBuilderFactory(
+          const FullType(BuiltList, const [const FullType(GSeosBoolExp)]),
+          () => new ListBuilder<GSeosBoolExp>())
+      ..addBuilderFactory(
+          const FullType(BuiltList, const [const FullType(GTagsBoolExp)]),
+          () => new ListBuilder<GTagsBoolExp>())
+      ..addBuilderFactory(
+          const FullType(BuiltList, const [const FullType(GTagsBoolExp)]),
+          () => new ListBuilder<GTagsBoolExp>())
+      ..addBuilderFactory(
+          const FullType(
+              BuiltList, const [const FullType(GUserAchievementsBoolExp)]),
+          () => new ListBuilder<GUserAchievementsBoolExp>())
+      ..addBuilderFactory(
+          const FullType(
+              BuiltList, const [const FullType(GUserAchievementsBoolExp)]),
+          () => new ListBuilder<GUserAchievementsBoolExp>())
+      ..addBuilderFactory(
+          const FullType(BuiltList, const [const FullType(GUsersBoolExp)]),
+          () => new ListBuilder<GUsersBoolExp>())
+      ..addBuilderFactory(
+          const FullType(BuiltList, const [const FullType(GUsersBoolExp)]),
+          () => new ListBuilder<GUsersBoolExp>())
+      ..addBuilderFactory(
+          const FullType(BuiltList, const [const FullType(String)]),
+          () => new ListBuilder<String>())
+      ..addBuilderFactory(
+          const FullType(BuiltList, const [const FullType(String)]),
+          () => new ListBuilder<String>())
+      ..addBuilderFactory(
+          const FullType(BuiltList, const [const FullType(String)]),
+          () => new ListBuilder<String>())
+      ..addBuilderFactory(
+          const FullType(BuiltList, const [const FullType(String)]),
+          () => new ListBuilder<String>())
+      ..addBuilderFactory(
+          const FullType(BuiltList, const [const FullType(int)]),
+          () => new ListBuilder<int>())
+      ..addBuilderFactory(
+          const FullType(BuiltList, const [const FullType(int)]),
+          () => new ListBuilder<int>()))
+    .build();
 
 // ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/app/backend/lib/graphql/news/__generated__/GetNews.ast.gql.dart
+++ b/app/backend/lib/graphql/news/__generated__/GetNews.ast.gql.dart
@@ -9,54 +9,50 @@ const GetNews = _i1.OperationDefinitionNode(
   name: _i1.NameNode(value: 'GetNews'),
   variableDefinitions: [],
   directives: [],
-  selectionSet: _i1.SelectionSetNode(
-    selections: [
-      _i1.FieldNode(
-        name: _i1.NameNode(value: 'news'),
-        alias: null,
-        arguments: [],
-        directives: [],
-        selectionSet: _i1.SelectionSetNode(
-          selections: [
-            _i1.FieldNode(
-              name: _i1.NameNode(value: 'title'),
-              alias: null,
-              arguments: [],
-              directives: [],
-              selectionSet: null,
-            ),
-            _i1.FieldNode(
-              name: _i1.NameNode(value: 'slug'),
-              alias: null,
-              arguments: [],
-              directives: [],
-              selectionSet: null,
-            ),
-            _i1.FieldNode(
-              name: _i1.NameNode(value: 'publishedAt'),
-              alias: null,
-              arguments: [],
-              directives: [],
-              selectionSet: null,
-            ),
-            _i1.FieldNode(
-              name: _i1.NameNode(value: 'excerpt'),
-              alias: null,
-              arguments: [],
-              directives: [],
-              selectionSet: null,
-            ),
-            _i1.FieldNode(
-              name: _i1.NameNode(value: 'coverImageUrl'),
-              alias: null,
-              arguments: [],
-              directives: [],
-              selectionSet: null,
-            ),
-          ],
+  selectionSet: _i1.SelectionSetNode(selections: [
+    _i1.FieldNode(
+      name: _i1.NameNode(value: 'news'),
+      alias: null,
+      arguments: [],
+      directives: [],
+      selectionSet: _i1.SelectionSetNode(selections: [
+        _i1.FieldNode(
+          name: _i1.NameNode(value: 'title'),
+          alias: null,
+          arguments: [],
+          directives: [],
+          selectionSet: null,
         ),
-      ),
-    ],
-  ),
+        _i1.FieldNode(
+          name: _i1.NameNode(value: 'slug'),
+          alias: null,
+          arguments: [],
+          directives: [],
+          selectionSet: null,
+        ),
+        _i1.FieldNode(
+          name: _i1.NameNode(value: 'publishedAt'),
+          alias: null,
+          arguments: [],
+          directives: [],
+          selectionSet: null,
+        ),
+        _i1.FieldNode(
+          name: _i1.NameNode(value: 'excerpt'),
+          alias: null,
+          arguments: [],
+          directives: [],
+          selectionSet: null,
+        ),
+        _i1.FieldNode(
+          name: _i1.NameNode(value: 'coverImageUrl'),
+          alias: null,
+          arguments: [],
+          directives: [],
+          selectionSet: null,
+        ),
+      ]),
+    )
+  ]),
 );
 const document = _i1.DocumentNode(definitions: [GetNews]);

--- a/app/backend/lib/graphql/news/__generated__/GetNews.data.gql.dart
+++ b/app/backend/lib/graphql/news/__generated__/GetNews.data.gql.dart
@@ -24,21 +24,25 @@ abstract class GGetNewsData
   BuiltList<GGetNewsData_news> get news;
   static Serializer<GGetNewsData> get serializer => _$gGetNewsDataSerializer;
 
-  Map<String, dynamic> toJson() =>
-      (_i1.serializers.serializeWith(GGetNewsData.serializer, this)
-          as Map<String, dynamic>);
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GGetNewsData.serializer,
+        this,
+      ) as Map<String, dynamic>);
 
   static GGetNewsData? fromJson(Map<String, dynamic> json) =>
-      _i1.serializers.deserializeWith(GGetNewsData.serializer, json);
+      _i1.serializers.deserializeWith(
+        GGetNewsData.serializer,
+        json,
+      );
 }
 
 abstract class GGetNewsData_news
     implements Built<GGetNewsData_news, GGetNewsData_newsBuilder> {
   GGetNewsData_news._();
 
-  factory GGetNewsData_news([
-    void Function(GGetNewsData_newsBuilder b) updates,
-  ]) = _$GGetNewsData_news;
+  factory GGetNewsData_news(
+          [void Function(GGetNewsData_newsBuilder b) updates]) =
+      _$GGetNewsData_news;
 
   static void _initializeBuilder(GGetNewsData_newsBuilder b) =>
       b..G__typename = 'News';
@@ -53,10 +57,14 @@ abstract class GGetNewsData_news
   static Serializer<GGetNewsData_news> get serializer =>
       _$gGetNewsDataNewsSerializer;
 
-  Map<String, dynamic> toJson() =>
-      (_i1.serializers.serializeWith(GGetNewsData_news.serializer, this)
-          as Map<String, dynamic>);
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GGetNewsData_news.serializer,
+        this,
+      ) as Map<String, dynamic>);
 
   static GGetNewsData_news? fromJson(Map<String, dynamic> json) =>
-      _i1.serializers.deserializeWith(GGetNewsData_news.serializer, json);
+      _i1.serializers.deserializeWith(
+        GGetNewsData_news.serializer,
+        json,
+      );
 }

--- a/app/backend/lib/graphql/news/__generated__/GetNews.data.gql.g.dart
+++ b/app/backend/lib/graphql/news/__generated__/GetNews.data.gql.g.dart
@@ -18,24 +18,16 @@ class _$GGetNewsDataSerializer implements StructuredSerializer<GGetNewsData> {
   final String wireName = 'GGetNewsData';
 
   @override
-  Iterable<Object?> serialize(
-    Serializers serializers,
-    GGetNewsData object, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+  Iterable<Object?> serialize(Serializers serializers, GGetNewsData object,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[
       '__typename',
-      serializers.serialize(
-        object.G__typename,
-        specifiedType: const FullType(String),
-      ),
+      serializers.serialize(object.G__typename,
+          specifiedType: const FullType(String)),
       'news',
-      serializers.serialize(
-        object.news,
-        specifiedType: const FullType(BuiltList, const [
-          const FullType(GGetNewsData_news),
-        ]),
-      ),
+      serializers.serialize(object.news,
+          specifiedType: const FullType(
+              BuiltList, const [const FullType(GGetNewsData_news)])),
     ];
 
     return result;
@@ -43,10 +35,8 @@ class _$GGetNewsDataSerializer implements StructuredSerializer<GGetNewsData> {
 
   @override
   GGetNewsData deserialize(
-    Serializers serializers,
-    Iterable<Object?> serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = new GGetNewsDataBuilder();
 
     final iterator = serialized.iterator;
@@ -56,23 +46,14 @@ class _$GGetNewsDataSerializer implements StructuredSerializer<GGetNewsData> {
       final Object? value = iterator.current;
       switch (key) {
         case '__typename':
-          result.G__typename =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )!
-                  as String;
+          result.G__typename = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
           break;
         case 'news':
-          result.news.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(BuiltList, const [
-                    const FullType(GGetNewsData_news),
-                  ]),
-                )!
-                as BuiltList<Object?>,
-          );
+          result.news.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(
+                      BuiltList, const [const FullType(GGetNewsData_news)]))!
+              as BuiltList<Object?>);
           break;
       }
     }
@@ -89,56 +70,43 @@ class _$GGetNewsData_newsSerializer
   final String wireName = 'GGetNewsData_news';
 
   @override
-  Iterable<Object?> serialize(
-    Serializers serializers,
-    GGetNewsData_news object, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+  Iterable<Object?> serialize(Serializers serializers, GGetNewsData_news object,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[
       '__typename',
-      serializers.serialize(
-        object.G__typename,
-        specifiedType: const FullType(String),
-      ),
+      serializers.serialize(object.G__typename,
+          specifiedType: const FullType(String)),
       'title',
-      serializers.serialize(
-        object.title,
-        specifiedType: const FullType(String),
-      ),
+      serializers.serialize(object.title,
+          specifiedType: const FullType(String)),
       'slug',
       serializers.serialize(object.slug, specifiedType: const FullType(String)),
       'excerpt',
-      serializers.serialize(
-        object.excerpt,
-        specifiedType: const FullType(String),
-      ),
+      serializers.serialize(object.excerpt,
+          specifiedType: const FullType(String)),
     ];
     Object? value;
     value = object.publishedAt;
     if (value != null) {
       result
         ..add('publishedAt')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(DateTime)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(DateTime)));
     }
     value = object.coverImageUrl;
     if (value != null) {
       result
         ..add('coverImageUrl')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(String)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
     }
     return result;
   }
 
   @override
   GGetNewsData_news deserialize(
-    Serializers serializers,
-    Iterable<Object?> serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = new GGetNewsData_newsBuilder();
 
     final iterator = serialized.iterator;
@@ -148,52 +116,28 @@ class _$GGetNewsData_newsSerializer
       final Object? value = iterator.current;
       switch (key) {
         case '__typename':
-          result.G__typename =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )!
-                  as String;
+          result.G__typename = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
           break;
         case 'title':
-          result.title =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )!
-                  as String;
+          result.title = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
           break;
         case 'slug':
-          result.slug =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )!
-                  as String;
+          result.slug = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
           break;
         case 'publishedAt':
-          result.publishedAt =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(DateTime),
-                  )
-                  as DateTime?;
+          result.publishedAt = serializers.deserialize(value,
+              specifiedType: const FullType(DateTime)) as DateTime?;
           break;
         case 'excerpt':
-          result.excerpt =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )!
-                  as String;
+          result.excerpt = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
           break;
         case 'coverImageUrl':
-          result.coverImageUrl =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )
-                  as String?;
+          result.coverImageUrl = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
           break;
       }
     }
@@ -212,12 +156,9 @@ class _$GGetNewsData extends GGetNewsData {
       (new GGetNewsDataBuilder()..update(updates))._build();
 
   _$GGetNewsData._({required this.G__typename, required this.news})
-    : super._() {
+      : super._() {
     BuiltValueNullFieldError.checkNotNull(
-      G__typename,
-      r'GGetNewsData',
-      'G__typename',
-    );
+        G__typename, r'GGetNewsData', 'G__typename');
     BuiltValueNullFieldError.checkNotNull(news, r'GGetNewsData', 'news');
   }
 
@@ -298,14 +239,10 @@ class GGetNewsDataBuilder
   _$GGetNewsData _build() {
     _$GGetNewsData _$result;
     try {
-      _$result =
-          _$v ??
+      _$result = _$v ??
           new _$GGetNewsData._(
             G__typename: BuiltValueNullFieldError.checkNotNull(
-              G__typename,
-              r'GGetNewsData',
-              'G__typename',
-            ),
+                G__typename, r'GGetNewsData', 'G__typename'),
             news: news.build(),
           );
     } catch (_) {
@@ -315,10 +252,7 @@ class GGetNewsDataBuilder
         news.build();
       } catch (e) {
         throw new BuiltValueNestedFieldError(
-          r'GGetNewsData',
-          _$failedField,
-          e.toString(),
-        );
+            r'GGetNewsData', _$failedField, e.toString());
       }
       rethrow;
     }
@@ -341,30 +275,24 @@ class _$GGetNewsData_news extends GGetNewsData_news {
   @override
   final String? coverImageUrl;
 
-  factory _$GGetNewsData_news([
-    void Function(GGetNewsData_newsBuilder)? updates,
-  ]) => (new GGetNewsData_newsBuilder()..update(updates))._build();
+  factory _$GGetNewsData_news(
+          [void Function(GGetNewsData_newsBuilder)? updates]) =>
+      (new GGetNewsData_newsBuilder()..update(updates))._build();
 
-  _$GGetNewsData_news._({
-    required this.G__typename,
-    required this.title,
-    required this.slug,
-    this.publishedAt,
-    required this.excerpt,
-    this.coverImageUrl,
-  }) : super._() {
+  _$GGetNewsData_news._(
+      {required this.G__typename,
+      required this.title,
+      required this.slug,
+      this.publishedAt,
+      required this.excerpt,
+      this.coverImageUrl})
+      : super._() {
     BuiltValueNullFieldError.checkNotNull(
-      G__typename,
-      r'GGetNewsData_news',
-      'G__typename',
-    );
+        G__typename, r'GGetNewsData_news', 'G__typename');
     BuiltValueNullFieldError.checkNotNull(title, r'GGetNewsData_news', 'title');
     BuiltValueNullFieldError.checkNotNull(slug, r'GGetNewsData_news', 'slug');
     BuiltValueNullFieldError.checkNotNull(
-      excerpt,
-      r'GGetNewsData_news',
-      'excerpt',
-    );
+        excerpt, r'GGetNewsData_news', 'excerpt');
   }
 
   @override
@@ -475,30 +403,17 @@ class GGetNewsData_newsBuilder
   GGetNewsData_news build() => _build();
 
   _$GGetNewsData_news _build() {
-    final _$result =
-        _$v ??
+    final _$result = _$v ??
         new _$GGetNewsData_news._(
           G__typename: BuiltValueNullFieldError.checkNotNull(
-            G__typename,
-            r'GGetNewsData_news',
-            'G__typename',
-          ),
+              G__typename, r'GGetNewsData_news', 'G__typename'),
           title: BuiltValueNullFieldError.checkNotNull(
-            title,
-            r'GGetNewsData_news',
-            'title',
-          ),
+              title, r'GGetNewsData_news', 'title'),
           slug: BuiltValueNullFieldError.checkNotNull(
-            slug,
-            r'GGetNewsData_news',
-            'slug',
-          ),
+              slug, r'GGetNewsData_news', 'slug'),
           publishedAt: publishedAt,
           excerpt: BuiltValueNullFieldError.checkNotNull(
-            excerpt,
-            r'GGetNewsData_news',
-            'excerpt',
-          ),
+              excerpt, r'GGetNewsData_news', 'excerpt'),
           coverImageUrl: coverImageUrl,
         );
     replace(_$result);

--- a/app/backend/lib/graphql/news/__generated__/GetNews.req.gql.dart
+++ b/app/backend/lib/graphql/news/__generated__/GetNews.req.gql.dart
@@ -38,17 +38,19 @@ abstract class GGetNewsReq
   _i4.Operation get operation;
   @override
   _i4.Request get execRequest => _i4.Request(
-    operation: operation,
-    variables: vars.toJson(),
-    context: context ?? const _i4.Context(),
-  );
+        operation: operation,
+        variables: vars.toJson(),
+        context: context ?? const _i4.Context(),
+      );
 
   @override
   String? get requestId;
   @override
   @BuiltValueField(serialize: false)
-  _i2.GGetNewsData? Function(_i2.GGetNewsData?, _i2.GGetNewsData?)?
-  get updateResult;
+  _i2.GGetNewsData? Function(
+    _i2.GGetNewsData?,
+    _i2.GGetNewsData?,
+  )? get updateResult;
   @override
   _i2.GGetNewsData? get optimisticResponse;
   @override
@@ -74,15 +76,19 @@ abstract class GGetNewsReq
 
   @override
   _i1.OperationRequest<_i2.GGetNewsData, _i3.GGetNewsVars> transformOperation(
-    _i4.Operation Function(_i4.Operation) transform,
-  ) => this.rebuild((b) => b..operation = transform(operation));
+          _i4.Operation Function(_i4.Operation) transform) =>
+      this.rebuild((b) => b..operation = transform(operation));
 
   static Serializer<GGetNewsReq> get serializer => _$gGetNewsReqSerializer;
 
-  Map<String, dynamic> toJson() =>
-      (_i6.serializers.serializeWith(GGetNewsReq.serializer, this)
-          as Map<String, dynamic>);
+  Map<String, dynamic> toJson() => (_i6.serializers.serializeWith(
+        GGetNewsReq.serializer,
+        this,
+      ) as Map<String, dynamic>);
 
   static GGetNewsReq? fromJson(Map<String, dynamic> json) =>
-      _i6.serializers.deserializeWith(GGetNewsReq.serializer, json);
+      _i6.serializers.deserializeWith(
+        GGetNewsReq.serializer,
+        json,
+      );
 }

--- a/app/backend/lib/graphql/news/__generated__/GetNews.req.gql.g.dart
+++ b/app/backend/lib/graphql/news/__generated__/GetNews.req.gql.g.dart
@@ -15,90 +15,62 @@ class _$GGetNewsReqSerializer implements StructuredSerializer<GGetNewsReq> {
   final String wireName = 'GGetNewsReq';
 
   @override
-  Iterable<Object?> serialize(
-    Serializers serializers,
-    GGetNewsReq object, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+  Iterable<Object?> serialize(Serializers serializers, GGetNewsReq object,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[
       'vars',
-      serializers.serialize(
-        object.vars,
-        specifiedType: const FullType(_i3.GGetNewsVars),
-      ),
+      serializers.serialize(object.vars,
+          specifiedType: const FullType(_i3.GGetNewsVars)),
       'operation',
-      serializers.serialize(
-        object.operation,
-        specifiedType: const FullType(_i4.Operation),
-      ),
+      serializers.serialize(object.operation,
+          specifiedType: const FullType(_i4.Operation)),
       'executeOnListen',
-      serializers.serialize(
-        object.executeOnListen,
-        specifiedType: const FullType(bool),
-      ),
+      serializers.serialize(object.executeOnListen,
+          specifiedType: const FullType(bool)),
     ];
     Object? value;
     value = object.requestId;
     if (value != null) {
       result
         ..add('requestId')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(String)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
     }
     value = object.optimisticResponse;
     if (value != null) {
       result
         ..add('optimisticResponse')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(_i2.GGetNewsData),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(_i2.GGetNewsData)));
     }
     value = object.updateCacheHandlerKey;
     if (value != null) {
       result
         ..add('updateCacheHandlerKey')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(String)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
     }
     value = object.updateCacheHandlerContext;
     if (value != null) {
       result
         ..add('updateCacheHandlerContext')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(Map, const [
-              const FullType(String),
-              const FullType(dynamic),
-            ]),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(
+                Map, const [const FullType(String), const FullType(dynamic)])));
     }
     value = object.fetchPolicy;
     if (value != null) {
       result
         ..add('fetchPolicy')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(_i1.FetchPolicy),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(_i1.FetchPolicy)));
     }
     return result;
   }
 
   @override
-  GGetNewsReq deserialize(
-    Serializers serializers,
-    Iterable<Object?> serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+  GGetNewsReq deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = new GGetNewsReqBuilder();
 
     final iterator = serialized.iterator;
@@ -108,73 +80,42 @@ class _$GGetNewsReqSerializer implements StructuredSerializer<GGetNewsReq> {
       final Object? value = iterator.current;
       switch (key) {
         case 'vars':
-          result.vars.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(_i3.GGetNewsVars),
-                )!
-                as _i3.GGetNewsVars,
-          );
+          result.vars.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(_i3.GGetNewsVars))!
+              as _i3.GGetNewsVars);
           break;
         case 'operation':
-          result.operation =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(_i4.Operation),
-                  )!
-                  as _i4.Operation;
+          result.operation = serializers.deserialize(value,
+              specifiedType: const FullType(_i4.Operation))! as _i4.Operation;
           break;
         case 'requestId':
-          result.requestId =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )
-                  as String?;
+          result.requestId = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
           break;
         case 'optimisticResponse':
-          result.optimisticResponse.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(_i2.GGetNewsData),
-                )!
-                as _i2.GGetNewsData,
-          );
+          result.optimisticResponse.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(_i2.GGetNewsData))!
+              as _i2.GGetNewsData);
           break;
         case 'updateCacheHandlerKey':
-          result.updateCacheHandlerKey =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )
-                  as String?;
+          result.updateCacheHandlerKey = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
           break;
         case 'updateCacheHandlerContext':
-          result.updateCacheHandlerContext =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(Map, const [
-                      const FullType(String),
-                      const FullType(dynamic),
-                    ]),
-                  )
-                  as Map<String, dynamic>?;
+          result.updateCacheHandlerContext = serializers.deserialize(value,
+              specifiedType: const FullType(Map, const [
+                const FullType(String),
+                const FullType(dynamic)
+              ])) as Map<String, dynamic>?;
           break;
         case 'fetchPolicy':
-          result.fetchPolicy =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(_i1.FetchPolicy),
-                  )
-                  as _i1.FetchPolicy?;
+          result.fetchPolicy = serializers.deserialize(value,
+                  specifiedType: const FullType(_i1.FetchPolicy))
+              as _i1.FetchPolicy?;
           break;
         case 'executeOnListen':
-          result.executeOnListen =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(bool),
-                  )!
-                  as bool;
+          result.executeOnListen = serializers.deserialize(value,
+              specifiedType: const FullType(bool))! as bool;
           break;
       }
     }
@@ -192,7 +133,7 @@ class _$GGetNewsReq extends GGetNewsReq {
   final String? requestId;
   @override
   final _i2.GGetNewsData? Function(_i2.GGetNewsData?, _i2.GGetNewsData?)?
-  updateResult;
+      updateResult;
   @override
   final _i2.GGetNewsData? optimisticResponse;
   @override
@@ -209,29 +150,23 @@ class _$GGetNewsReq extends GGetNewsReq {
   factory _$GGetNewsReq([void Function(GGetNewsReqBuilder)? updates]) =>
       (new GGetNewsReqBuilder()..update(updates))._build();
 
-  _$GGetNewsReq._({
-    required this.vars,
-    required this.operation,
-    this.requestId,
-    this.updateResult,
-    this.optimisticResponse,
-    this.updateCacheHandlerKey,
-    this.updateCacheHandlerContext,
-    this.fetchPolicy,
-    required this.executeOnListen,
-    this.context,
-  }) : super._() {
+  _$GGetNewsReq._(
+      {required this.vars,
+      required this.operation,
+      this.requestId,
+      this.updateResult,
+      this.optimisticResponse,
+      this.updateCacheHandlerKey,
+      this.updateCacheHandlerContext,
+      this.fetchPolicy,
+      required this.executeOnListen,
+      this.context})
+      : super._() {
     BuiltValueNullFieldError.checkNotNull(vars, r'GGetNewsReq', 'vars');
     BuiltValueNullFieldError.checkNotNull(
-      operation,
-      r'GGetNewsReq',
-      'operation',
-    );
+        operation, r'GGetNewsReq', 'operation');
     BuiltValueNullFieldError.checkNotNull(
-      executeOnListen,
-      r'GGetNewsReq',
-      'executeOnListen',
-    );
+        executeOnListen, r'GGetNewsReq', 'executeOnListen');
   }
 
   @override
@@ -309,13 +244,13 @@ class GGetNewsReqBuilder implements Builder<GGetNewsReq, GGetNewsReqBuilder> {
   set requestId(String? requestId) => _$this._requestId = requestId;
 
   _i2.GGetNewsData? Function(_i2.GGetNewsData?, _i2.GGetNewsData?)?
-  _updateResult;
+      _updateResult;
   _i2.GGetNewsData? Function(_i2.GGetNewsData?, _i2.GGetNewsData?)?
-  get updateResult => _$this._updateResult;
+      get updateResult => _$this._updateResult;
   set updateResult(
-    _i2.GGetNewsData? Function(_i2.GGetNewsData?, _i2.GGetNewsData?)?
-    updateResult,
-  ) => _$this._updateResult = updateResult;
+          _i2.GGetNewsData? Function(_i2.GGetNewsData?, _i2.GGetNewsData?)?
+              updateResult) =>
+      _$this._updateResult = updateResult;
 
   _i2.GGetNewsDataBuilder? _optimisticResponse;
   _i2.GGetNewsDataBuilder get optimisticResponse =>
@@ -332,8 +267,8 @@ class GGetNewsReqBuilder implements Builder<GGetNewsReq, GGetNewsReqBuilder> {
   Map<String, dynamic>? get updateCacheHandlerContext =>
       _$this._updateCacheHandlerContext;
   set updateCacheHandlerContext(
-    Map<String, dynamic>? updateCacheHandlerContext,
-  ) => _$this._updateCacheHandlerContext = updateCacheHandlerContext;
+          Map<String, dynamic>? updateCacheHandlerContext) =>
+      _$this._updateCacheHandlerContext = updateCacheHandlerContext;
 
   _i1.FetchPolicy? _fetchPolicy;
   _i1.FetchPolicy? get fetchPolicy => _$this._fetchPolicy;
@@ -388,15 +323,11 @@ class GGetNewsReqBuilder implements Builder<GGetNewsReq, GGetNewsReqBuilder> {
   _$GGetNewsReq _build() {
     _$GGetNewsReq _$result;
     try {
-      _$result =
-          _$v ??
+      _$result = _$v ??
           new _$GGetNewsReq._(
             vars: vars.build(),
             operation: BuiltValueNullFieldError.checkNotNull(
-              operation,
-              r'GGetNewsReq',
-              'operation',
-            ),
+                operation, r'GGetNewsReq', 'operation'),
             requestId: requestId,
             updateResult: updateResult,
             optimisticResponse: _optimisticResponse?.build(),
@@ -404,10 +335,7 @@ class GGetNewsReqBuilder implements Builder<GGetNewsReq, GGetNewsReqBuilder> {
             updateCacheHandlerContext: updateCacheHandlerContext,
             fetchPolicy: fetchPolicy,
             executeOnListen: BuiltValueNullFieldError.checkNotNull(
-              executeOnListen,
-              r'GGetNewsReq',
-              'executeOnListen',
-            ),
+                executeOnListen, r'GGetNewsReq', 'executeOnListen'),
             context: context,
           );
     } catch (_) {
@@ -420,10 +348,7 @@ class GGetNewsReqBuilder implements Builder<GGetNewsReq, GGetNewsReqBuilder> {
         _optimisticResponse?.build();
       } catch (e) {
         throw new BuiltValueNestedFieldError(
-          r'GGetNewsReq',
-          _$failedField,
-          e.toString(),
-        );
+            r'GGetNewsReq', _$failedField, e.toString());
       }
       rethrow;
     }

--- a/app/backend/lib/graphql/news/__generated__/GetNews.var.gql.dart
+++ b/app/backend/lib/graphql/news/__generated__/GetNews.var.gql.dart
@@ -17,10 +17,14 @@ abstract class GGetNewsVars
 
   static Serializer<GGetNewsVars> get serializer => _$gGetNewsVarsSerializer;
 
-  Map<String, dynamic> toJson() =>
-      (_i1.serializers.serializeWith(GGetNewsVars.serializer, this)
-          as Map<String, dynamic>);
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GGetNewsVars.serializer,
+        this,
+      ) as Map<String, dynamic>);
 
   static GGetNewsVars? fromJson(Map<String, dynamic> json) =>
-      _i1.serializers.deserializeWith(GGetNewsVars.serializer, json);
+      _i1.serializers.deserializeWith(
+        GGetNewsVars.serializer,
+        json,
+      );
 }

--- a/app/backend/lib/graphql/news/__generated__/GetNews.var.gql.g.dart
+++ b/app/backend/lib/graphql/news/__generated__/GetNews.var.gql.g.dart
@@ -16,20 +16,15 @@ class _$GGetNewsVarsSerializer implements StructuredSerializer<GGetNewsVars> {
   final String wireName = 'GGetNewsVars';
 
   @override
-  Iterable<Object?> serialize(
-    Serializers serializers,
-    GGetNewsVars object, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+  Iterable<Object?> serialize(Serializers serializers, GGetNewsVars object,
+      {FullType specifiedType = FullType.unspecified}) {
     return <Object?>[];
   }
 
   @override
   GGetNewsVars deserialize(
-    Serializers serializers,
-    Iterable<Object?> serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
     return new GGetNewsVarsBuilder().build();
   }
 }

--- a/app/backend/lib/graphql/quest/__generated__/GetQuests.ast.gql.dart
+++ b/app/backend/lib/graphql/quest/__generated__/GetQuests.ast.gql.dart
@@ -16,106 +16,96 @@ const GetQuests = _i1.OperationDefinitionNode(
       ),
       defaultValue: _i1.DefaultValueNode(value: null),
       directives: [],
-    ),
+    )
   ],
   directives: [],
-  selectionSet: _i1.SelectionSetNode(
-    selections: [
-      _i1.FieldNode(
-        name: _i1.NameNode(value: 'mainQuests'),
-        alias: null,
-        arguments: [
-          _i1.ArgumentNode(
-            name: _i1.NameNode(value: 'where'),
-            value: _i1.ObjectValueNode(
-              fields: [
+  selectionSet: _i1.SelectionSetNode(selections: [
+    _i1.FieldNode(
+      name: _i1.NameNode(value: 'mainQuests'),
+      alias: null,
+      arguments: [
+        _i1.ArgumentNode(
+          name: _i1.NameNode(value: 'where'),
+          value: _i1.ObjectValueNode(fields: [
+            _i1.ObjectFieldNode(
+              name: _i1.NameNode(value: 'userId'),
+              value: _i1.ObjectValueNode(fields: [
                 _i1.ObjectFieldNode(
-                  name: _i1.NameNode(value: 'userId'),
-                  value: _i1.ObjectValueNode(
-                    fields: [
-                      _i1.ObjectFieldNode(
-                        name: _i1.NameNode(value: '_eq'),
-                        value: _i1.VariableNode(
-                          name: _i1.NameNode(value: 'userId'),
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-              ],
-            ),
-          ),
-        ],
-        directives: [],
-        selectionSet: _i1.SelectionSetNode(
-          selections: [
-            _i1.FieldNode(
-              name: _i1.NameNode(value: 'id'),
-              alias: null,
-              arguments: [],
-              directives: [],
-              selectionSet: null,
-            ),
-            _i1.FieldNode(
-              name: _i1.NameNode(value: 'title'),
-              alias: null,
-              arguments: [],
-              directives: [],
-              selectionSet: null,
-            ),
-            _i1.FieldNode(
-              name: _i1.NameNode(value: 'description'),
-              alias: null,
-              arguments: [],
-              directives: [],
-              selectionSet: null,
-            ),
-            _i1.FieldNode(
-              name: _i1.NameNode(value: 'begunAt'),
-              alias: null,
-              arguments: [],
-              directives: [],
-              selectionSet: null,
-            ),
-            _i1.FieldNode(
-              name: _i1.NameNode(value: 'endedAt'),
-              alias: null,
-              arguments: [],
-              directives: [],
-              selectionSet: null,
-            ),
-            _i1.FieldNode(
-              name: _i1.NameNode(value: 'categoryId'),
-              alias: null,
-              arguments: [],
-              directives: [],
-              selectionSet: null,
-            ),
-            _i1.FieldNode(
-              name: _i1.NameNode(value: 'status'),
-              alias: null,
-              arguments: [],
-              directives: [],
-              selectionSet: null,
-            ),
-            _i1.FieldNode(
-              name: _i1.NameNode(value: 'coverImageUrl'),
-              alias: null,
-              arguments: [],
-              directives: [],
-              selectionSet: null,
-            ),
-            _i1.FieldNode(
-              name: _i1.NameNode(value: 'note'),
-              alias: null,
-              arguments: [],
-              directives: [],
-              selectionSet: null,
-            ),
-          ],
+                  name: _i1.NameNode(value: '_eq'),
+                  value: _i1.VariableNode(name: _i1.NameNode(value: 'userId')),
+                )
+              ]),
+            )
+          ]),
+        )
+      ],
+      directives: [],
+      selectionSet: _i1.SelectionSetNode(selections: [
+        _i1.FieldNode(
+          name: _i1.NameNode(value: 'id'),
+          alias: null,
+          arguments: [],
+          directives: [],
+          selectionSet: null,
         ),
-      ),
-    ],
-  ),
+        _i1.FieldNode(
+          name: _i1.NameNode(value: 'title'),
+          alias: null,
+          arguments: [],
+          directives: [],
+          selectionSet: null,
+        ),
+        _i1.FieldNode(
+          name: _i1.NameNode(value: 'description'),
+          alias: null,
+          arguments: [],
+          directives: [],
+          selectionSet: null,
+        ),
+        _i1.FieldNode(
+          name: _i1.NameNode(value: 'begunAt'),
+          alias: null,
+          arguments: [],
+          directives: [],
+          selectionSet: null,
+        ),
+        _i1.FieldNode(
+          name: _i1.NameNode(value: 'endedAt'),
+          alias: null,
+          arguments: [],
+          directives: [],
+          selectionSet: null,
+        ),
+        _i1.FieldNode(
+          name: _i1.NameNode(value: 'categoryId'),
+          alias: null,
+          arguments: [],
+          directives: [],
+          selectionSet: null,
+        ),
+        _i1.FieldNode(
+          name: _i1.NameNode(value: 'status'),
+          alias: null,
+          arguments: [],
+          directives: [],
+          selectionSet: null,
+        ),
+        _i1.FieldNode(
+          name: _i1.NameNode(value: 'coverImageUrl'),
+          alias: null,
+          arguments: [],
+          directives: [],
+          selectionSet: null,
+        ),
+        _i1.FieldNode(
+          name: _i1.NameNode(value: 'note'),
+          alias: null,
+          arguments: [],
+          directives: [],
+          selectionSet: null,
+        ),
+      ]),
+    )
+  ]),
 );
 const document = _i1.DocumentNode(definitions: [GetQuests]);

--- a/app/backend/lib/graphql/quest/__generated__/GetQuests.data.gql.dart
+++ b/app/backend/lib/graphql/quest/__generated__/GetQuests.data.gql.dart
@@ -27,12 +27,16 @@ abstract class GGetQuestsData
   static Serializer<GGetQuestsData> get serializer =>
       _$gGetQuestsDataSerializer;
 
-  Map<String, dynamic> toJson() =>
-      (_i1.serializers.serializeWith(GGetQuestsData.serializer, this)
-          as Map<String, dynamic>);
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GGetQuestsData.serializer,
+        this,
+      ) as Map<String, dynamic>);
 
   static GGetQuestsData? fromJson(Map<String, dynamic> json) =>
-      _i1.serializers.deserializeWith(GGetQuestsData.serializer, json);
+      _i1.serializers.deserializeWith(
+        GGetQuestsData.serializer,
+        json,
+      );
 }
 
 abstract class GGetQuestsData_mainQuests
@@ -40,9 +44,9 @@ abstract class GGetQuestsData_mainQuests
         Built<GGetQuestsData_mainQuests, GGetQuestsData_mainQuestsBuilder> {
   GGetQuestsData_mainQuests._();
 
-  factory GGetQuestsData_mainQuests([
-    void Function(GGetQuestsData_mainQuestsBuilder b) updates,
-  ]) = _$GGetQuestsData_mainQuests;
+  factory GGetQuestsData_mainQuests(
+          [void Function(GGetQuestsData_mainQuestsBuilder b) updates]) =
+      _$GGetQuestsData_mainQuests;
 
   static void _initializeBuilder(GGetQuestsData_mainQuestsBuilder b) =>
       b..G__typename = 'MainQuests';
@@ -61,11 +65,14 @@ abstract class GGetQuestsData_mainQuests
   static Serializer<GGetQuestsData_mainQuests> get serializer =>
       _$gGetQuestsDataMainQuestsSerializer;
 
-  Map<String, dynamic> toJson() =>
-      (_i1.serializers.serializeWith(GGetQuestsData_mainQuests.serializer, this)
-          as Map<String, dynamic>);
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GGetQuestsData_mainQuests.serializer,
+        this,
+      ) as Map<String, dynamic>);
 
-  static GGetQuestsData_mainQuests? fromJson(Map<String, dynamic> json) => _i1
-      .serializers
-      .deserializeWith(GGetQuestsData_mainQuests.serializer, json);
+  static GGetQuestsData_mainQuests? fromJson(Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GGetQuestsData_mainQuests.serializer,
+        json,
+      );
 }

--- a/app/backend/lib/graphql/quest/__generated__/GetQuests.data.gql.g.dart
+++ b/app/backend/lib/graphql/quest/__generated__/GetQuests.data.gql.g.dart
@@ -19,24 +19,16 @@ class _$GGetQuestsDataSerializer
   final String wireName = 'GGetQuestsData';
 
   @override
-  Iterable<Object?> serialize(
-    Serializers serializers,
-    GGetQuestsData object, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+  Iterable<Object?> serialize(Serializers serializers, GGetQuestsData object,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[
       '__typename',
-      serializers.serialize(
-        object.G__typename,
-        specifiedType: const FullType(String),
-      ),
+      serializers.serialize(object.G__typename,
+          specifiedType: const FullType(String)),
       'mainQuests',
-      serializers.serialize(
-        object.mainQuests,
-        specifiedType: const FullType(BuiltList, const [
-          const FullType(GGetQuestsData_mainQuests),
-        ]),
-      ),
+      serializers.serialize(object.mainQuests,
+          specifiedType: const FullType(
+              BuiltList, const [const FullType(GGetQuestsData_mainQuests)])),
     ];
 
     return result;
@@ -44,10 +36,8 @@ class _$GGetQuestsDataSerializer
 
   @override
   GGetQuestsData deserialize(
-    Serializers serializers,
-    Iterable<Object?> serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = new GGetQuestsDataBuilder();
 
     final iterator = serialized.iterator;
@@ -57,23 +47,14 @@ class _$GGetQuestsDataSerializer
       final Object? value = iterator.current;
       switch (key) {
         case '__typename':
-          result.G__typename =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )!
-                  as String;
+          result.G__typename = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
           break;
         case 'mainQuests':
-          result.mainQuests.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(BuiltList, const [
-                    const FullType(GGetQuestsData_mainQuests),
-                  ]),
-                )!
-                as BuiltList<Object?>,
-          );
+          result.mainQuests.replace(serializers.deserialize(value,
+              specifiedType: const FullType(BuiltList, const [
+                const FullType(GGetQuestsData_mainQuests)
+              ]))! as BuiltList<Object?>);
           break;
       }
     }
@@ -87,40 +68,30 @@ class _$GGetQuestsData_mainQuestsSerializer
   @override
   final Iterable<Type> types = const [
     GGetQuestsData_mainQuests,
-    _$GGetQuestsData_mainQuests,
+    _$GGetQuestsData_mainQuests
   ];
   @override
   final String wireName = 'GGetQuestsData_mainQuests';
 
   @override
   Iterable<Object?> serialize(
-    Serializers serializers,
-    GGetQuestsData_mainQuests object, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, GGetQuestsData_mainQuests object,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[
       '__typename',
-      serializers.serialize(
-        object.G__typename,
-        specifiedType: const FullType(String),
-      ),
+      serializers.serialize(object.G__typename,
+          specifiedType: const FullType(String)),
       'id',
       serializers.serialize(object.id, specifiedType: const FullType(String)),
       'title',
-      serializers.serialize(
-        object.title,
-        specifiedType: const FullType(String),
-      ),
+      serializers.serialize(object.title,
+          specifiedType: const FullType(String)),
       'description',
-      serializers.serialize(
-        object.description,
-        specifiedType: const FullType(String),
-      ),
+      serializers.serialize(object.description,
+          specifiedType: const FullType(String)),
       'status',
-      serializers.serialize(
-        object.status,
-        specifiedType: const FullType(_i2.GQuestStatusEnum),
-      ),
+      serializers.serialize(object.status,
+          specifiedType: const FullType(_i2.GQuestStatusEnum)),
       'note',
       serializers.serialize(object.note, specifiedType: const FullType(String)),
     ];
@@ -129,43 +100,37 @@ class _$GGetQuestsData_mainQuestsSerializer
     if (value != null) {
       result
         ..add('begunAt')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(DateTime)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(DateTime)));
     }
     value = object.endedAt;
     if (value != null) {
       result
         ..add('endedAt')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(DateTime)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(DateTime)));
     }
     value = object.categoryId;
     if (value != null) {
       result
         ..add('categoryId')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(String)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
     }
     value = object.coverImageUrl;
     if (value != null) {
       result
         ..add('coverImageUrl')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(String)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
     }
     return result;
   }
 
   @override
   GGetQuestsData_mainQuests deserialize(
-    Serializers serializers,
-    Iterable<Object?> serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = new GGetQuestsData_mainQuestsBuilder();
 
     final iterator = serialized.iterator;
@@ -175,84 +140,45 @@ class _$GGetQuestsData_mainQuestsSerializer
       final Object? value = iterator.current;
       switch (key) {
         case '__typename':
-          result.G__typename =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )!
-                  as String;
+          result.G__typename = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
           break;
         case 'id':
-          result.id =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )!
-                  as String;
+          result.id = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
           break;
         case 'title':
-          result.title =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )!
-                  as String;
+          result.title = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
           break;
         case 'description':
-          result.description =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )!
-                  as String;
+          result.description = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
           break;
         case 'begunAt':
-          result.begunAt =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(DateTime),
-                  )
-                  as DateTime?;
+          result.begunAt = serializers.deserialize(value,
+              specifiedType: const FullType(DateTime)) as DateTime?;
           break;
         case 'endedAt':
-          result.endedAt =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(DateTime),
-                  )
-                  as DateTime?;
+          result.endedAt = serializers.deserialize(value,
+              specifiedType: const FullType(DateTime)) as DateTime?;
           break;
         case 'categoryId':
-          result.categoryId =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )
-                  as String?;
+          result.categoryId = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
           break;
         case 'status':
-          result.status =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(_i2.GQuestStatusEnum),
-                  )!
-                  as _i2.GQuestStatusEnum;
+          result.status = serializers.deserialize(value,
+                  specifiedType: const FullType(_i2.GQuestStatusEnum))!
+              as _i2.GQuestStatusEnum;
           break;
         case 'coverImageUrl':
-          result.coverImageUrl =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )
-                  as String?;
+          result.coverImageUrl = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
           break;
         case 'note':
-          result.note =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )!
-                  as String;
+          result.note = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
           break;
       }
     }
@@ -271,17 +197,11 @@ class _$GGetQuestsData extends GGetQuestsData {
       (new GGetQuestsDataBuilder()..update(updates))._build();
 
   _$GGetQuestsData._({required this.G__typename, required this.mainQuests})
-    : super._() {
+      : super._() {
     BuiltValueNullFieldError.checkNotNull(
-      G__typename,
-      r'GGetQuestsData',
-      'G__typename',
-    );
+        G__typename, r'GGetQuestsData', 'G__typename');
     BuiltValueNullFieldError.checkNotNull(
-      mainQuests,
-      r'GGetQuestsData',
-      'mainQuests',
-    );
+        mainQuests, r'GGetQuestsData', 'mainQuests');
   }
 
   @override
@@ -363,14 +283,10 @@ class GGetQuestsDataBuilder
   _$GGetQuestsData _build() {
     _$GGetQuestsData _$result;
     try {
-      _$result =
-          _$v ??
+      _$result = _$v ??
           new _$GGetQuestsData._(
             G__typename: BuiltValueNullFieldError.checkNotNull(
-              G__typename,
-              r'GGetQuestsData',
-              'G__typename',
-            ),
+                G__typename, r'GGetQuestsData', 'G__typename'),
             mainQuests: mainQuests.build(),
           );
     } catch (_) {
@@ -380,10 +296,7 @@ class GGetQuestsDataBuilder
         mainQuests.build();
       } catch (e) {
         throw new BuiltValueNestedFieldError(
-          r'GGetQuestsData',
-          _$failedField,
-          e.toString(),
-        );
+            r'GGetQuestsData', _$failedField, e.toString());
       }
       rethrow;
     }
@@ -414,58 +327,40 @@ class _$GGetQuestsData_mainQuests extends GGetQuestsData_mainQuests {
   @override
   final String note;
 
-  factory _$GGetQuestsData_mainQuests([
-    void Function(GGetQuestsData_mainQuestsBuilder)? updates,
-  ]) => (new GGetQuestsData_mainQuestsBuilder()..update(updates))._build();
+  factory _$GGetQuestsData_mainQuests(
+          [void Function(GGetQuestsData_mainQuestsBuilder)? updates]) =>
+      (new GGetQuestsData_mainQuestsBuilder()..update(updates))._build();
 
-  _$GGetQuestsData_mainQuests._({
-    required this.G__typename,
-    required this.id,
-    required this.title,
-    required this.description,
-    this.begunAt,
-    this.endedAt,
-    this.categoryId,
-    required this.status,
-    this.coverImageUrl,
-    required this.note,
-  }) : super._() {
+  _$GGetQuestsData_mainQuests._(
+      {required this.G__typename,
+      required this.id,
+      required this.title,
+      required this.description,
+      this.begunAt,
+      this.endedAt,
+      this.categoryId,
+      required this.status,
+      this.coverImageUrl,
+      required this.note})
+      : super._() {
     BuiltValueNullFieldError.checkNotNull(
-      G__typename,
-      r'GGetQuestsData_mainQuests',
-      'G__typename',
-    );
+        G__typename, r'GGetQuestsData_mainQuests', 'G__typename');
     BuiltValueNullFieldError.checkNotNull(
-      id,
-      r'GGetQuestsData_mainQuests',
-      'id',
-    );
+        id, r'GGetQuestsData_mainQuests', 'id');
     BuiltValueNullFieldError.checkNotNull(
-      title,
-      r'GGetQuestsData_mainQuests',
-      'title',
-    );
+        title, r'GGetQuestsData_mainQuests', 'title');
     BuiltValueNullFieldError.checkNotNull(
-      description,
-      r'GGetQuestsData_mainQuests',
-      'description',
-    );
+        description, r'GGetQuestsData_mainQuests', 'description');
     BuiltValueNullFieldError.checkNotNull(
-      status,
-      r'GGetQuestsData_mainQuests',
-      'status',
-    );
+        status, r'GGetQuestsData_mainQuests', 'status');
     BuiltValueNullFieldError.checkNotNull(
-      note,
-      r'GGetQuestsData_mainQuests',
-      'note',
-    );
+        note, r'GGetQuestsData_mainQuests', 'note');
   }
 
   @override
   GGetQuestsData_mainQuests rebuild(
-    void Function(GGetQuestsData_mainQuestsBuilder) updates,
-  ) => (toBuilder()..update(updates)).build();
+          void Function(GGetQuestsData_mainQuestsBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
 
   @override
   GGetQuestsData_mainQuestsBuilder toBuilder() =>
@@ -604,43 +499,24 @@ class GGetQuestsData_mainQuestsBuilder
   GGetQuestsData_mainQuests build() => _build();
 
   _$GGetQuestsData_mainQuests _build() {
-    final _$result =
-        _$v ??
+    final _$result = _$v ??
         new _$GGetQuestsData_mainQuests._(
           G__typename: BuiltValueNullFieldError.checkNotNull(
-            G__typename,
-            r'GGetQuestsData_mainQuests',
-            'G__typename',
-          ),
+              G__typename, r'GGetQuestsData_mainQuests', 'G__typename'),
           id: BuiltValueNullFieldError.checkNotNull(
-            id,
-            r'GGetQuestsData_mainQuests',
-            'id',
-          ),
+              id, r'GGetQuestsData_mainQuests', 'id'),
           title: BuiltValueNullFieldError.checkNotNull(
-            title,
-            r'GGetQuestsData_mainQuests',
-            'title',
-          ),
+              title, r'GGetQuestsData_mainQuests', 'title'),
           description: BuiltValueNullFieldError.checkNotNull(
-            description,
-            r'GGetQuestsData_mainQuests',
-            'description',
-          ),
+              description, r'GGetQuestsData_mainQuests', 'description'),
           begunAt: begunAt,
           endedAt: endedAt,
           categoryId: categoryId,
           status: BuiltValueNullFieldError.checkNotNull(
-            status,
-            r'GGetQuestsData_mainQuests',
-            'status',
-          ),
+              status, r'GGetQuestsData_mainQuests', 'status'),
           coverImageUrl: coverImageUrl,
           note: BuiltValueNullFieldError.checkNotNull(
-            note,
-            r'GGetQuestsData_mainQuests',
-            'note',
-          ),
+              note, r'GGetQuestsData_mainQuests', 'note'),
         );
     replace(_$result);
     return _$result;

--- a/app/backend/lib/graphql/quest/__generated__/GetQuests.req.gql.dart
+++ b/app/backend/lib/graphql/quest/__generated__/GetQuests.req.gql.dart
@@ -38,17 +38,19 @@ abstract class GGetQuestsReq
   _i4.Operation get operation;
   @override
   _i4.Request get execRequest => _i4.Request(
-    operation: operation,
-    variables: vars.toJson(),
-    context: context ?? const _i4.Context(),
-  );
+        operation: operation,
+        variables: vars.toJson(),
+        context: context ?? const _i4.Context(),
+      );
 
   @override
   String? get requestId;
   @override
   @BuiltValueField(serialize: false)
-  _i2.GGetQuestsData? Function(_i2.GGetQuestsData?, _i2.GGetQuestsData?)?
-  get updateResult;
+  _i2.GGetQuestsData? Function(
+    _i2.GGetQuestsData?,
+    _i2.GGetQuestsData?,
+  )? get updateResult;
   @override
   _i2.GGetQuestsData? get optimisticResponse;
   @override
@@ -74,15 +76,19 @@ abstract class GGetQuestsReq
 
   @override
   _i1.OperationRequest<_i2.GGetQuestsData, _i3.GGetQuestsVars>
-  transformOperation(_i4.Operation Function(_i4.Operation) transform) =>
-      this.rebuild((b) => b..operation = transform(operation));
+      transformOperation(_i4.Operation Function(_i4.Operation) transform) =>
+          this.rebuild((b) => b..operation = transform(operation));
 
   static Serializer<GGetQuestsReq> get serializer => _$gGetQuestsReqSerializer;
 
-  Map<String, dynamic> toJson() =>
-      (_i6.serializers.serializeWith(GGetQuestsReq.serializer, this)
-          as Map<String, dynamic>);
+  Map<String, dynamic> toJson() => (_i6.serializers.serializeWith(
+        GGetQuestsReq.serializer,
+        this,
+      ) as Map<String, dynamic>);
 
   static GGetQuestsReq? fromJson(Map<String, dynamic> json) =>
-      _i6.serializers.deserializeWith(GGetQuestsReq.serializer, json);
+      _i6.serializers.deserializeWith(
+        GGetQuestsReq.serializer,
+        json,
+      );
 }

--- a/app/backend/lib/graphql/quest/__generated__/GetQuests.req.gql.g.dart
+++ b/app/backend/lib/graphql/quest/__generated__/GetQuests.req.gql.g.dart
@@ -16,90 +16,63 @@ class _$GGetQuestsReqSerializer implements StructuredSerializer<GGetQuestsReq> {
   final String wireName = 'GGetQuestsReq';
 
   @override
-  Iterable<Object?> serialize(
-    Serializers serializers,
-    GGetQuestsReq object, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+  Iterable<Object?> serialize(Serializers serializers, GGetQuestsReq object,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[
       'vars',
-      serializers.serialize(
-        object.vars,
-        specifiedType: const FullType(_i3.GGetQuestsVars),
-      ),
+      serializers.serialize(object.vars,
+          specifiedType: const FullType(_i3.GGetQuestsVars)),
       'operation',
-      serializers.serialize(
-        object.operation,
-        specifiedType: const FullType(_i4.Operation),
-      ),
+      serializers.serialize(object.operation,
+          specifiedType: const FullType(_i4.Operation)),
       'executeOnListen',
-      serializers.serialize(
-        object.executeOnListen,
-        specifiedType: const FullType(bool),
-      ),
+      serializers.serialize(object.executeOnListen,
+          specifiedType: const FullType(bool)),
     ];
     Object? value;
     value = object.requestId;
     if (value != null) {
       result
         ..add('requestId')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(String)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
     }
     value = object.optimisticResponse;
     if (value != null) {
       result
         ..add('optimisticResponse')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(_i2.GGetQuestsData),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(_i2.GGetQuestsData)));
     }
     value = object.updateCacheHandlerKey;
     if (value != null) {
       result
         ..add('updateCacheHandlerKey')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(String)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
     }
     value = object.updateCacheHandlerContext;
     if (value != null) {
       result
         ..add('updateCacheHandlerContext')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(Map, const [
-              const FullType(String),
-              const FullType(dynamic),
-            ]),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(
+                Map, const [const FullType(String), const FullType(dynamic)])));
     }
     value = object.fetchPolicy;
     if (value != null) {
       result
         ..add('fetchPolicy')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(_i1.FetchPolicy),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(_i1.FetchPolicy)));
     }
     return result;
   }
 
   @override
   GGetQuestsReq deserialize(
-    Serializers serializers,
-    Iterable<Object?> serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = new GGetQuestsReqBuilder();
 
     final iterator = serialized.iterator;
@@ -109,73 +82,42 @@ class _$GGetQuestsReqSerializer implements StructuredSerializer<GGetQuestsReq> {
       final Object? value = iterator.current;
       switch (key) {
         case 'vars':
-          result.vars.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(_i3.GGetQuestsVars),
-                )!
-                as _i3.GGetQuestsVars,
-          );
+          result.vars.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(_i3.GGetQuestsVars))!
+              as _i3.GGetQuestsVars);
           break;
         case 'operation':
-          result.operation =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(_i4.Operation),
-                  )!
-                  as _i4.Operation;
+          result.operation = serializers.deserialize(value,
+              specifiedType: const FullType(_i4.Operation))! as _i4.Operation;
           break;
         case 'requestId':
-          result.requestId =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )
-                  as String?;
+          result.requestId = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
           break;
         case 'optimisticResponse':
-          result.optimisticResponse.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(_i2.GGetQuestsData),
-                )!
-                as _i2.GGetQuestsData,
-          );
+          result.optimisticResponse.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(_i2.GGetQuestsData))!
+              as _i2.GGetQuestsData);
           break;
         case 'updateCacheHandlerKey':
-          result.updateCacheHandlerKey =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )
-                  as String?;
+          result.updateCacheHandlerKey = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
           break;
         case 'updateCacheHandlerContext':
-          result.updateCacheHandlerContext =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(Map, const [
-                      const FullType(String),
-                      const FullType(dynamic),
-                    ]),
-                  )
-                  as Map<String, dynamic>?;
+          result.updateCacheHandlerContext = serializers.deserialize(value,
+              specifiedType: const FullType(Map, const [
+                const FullType(String),
+                const FullType(dynamic)
+              ])) as Map<String, dynamic>?;
           break;
         case 'fetchPolicy':
-          result.fetchPolicy =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(_i1.FetchPolicy),
-                  )
-                  as _i1.FetchPolicy?;
+          result.fetchPolicy = serializers.deserialize(value,
+                  specifiedType: const FullType(_i1.FetchPolicy))
+              as _i1.FetchPolicy?;
           break;
         case 'executeOnListen':
-          result.executeOnListen =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(bool),
-                  )!
-                  as bool;
+          result.executeOnListen = serializers.deserialize(value,
+              specifiedType: const FullType(bool))! as bool;
           break;
       }
     }
@@ -193,7 +135,7 @@ class _$GGetQuestsReq extends GGetQuestsReq {
   final String? requestId;
   @override
   final _i2.GGetQuestsData? Function(_i2.GGetQuestsData?, _i2.GGetQuestsData?)?
-  updateResult;
+      updateResult;
   @override
   final _i2.GGetQuestsData? optimisticResponse;
   @override
@@ -210,29 +152,23 @@ class _$GGetQuestsReq extends GGetQuestsReq {
   factory _$GGetQuestsReq([void Function(GGetQuestsReqBuilder)? updates]) =>
       (new GGetQuestsReqBuilder()..update(updates))._build();
 
-  _$GGetQuestsReq._({
-    required this.vars,
-    required this.operation,
-    this.requestId,
-    this.updateResult,
-    this.optimisticResponse,
-    this.updateCacheHandlerKey,
-    this.updateCacheHandlerContext,
-    this.fetchPolicy,
-    required this.executeOnListen,
-    this.context,
-  }) : super._() {
+  _$GGetQuestsReq._(
+      {required this.vars,
+      required this.operation,
+      this.requestId,
+      this.updateResult,
+      this.optimisticResponse,
+      this.updateCacheHandlerKey,
+      this.updateCacheHandlerContext,
+      this.fetchPolicy,
+      required this.executeOnListen,
+      this.context})
+      : super._() {
     BuiltValueNullFieldError.checkNotNull(vars, r'GGetQuestsReq', 'vars');
     BuiltValueNullFieldError.checkNotNull(
-      operation,
-      r'GGetQuestsReq',
-      'operation',
-    );
+        operation, r'GGetQuestsReq', 'operation');
     BuiltValueNullFieldError.checkNotNull(
-      executeOnListen,
-      r'GGetQuestsReq',
-      'executeOnListen',
-    );
+        executeOnListen, r'GGetQuestsReq', 'executeOnListen');
   }
 
   @override
@@ -311,13 +247,14 @@ class GGetQuestsReqBuilder
   set requestId(String? requestId) => _$this._requestId = requestId;
 
   _i2.GGetQuestsData? Function(_i2.GGetQuestsData?, _i2.GGetQuestsData?)?
-  _updateResult;
+      _updateResult;
   _i2.GGetQuestsData? Function(_i2.GGetQuestsData?, _i2.GGetQuestsData?)?
-  get updateResult => _$this._updateResult;
+      get updateResult => _$this._updateResult;
   set updateResult(
-    _i2.GGetQuestsData? Function(_i2.GGetQuestsData?, _i2.GGetQuestsData?)?
-    updateResult,
-  ) => _$this._updateResult = updateResult;
+          _i2.GGetQuestsData? Function(
+                  _i2.GGetQuestsData?, _i2.GGetQuestsData?)?
+              updateResult) =>
+      _$this._updateResult = updateResult;
 
   _i2.GGetQuestsDataBuilder? _optimisticResponse;
   _i2.GGetQuestsDataBuilder get optimisticResponse =>
@@ -334,8 +271,8 @@ class GGetQuestsReqBuilder
   Map<String, dynamic>? get updateCacheHandlerContext =>
       _$this._updateCacheHandlerContext;
   set updateCacheHandlerContext(
-    Map<String, dynamic>? updateCacheHandlerContext,
-  ) => _$this._updateCacheHandlerContext = updateCacheHandlerContext;
+          Map<String, dynamic>? updateCacheHandlerContext) =>
+      _$this._updateCacheHandlerContext = updateCacheHandlerContext;
 
   _i1.FetchPolicy? _fetchPolicy;
   _i1.FetchPolicy? get fetchPolicy => _$this._fetchPolicy;
@@ -390,15 +327,11 @@ class GGetQuestsReqBuilder
   _$GGetQuestsReq _build() {
     _$GGetQuestsReq _$result;
     try {
-      _$result =
-          _$v ??
+      _$result = _$v ??
           new _$GGetQuestsReq._(
             vars: vars.build(),
             operation: BuiltValueNullFieldError.checkNotNull(
-              operation,
-              r'GGetQuestsReq',
-              'operation',
-            ),
+                operation, r'GGetQuestsReq', 'operation'),
             requestId: requestId,
             updateResult: updateResult,
             optimisticResponse: _optimisticResponse?.build(),
@@ -406,10 +339,7 @@ class GGetQuestsReqBuilder
             updateCacheHandlerContext: updateCacheHandlerContext,
             fetchPolicy: fetchPolicy,
             executeOnListen: BuiltValueNullFieldError.checkNotNull(
-              executeOnListen,
-              r'GGetQuestsReq',
-              'executeOnListen',
-            ),
+                executeOnListen, r'GGetQuestsReq', 'executeOnListen'),
             context: context,
           );
     } catch (_) {
@@ -422,10 +352,7 @@ class GGetQuestsReqBuilder
         _optimisticResponse?.build();
       } catch (e) {
         throw new BuiltValueNestedFieldError(
-          r'GGetQuestsReq',
-          _$failedField,
-          e.toString(),
-        );
+            r'GGetQuestsReq', _$failedField, e.toString());
       }
       rethrow;
     }

--- a/app/backend/lib/graphql/quest/__generated__/GetQuests.var.gql.dart
+++ b/app/backend/lib/graphql/quest/__generated__/GetQuests.var.gql.dart
@@ -19,10 +19,14 @@ abstract class GGetQuestsVars
   static Serializer<GGetQuestsVars> get serializer =>
       _$gGetQuestsVarsSerializer;
 
-  Map<String, dynamic> toJson() =>
-      (_i1.serializers.serializeWith(GGetQuestsVars.serializer, this)
-          as Map<String, dynamic>);
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GGetQuestsVars.serializer,
+        this,
+      ) as Map<String, dynamic>);
 
   static GGetQuestsVars? fromJson(Map<String, dynamic> json) =>
-      _i1.serializers.deserializeWith(GGetQuestsVars.serializer, json);
+      _i1.serializers.deserializeWith(
+        GGetQuestsVars.serializer,
+        json,
+      );
 }

--- a/app/backend/lib/graphql/quest/__generated__/GetQuests.var.gql.g.dart
+++ b/app/backend/lib/graphql/quest/__generated__/GetQuests.var.gql.g.dart
@@ -17,17 +17,12 @@ class _$GGetQuestsVarsSerializer
   final String wireName = 'GGetQuestsVars';
 
   @override
-  Iterable<Object?> serialize(
-    Serializers serializers,
-    GGetQuestsVars object, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+  Iterable<Object?> serialize(Serializers serializers, GGetQuestsVars object,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[
       'userId',
-      serializers.serialize(
-        object.userId,
-        specifiedType: const FullType(String),
-      ),
+      serializers.serialize(object.userId,
+          specifiedType: const FullType(String)),
     ];
 
     return result;
@@ -35,10 +30,8 @@ class _$GGetQuestsVarsSerializer
 
   @override
   GGetQuestsVars deserialize(
-    Serializers serializers,
-    Iterable<Object?> serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = new GGetQuestsVarsBuilder();
 
     final iterator = serialized.iterator;
@@ -48,12 +41,8 @@ class _$GGetQuestsVarsSerializer
       final Object? value = iterator.current;
       switch (key) {
         case 'userId':
-          result.userId =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )!
-                  as String;
+          result.userId = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
           break;
       }
     }
@@ -97,9 +86,9 @@ class _$GGetQuestsVars extends GGetQuestsVars {
 
   @override
   String toString() {
-    return (newBuiltValueToStringHelper(
-      r'GGetQuestsVars',
-    )..add('userId', userId)).toString();
+    return (newBuiltValueToStringHelper(r'GGetQuestsVars')
+          ..add('userId', userId))
+        .toString();
   }
 }
 
@@ -137,14 +126,10 @@ class GGetQuestsVarsBuilder
   GGetQuestsVars build() => _build();
 
   _$GGetQuestsVars _build() {
-    final _$result =
-        _$v ??
+    final _$result = _$v ??
         new _$GGetQuestsVars._(
           userId: BuiltValueNullFieldError.checkNotNull(
-            userId,
-            r'GGetQuestsVars',
-            'userId',
-          ),
+              userId, r'GGetQuestsVars', 'userId'),
         );
     replace(_$result);
     return _$result;

--- a/app/backend/lib/graphql/quest/__generated__/InsertMainQuest.ast.gql.dart
+++ b/app/backend/lib/graphql/quest/__generated__/InsertMainQuest.ast.gql.dart
@@ -42,114 +42,108 @@ const InsertMainQuest = _i1.OperationDefinitionNode(
         isNonNull: false,
       ),
       defaultValue: _i1.DefaultValueNode(
-        value: _i1.StringValueNode(value: '', isBlock: false),
-      ),
+          value: _i1.StringValueNode(
+        value: '',
+        isBlock: false,
+      )),
       directives: [],
     ),
   ],
   directives: [],
-  selectionSet: _i1.SelectionSetNode(
-    selections: [
-      _i1.FieldNode(
-        name: _i1.NameNode(value: 'insertMainQuestsOne'),
-        alias: null,
-        arguments: [
-          _i1.ArgumentNode(
-            name: _i1.NameNode(value: 'object'),
-            value: _i1.ObjectValueNode(
-              fields: [
-                _i1.ObjectFieldNode(
-                  name: _i1.NameNode(value: 'userId'),
-                  value: _i1.VariableNode(name: _i1.NameNode(value: 'userId')),
-                ),
-                _i1.ObjectFieldNode(
-                  name: _i1.NameNode(value: 'title'),
-                  value: _i1.VariableNode(name: _i1.NameNode(value: 'title')),
-                ),
-                _i1.ObjectFieldNode(
-                  name: _i1.NameNode(value: 'description'),
-                  value: _i1.VariableNode(
-                    name: _i1.NameNode(value: 'description'),
-                  ),
-                ),
-                _i1.ObjectFieldNode(
-                  name: _i1.NameNode(value: 'note'),
-                  value: _i1.VariableNode(name: _i1.NameNode(value: 'note')),
-                ),
-              ],
+  selectionSet: _i1.SelectionSetNode(selections: [
+    _i1.FieldNode(
+      name: _i1.NameNode(value: 'insertMainQuestsOne'),
+      alias: null,
+      arguments: [
+        _i1.ArgumentNode(
+          name: _i1.NameNode(value: 'object'),
+          value: _i1.ObjectValueNode(fields: [
+            _i1.ObjectFieldNode(
+              name: _i1.NameNode(value: 'userId'),
+              value: _i1.VariableNode(name: _i1.NameNode(value: 'userId')),
             ),
-          ),
-        ],
-        directives: [],
-        selectionSet: _i1.SelectionSetNode(
-          selections: [
-            _i1.FieldNode(
-              name: _i1.NameNode(value: 'id'),
-              alias: null,
-              arguments: [],
-              directives: [],
-              selectionSet: null,
-            ),
-            _i1.FieldNode(
+            _i1.ObjectFieldNode(
               name: _i1.NameNode(value: 'title'),
-              alias: null,
-              arguments: [],
-              directives: [],
-              selectionSet: null,
+              value: _i1.VariableNode(name: _i1.NameNode(value: 'title')),
             ),
-            _i1.FieldNode(
+            _i1.ObjectFieldNode(
               name: _i1.NameNode(value: 'description'),
-              alias: null,
-              arguments: [],
-              directives: [],
-              selectionSet: null,
+              value: _i1.VariableNode(name: _i1.NameNode(value: 'description')),
             ),
-            _i1.FieldNode(
-              name: _i1.NameNode(value: 'begunAt'),
-              alias: null,
-              arguments: [],
-              directives: [],
-              selectionSet: null,
-            ),
-            _i1.FieldNode(
-              name: _i1.NameNode(value: 'endedAt'),
-              alias: null,
-              arguments: [],
-              directives: [],
-              selectionSet: null,
-            ),
-            _i1.FieldNode(
-              name: _i1.NameNode(value: 'categoryId'),
-              alias: null,
-              arguments: [],
-              directives: [],
-              selectionSet: null,
-            ),
-            _i1.FieldNode(
-              name: _i1.NameNode(value: 'status'),
-              alias: null,
-              arguments: [],
-              directives: [],
-              selectionSet: null,
-            ),
-            _i1.FieldNode(
-              name: _i1.NameNode(value: 'coverImageUrl'),
-              alias: null,
-              arguments: [],
-              directives: [],
-              selectionSet: null,
-            ),
-            _i1.FieldNode(
+            _i1.ObjectFieldNode(
               name: _i1.NameNode(value: 'note'),
-              alias: null,
-              arguments: [],
-              directives: [],
-              selectionSet: null,
+              value: _i1.VariableNode(name: _i1.NameNode(value: 'note')),
             ),
-          ],
+          ]),
+        )
+      ],
+      directives: [],
+      selectionSet: _i1.SelectionSetNode(selections: [
+        _i1.FieldNode(
+          name: _i1.NameNode(value: 'id'),
+          alias: null,
+          arguments: [],
+          directives: [],
+          selectionSet: null,
         ),
-      ),
-    ],
-  ),
+        _i1.FieldNode(
+          name: _i1.NameNode(value: 'title'),
+          alias: null,
+          arguments: [],
+          directives: [],
+          selectionSet: null,
+        ),
+        _i1.FieldNode(
+          name: _i1.NameNode(value: 'description'),
+          alias: null,
+          arguments: [],
+          directives: [],
+          selectionSet: null,
+        ),
+        _i1.FieldNode(
+          name: _i1.NameNode(value: 'begunAt'),
+          alias: null,
+          arguments: [],
+          directives: [],
+          selectionSet: null,
+        ),
+        _i1.FieldNode(
+          name: _i1.NameNode(value: 'endedAt'),
+          alias: null,
+          arguments: [],
+          directives: [],
+          selectionSet: null,
+        ),
+        _i1.FieldNode(
+          name: _i1.NameNode(value: 'categoryId'),
+          alias: null,
+          arguments: [],
+          directives: [],
+          selectionSet: null,
+        ),
+        _i1.FieldNode(
+          name: _i1.NameNode(value: 'status'),
+          alias: null,
+          arguments: [],
+          directives: [],
+          selectionSet: null,
+        ),
+        _i1.FieldNode(
+          name: _i1.NameNode(value: 'coverImageUrl'),
+          alias: null,
+          arguments: [],
+          directives: [],
+          selectionSet: null,
+        ),
+        _i1.FieldNode(
+          name: _i1.NameNode(value: 'note'),
+          alias: null,
+          arguments: [],
+          directives: [],
+          selectionSet: null,
+        ),
+      ]),
+    )
+  ]),
 );
 const document = _i1.DocumentNode(definitions: [InsertMainQuest]);

--- a/app/backend/lib/graphql/quest/__generated__/InsertMainQuest.data.gql.dart
+++ b/app/backend/lib/graphql/quest/__generated__/InsertMainQuest.data.gql.dart
@@ -14,9 +14,9 @@ abstract class GInsertMainQuestData
     implements Built<GInsertMainQuestData, GInsertMainQuestDataBuilder> {
   GInsertMainQuestData._();
 
-  factory GInsertMainQuestData([
-    void Function(GInsertMainQuestDataBuilder b) updates,
-  ]) = _$GInsertMainQuestData;
+  factory GInsertMainQuestData(
+          [void Function(GInsertMainQuestDataBuilder b) updates]) =
+      _$GInsertMainQuestData;
 
   static void _initializeBuilder(GInsertMainQuestDataBuilder b) =>
       b..G__typename = 'mutation_root';
@@ -27,29 +27,31 @@ abstract class GInsertMainQuestData
   static Serializer<GInsertMainQuestData> get serializer =>
       _$gInsertMainQuestDataSerializer;
 
-  Map<String, dynamic> toJson() =>
-      (_i1.serializers.serializeWith(GInsertMainQuestData.serializer, this)
-          as Map<String, dynamic>);
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GInsertMainQuestData.serializer,
+        this,
+      ) as Map<String, dynamic>);
 
   static GInsertMainQuestData? fromJson(Map<String, dynamic> json) =>
-      _i1.serializers.deserializeWith(GInsertMainQuestData.serializer, json);
+      _i1.serializers.deserializeWith(
+        GInsertMainQuestData.serializer,
+        json,
+      );
 }
 
 abstract class GInsertMainQuestData_insertMainQuestsOne
     implements
-        Built<
-          GInsertMainQuestData_insertMainQuestsOne,
-          GInsertMainQuestData_insertMainQuestsOneBuilder
-        > {
+        Built<GInsertMainQuestData_insertMainQuestsOne,
+            GInsertMainQuestData_insertMainQuestsOneBuilder> {
   GInsertMainQuestData_insertMainQuestsOne._();
 
-  factory GInsertMainQuestData_insertMainQuestsOne([
-    void Function(GInsertMainQuestData_insertMainQuestsOneBuilder b) updates,
-  ]) = _$GInsertMainQuestData_insertMainQuestsOne;
+  factory GInsertMainQuestData_insertMainQuestsOne(
+      [void Function(GInsertMainQuestData_insertMainQuestsOneBuilder b)
+          updates]) = _$GInsertMainQuestData_insertMainQuestsOne;
 
   static void _initializeBuilder(
-    GInsertMainQuestData_insertMainQuestsOneBuilder b,
-  ) => b..G__typename = 'MainQuests';
+          GInsertMainQuestData_insertMainQuestsOneBuilder b) =>
+      b..G__typename = 'MainQuests';
 
   @BuiltValueField(wireName: '__typename')
   String get G__typename;
@@ -65,17 +67,15 @@ abstract class GInsertMainQuestData_insertMainQuestsOne
   static Serializer<GInsertMainQuestData_insertMainQuestsOne> get serializer =>
       _$gInsertMainQuestDataInsertMainQuestsOneSerializer;
 
-  Map<String, dynamic> toJson() =>
-      (_i1.serializers.serializeWith(
-            GInsertMainQuestData_insertMainQuestsOne.serializer,
-            this,
-          )
-          as Map<String, dynamic>);
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GInsertMainQuestData_insertMainQuestsOne.serializer,
+        this,
+      ) as Map<String, dynamic>);
 
   static GInsertMainQuestData_insertMainQuestsOne? fromJson(
-    Map<String, dynamic> json,
-  ) => _i1.serializers.deserializeWith(
-    GInsertMainQuestData_insertMainQuestsOne.serializer,
-    json,
-  );
+          Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GInsertMainQuestData_insertMainQuestsOne.serializer,
+        json,
+      );
 }

--- a/app/backend/lib/graphql/quest/__generated__/InsertMainQuest.data.gql.g.dart
+++ b/app/backend/lib/graphql/quest/__generated__/InsertMainQuest.data.gql.g.dart
@@ -9,7 +9,7 @@ part of 'InsertMainQuest.data.gql.dart';
 Serializer<GInsertMainQuestData> _$gInsertMainQuestDataSerializer =
     new _$GInsertMainQuestDataSerializer();
 Serializer<GInsertMainQuestData_insertMainQuestsOne>
-_$gInsertMainQuestDataInsertMainQuestsOneSerializer =
+    _$gInsertMainQuestDataInsertMainQuestsOneSerializer =
     new _$GInsertMainQuestData_insertMainQuestsOneSerializer();
 
 class _$GInsertMainQuestDataSerializer
@@ -17,47 +17,36 @@ class _$GInsertMainQuestDataSerializer
   @override
   final Iterable<Type> types = const [
     GInsertMainQuestData,
-    _$GInsertMainQuestData,
+    _$GInsertMainQuestData
   ];
   @override
   final String wireName = 'GInsertMainQuestData';
 
   @override
   Iterable<Object?> serialize(
-    Serializers serializers,
-    GInsertMainQuestData object, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, GInsertMainQuestData object,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[
       '__typename',
-      serializers.serialize(
-        object.G__typename,
-        specifiedType: const FullType(String),
-      ),
+      serializers.serialize(object.G__typename,
+          specifiedType: const FullType(String)),
     ];
     Object? value;
     value = object.insertMainQuestsOne;
     if (value != null) {
       result
         ..add('insertMainQuestsOne')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(
-              GInsertMainQuestData_insertMainQuestsOne,
-            ),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType:
+                const FullType(GInsertMainQuestData_insertMainQuestsOne)));
     }
     return result;
   }
 
   @override
   GInsertMainQuestData deserialize(
-    Serializers serializers,
-    Iterable<Object?> serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = new GInsertMainQuestDataBuilder();
 
     final iterator = serialized.iterator;
@@ -67,23 +56,14 @@ class _$GInsertMainQuestDataSerializer
       final Object? value = iterator.current;
       switch (key) {
         case '__typename':
-          result.G__typename =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )!
-                  as String;
+          result.G__typename = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
           break;
         case 'insertMainQuestsOne':
-          result.insertMainQuestsOne.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(
-                    GInsertMainQuestData_insertMainQuestsOne,
-                  ),
-                )!
-                as GInsertMainQuestData_insertMainQuestsOne,
-          );
+          result.insertMainQuestsOne.replace(serializers.deserialize(value,
+                  specifiedType:
+                      const FullType(GInsertMainQuestData_insertMainQuestsOne))!
+              as GInsertMainQuestData_insertMainQuestsOne);
           break;
       }
     }
@@ -97,40 +77,30 @@ class _$GInsertMainQuestData_insertMainQuestsOneSerializer
   @override
   final Iterable<Type> types = const [
     GInsertMainQuestData_insertMainQuestsOne,
-    _$GInsertMainQuestData_insertMainQuestsOne,
+    _$GInsertMainQuestData_insertMainQuestsOne
   ];
   @override
   final String wireName = 'GInsertMainQuestData_insertMainQuestsOne';
 
   @override
   Iterable<Object?> serialize(
-    Serializers serializers,
-    GInsertMainQuestData_insertMainQuestsOne object, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, GInsertMainQuestData_insertMainQuestsOne object,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[
       '__typename',
-      serializers.serialize(
-        object.G__typename,
-        specifiedType: const FullType(String),
-      ),
+      serializers.serialize(object.G__typename,
+          specifiedType: const FullType(String)),
       'id',
       serializers.serialize(object.id, specifiedType: const FullType(String)),
       'title',
-      serializers.serialize(
-        object.title,
-        specifiedType: const FullType(String),
-      ),
+      serializers.serialize(object.title,
+          specifiedType: const FullType(String)),
       'description',
-      serializers.serialize(
-        object.description,
-        specifiedType: const FullType(String),
-      ),
+      serializers.serialize(object.description,
+          specifiedType: const FullType(String)),
       'status',
-      serializers.serialize(
-        object.status,
-        specifiedType: const FullType(_i2.GQuestStatusEnum),
-      ),
+      serializers.serialize(object.status,
+          specifiedType: const FullType(_i2.GQuestStatusEnum)),
       'note',
       serializers.serialize(object.note, specifiedType: const FullType(String)),
     ];
@@ -139,43 +109,37 @@ class _$GInsertMainQuestData_insertMainQuestsOneSerializer
     if (value != null) {
       result
         ..add('begunAt')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(DateTime)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(DateTime)));
     }
     value = object.endedAt;
     if (value != null) {
       result
         ..add('endedAt')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(DateTime)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(DateTime)));
     }
     value = object.categoryId;
     if (value != null) {
       result
         ..add('categoryId')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(String)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
     }
     value = object.coverImageUrl;
     if (value != null) {
       result
         ..add('coverImageUrl')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(String)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
     }
     return result;
   }
 
   @override
   GInsertMainQuestData_insertMainQuestsOne deserialize(
-    Serializers serializers,
-    Iterable<Object?> serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = new GInsertMainQuestData_insertMainQuestsOneBuilder();
 
     final iterator = serialized.iterator;
@@ -185,84 +149,45 @@ class _$GInsertMainQuestData_insertMainQuestsOneSerializer
       final Object? value = iterator.current;
       switch (key) {
         case '__typename':
-          result.G__typename =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )!
-                  as String;
+          result.G__typename = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
           break;
         case 'id':
-          result.id =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )!
-                  as String;
+          result.id = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
           break;
         case 'title':
-          result.title =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )!
-                  as String;
+          result.title = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
           break;
         case 'description':
-          result.description =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )!
-                  as String;
+          result.description = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
           break;
         case 'begunAt':
-          result.begunAt =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(DateTime),
-                  )
-                  as DateTime?;
+          result.begunAt = serializers.deserialize(value,
+              specifiedType: const FullType(DateTime)) as DateTime?;
           break;
         case 'endedAt':
-          result.endedAt =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(DateTime),
-                  )
-                  as DateTime?;
+          result.endedAt = serializers.deserialize(value,
+              specifiedType: const FullType(DateTime)) as DateTime?;
           break;
         case 'categoryId':
-          result.categoryId =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )
-                  as String?;
+          result.categoryId = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
           break;
         case 'status':
-          result.status =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(_i2.GQuestStatusEnum),
-                  )!
-                  as _i2.GQuestStatusEnum;
+          result.status = serializers.deserialize(value,
+                  specifiedType: const FullType(_i2.GQuestStatusEnum))!
+              as _i2.GQuestStatusEnum;
           break;
         case 'coverImageUrl':
-          result.coverImageUrl =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )
-                  as String?;
+          result.coverImageUrl = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
           break;
         case 'note':
-          result.note =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )!
-                  as String;
+          result.note = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
           break;
       }
     }
@@ -277,25 +202,21 @@ class _$GInsertMainQuestData extends GInsertMainQuestData {
   @override
   final GInsertMainQuestData_insertMainQuestsOne? insertMainQuestsOne;
 
-  factory _$GInsertMainQuestData([
-    void Function(GInsertMainQuestDataBuilder)? updates,
-  ]) => (new GInsertMainQuestDataBuilder()..update(updates))._build();
+  factory _$GInsertMainQuestData(
+          [void Function(GInsertMainQuestDataBuilder)? updates]) =>
+      (new GInsertMainQuestDataBuilder()..update(updates))._build();
 
-  _$GInsertMainQuestData._({
-    required this.G__typename,
-    this.insertMainQuestsOne,
-  }) : super._() {
+  _$GInsertMainQuestData._(
+      {required this.G__typename, this.insertMainQuestsOne})
+      : super._() {
     BuiltValueNullFieldError.checkNotNull(
-      G__typename,
-      r'GInsertMainQuestData',
-      'G__typename',
-    );
+        G__typename, r'GInsertMainQuestData', 'G__typename');
   }
 
   @override
   GInsertMainQuestData rebuild(
-    void Function(GInsertMainQuestDataBuilder) updates,
-  ) => (toBuilder()..update(updates)).build();
+          void Function(GInsertMainQuestDataBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
 
   @override
   GInsertMainQuestDataBuilder toBuilder() =>
@@ -340,8 +261,9 @@ class GInsertMainQuestDataBuilder
       _$this._insertMainQuestsOne ??=
           new GInsertMainQuestData_insertMainQuestsOneBuilder();
   set insertMainQuestsOne(
-    GInsertMainQuestData_insertMainQuestsOneBuilder? insertMainQuestsOne,
-  ) => _$this._insertMainQuestsOne = insertMainQuestsOne;
+          GInsertMainQuestData_insertMainQuestsOneBuilder?
+              insertMainQuestsOne) =>
+      _$this._insertMainQuestsOne = insertMainQuestsOne;
 
   GInsertMainQuestDataBuilder() {
     GInsertMainQuestData._initializeBuilder(this);
@@ -374,14 +296,10 @@ class GInsertMainQuestDataBuilder
   _$GInsertMainQuestData _build() {
     _$GInsertMainQuestData _$result;
     try {
-      _$result =
-          _$v ??
+      _$result = _$v ??
           new _$GInsertMainQuestData._(
             G__typename: BuiltValueNullFieldError.checkNotNull(
-              G__typename,
-              r'GInsertMainQuestData',
-              'G__typename',
-            ),
+                G__typename, r'GInsertMainQuestData', 'G__typename'),
             insertMainQuestsOne: _insertMainQuestsOne?.build(),
           );
     } catch (_) {
@@ -391,10 +309,7 @@ class GInsertMainQuestDataBuilder
         _insertMainQuestsOne?.build();
       } catch (e) {
         throw new BuiltValueNestedFieldError(
-          r'GInsertMainQuestData',
-          _$failedField,
-          e.toString(),
-        );
+            r'GInsertMainQuestData', _$failedField, e.toString());
       }
       rethrow;
     }
@@ -426,59 +341,43 @@ class _$GInsertMainQuestData_insertMainQuestsOne
   @override
   final String note;
 
-  factory _$GInsertMainQuestData_insertMainQuestsOne([
-    void Function(GInsertMainQuestData_insertMainQuestsOneBuilder)? updates,
-  ]) => (new GInsertMainQuestData_insertMainQuestsOneBuilder()..update(updates))
-      ._build();
+  factory _$GInsertMainQuestData_insertMainQuestsOne(
+          [void Function(GInsertMainQuestData_insertMainQuestsOneBuilder)?
+              updates]) =>
+      (new GInsertMainQuestData_insertMainQuestsOneBuilder()..update(updates))
+          ._build();
 
-  _$GInsertMainQuestData_insertMainQuestsOne._({
-    required this.G__typename,
-    required this.id,
-    required this.title,
-    required this.description,
-    this.begunAt,
-    this.endedAt,
-    this.categoryId,
-    required this.status,
-    this.coverImageUrl,
-    required this.note,
-  }) : super._() {
+  _$GInsertMainQuestData_insertMainQuestsOne._(
+      {required this.G__typename,
+      required this.id,
+      required this.title,
+      required this.description,
+      this.begunAt,
+      this.endedAt,
+      this.categoryId,
+      required this.status,
+      this.coverImageUrl,
+      required this.note})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(G__typename,
+        r'GInsertMainQuestData_insertMainQuestsOne', 'G__typename');
     BuiltValueNullFieldError.checkNotNull(
-      G__typename,
-      r'GInsertMainQuestData_insertMainQuestsOne',
-      'G__typename',
-    );
+        id, r'GInsertMainQuestData_insertMainQuestsOne', 'id');
     BuiltValueNullFieldError.checkNotNull(
-      id,
-      r'GInsertMainQuestData_insertMainQuestsOne',
-      'id',
-    );
+        title, r'GInsertMainQuestData_insertMainQuestsOne', 'title');
+    BuiltValueNullFieldError.checkNotNull(description,
+        r'GInsertMainQuestData_insertMainQuestsOne', 'description');
     BuiltValueNullFieldError.checkNotNull(
-      title,
-      r'GInsertMainQuestData_insertMainQuestsOne',
-      'title',
-    );
+        status, r'GInsertMainQuestData_insertMainQuestsOne', 'status');
     BuiltValueNullFieldError.checkNotNull(
-      description,
-      r'GInsertMainQuestData_insertMainQuestsOne',
-      'description',
-    );
-    BuiltValueNullFieldError.checkNotNull(
-      status,
-      r'GInsertMainQuestData_insertMainQuestsOne',
-      'status',
-    );
-    BuiltValueNullFieldError.checkNotNull(
-      note,
-      r'GInsertMainQuestData_insertMainQuestsOne',
-      'note',
-    );
+        note, r'GInsertMainQuestData_insertMainQuestsOne', 'note');
   }
 
   @override
   GInsertMainQuestData_insertMainQuestsOne rebuild(
-    void Function(GInsertMainQuestData_insertMainQuestsOneBuilder) updates,
-  ) => (toBuilder()..update(updates)).build();
+          void Function(GInsertMainQuestData_insertMainQuestsOneBuilder)
+              updates) =>
+      (toBuilder()..update(updates)).build();
 
   @override
   GInsertMainQuestData_insertMainQuestsOneBuilder toBuilder() =>
@@ -520,8 +419,7 @@ class _$GInsertMainQuestData_insertMainQuestsOne
   @override
   String toString() {
     return (newBuiltValueToStringHelper(
-            r'GInsertMainQuestData_insertMainQuestsOne',
-          )
+            r'GInsertMainQuestData_insertMainQuestsOne')
           ..add('G__typename', G__typename)
           ..add('id', id)
           ..add('title', title)
@@ -538,10 +436,8 @@ class _$GInsertMainQuestData_insertMainQuestsOne
 
 class GInsertMainQuestData_insertMainQuestsOneBuilder
     implements
-        Builder<
-          GInsertMainQuestData_insertMainQuestsOne,
-          GInsertMainQuestData_insertMainQuestsOneBuilder
-        > {
+        Builder<GInsertMainQuestData_insertMainQuestsOne,
+            GInsertMainQuestData_insertMainQuestsOneBuilder> {
   _$GInsertMainQuestData_insertMainQuestsOne? _$v;
 
   String? _G__typename;
@@ -615,8 +511,7 @@ class GInsertMainQuestData_insertMainQuestsOneBuilder
 
   @override
   void update(
-    void Function(GInsertMainQuestData_insertMainQuestsOneBuilder)? updates,
-  ) {
+      void Function(GInsertMainQuestData_insertMainQuestsOneBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
@@ -624,43 +519,24 @@ class GInsertMainQuestData_insertMainQuestsOneBuilder
   GInsertMainQuestData_insertMainQuestsOne build() => _build();
 
   _$GInsertMainQuestData_insertMainQuestsOne _build() {
-    final _$result =
-        _$v ??
+    final _$result = _$v ??
         new _$GInsertMainQuestData_insertMainQuestsOne._(
-          G__typename: BuiltValueNullFieldError.checkNotNull(
-            G__typename,
-            r'GInsertMainQuestData_insertMainQuestsOne',
-            'G__typename',
-          ),
+          G__typename: BuiltValueNullFieldError.checkNotNull(G__typename,
+              r'GInsertMainQuestData_insertMainQuestsOne', 'G__typename'),
           id: BuiltValueNullFieldError.checkNotNull(
-            id,
-            r'GInsertMainQuestData_insertMainQuestsOne',
-            'id',
-          ),
+              id, r'GInsertMainQuestData_insertMainQuestsOne', 'id'),
           title: BuiltValueNullFieldError.checkNotNull(
-            title,
-            r'GInsertMainQuestData_insertMainQuestsOne',
-            'title',
-          ),
-          description: BuiltValueNullFieldError.checkNotNull(
-            description,
-            r'GInsertMainQuestData_insertMainQuestsOne',
-            'description',
-          ),
+              title, r'GInsertMainQuestData_insertMainQuestsOne', 'title'),
+          description: BuiltValueNullFieldError.checkNotNull(description,
+              r'GInsertMainQuestData_insertMainQuestsOne', 'description'),
           begunAt: begunAt,
           endedAt: endedAt,
           categoryId: categoryId,
           status: BuiltValueNullFieldError.checkNotNull(
-            status,
-            r'GInsertMainQuestData_insertMainQuestsOne',
-            'status',
-          ),
+              status, r'GInsertMainQuestData_insertMainQuestsOne', 'status'),
           coverImageUrl: coverImageUrl,
           note: BuiltValueNullFieldError.checkNotNull(
-            note,
-            r'GInsertMainQuestData_insertMainQuestsOne',
-            'note',
-          ),
+              note, r'GInsertMainQuestData_insertMainQuestsOne', 'note'),
         );
     replace(_$result);
     return _$result;

--- a/app/backend/lib/graphql/quest/__generated__/InsertMainQuest.req.gql.dart
+++ b/app/backend/lib/graphql/quest/__generated__/InsertMainQuest.req.gql.dart
@@ -19,15 +19,13 @@ part 'InsertMainQuest.req.gql.g.dart';
 abstract class GInsertMainQuestReq
     implements
         Built<GInsertMainQuestReq, GInsertMainQuestReqBuilder>,
-        _i1.OperationRequest<
-          _i2.GInsertMainQuestData,
-          _i3.GInsertMainQuestVars
-        > {
+        _i1
+        .OperationRequest<_i2.GInsertMainQuestData, _i3.GInsertMainQuestVars> {
   GInsertMainQuestReq._();
 
-  factory GInsertMainQuestReq([
-    void Function(GInsertMainQuestReqBuilder b) updates,
-  ]) = _$GInsertMainQuestReq;
+  factory GInsertMainQuestReq(
+          [void Function(GInsertMainQuestReqBuilder b) updates]) =
+      _$GInsertMainQuestReq;
 
   static void _initializeBuilder(GInsertMainQuestReqBuilder b) => b
     ..operation = _i4.Operation(
@@ -42,10 +40,10 @@ abstract class GInsertMainQuestReq
   _i4.Operation get operation;
   @override
   _i4.Request get execRequest => _i4.Request(
-    operation: operation,
-    variables: vars.toJson(),
-    context: context ?? const _i4.Context(),
-  );
+        operation: operation,
+        variables: vars.toJson(),
+        context: context ?? const _i4.Context(),
+      );
 
   @override
   String? get requestId;
@@ -54,8 +52,7 @@ abstract class GInsertMainQuestReq
   _i2.GInsertMainQuestData? Function(
     _i2.GInsertMainQuestData?,
     _i2.GInsertMainQuestData?,
-  )?
-  get updateResult;
+  )? get updateResult;
   @override
   _i2.GInsertMainQuestData? get optimisticResponse;
   @override
@@ -82,16 +79,20 @@ abstract class GInsertMainQuestReq
 
   @override
   _i1.OperationRequest<_i2.GInsertMainQuestData, _i3.GInsertMainQuestVars>
-  transformOperation(_i4.Operation Function(_i4.Operation) transform) =>
-      this.rebuild((b) => b..operation = transform(operation));
+      transformOperation(_i4.Operation Function(_i4.Operation) transform) =>
+          this.rebuild((b) => b..operation = transform(operation));
 
   static Serializer<GInsertMainQuestReq> get serializer =>
       _$gInsertMainQuestReqSerializer;
 
-  Map<String, dynamic> toJson() =>
-      (_i6.serializers.serializeWith(GInsertMainQuestReq.serializer, this)
-          as Map<String, dynamic>);
+  Map<String, dynamic> toJson() => (_i6.serializers.serializeWith(
+        GInsertMainQuestReq.serializer,
+        this,
+      ) as Map<String, dynamic>);
 
   static GInsertMainQuestReq? fromJson(Map<String, dynamic> json) =>
-      _i6.serializers.deserializeWith(GInsertMainQuestReq.serializer, json);
+      _i6.serializers.deserializeWith(
+        GInsertMainQuestReq.serializer,
+        json,
+      );
 }

--- a/app/backend/lib/graphql/quest/__generated__/InsertMainQuest.req.gql.g.dart
+++ b/app/backend/lib/graphql/quest/__generated__/InsertMainQuest.req.gql.g.dart
@@ -14,96 +14,70 @@ class _$GInsertMainQuestReqSerializer
   @override
   final Iterable<Type> types = const [
     GInsertMainQuestReq,
-    _$GInsertMainQuestReq,
+    _$GInsertMainQuestReq
   ];
   @override
   final String wireName = 'GInsertMainQuestReq';
 
   @override
   Iterable<Object?> serialize(
-    Serializers serializers,
-    GInsertMainQuestReq object, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, GInsertMainQuestReq object,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[
       'vars',
-      serializers.serialize(
-        object.vars,
-        specifiedType: const FullType(_i3.GInsertMainQuestVars),
-      ),
+      serializers.serialize(object.vars,
+          specifiedType: const FullType(_i3.GInsertMainQuestVars)),
       'operation',
-      serializers.serialize(
-        object.operation,
-        specifiedType: const FullType(_i4.Operation),
-      ),
+      serializers.serialize(object.operation,
+          specifiedType: const FullType(_i4.Operation)),
       'executeOnListen',
-      serializers.serialize(
-        object.executeOnListen,
-        specifiedType: const FullType(bool),
-      ),
+      serializers.serialize(object.executeOnListen,
+          specifiedType: const FullType(bool)),
     ];
     Object? value;
     value = object.requestId;
     if (value != null) {
       result
         ..add('requestId')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(String)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
     }
     value = object.optimisticResponse;
     if (value != null) {
       result
         ..add('optimisticResponse')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(_i2.GInsertMainQuestData),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(_i2.GInsertMainQuestData)));
     }
     value = object.updateCacheHandlerKey;
     if (value != null) {
       result
         ..add('updateCacheHandlerKey')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(String)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
     }
     value = object.updateCacheHandlerContext;
     if (value != null) {
       result
         ..add('updateCacheHandlerContext')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(Map, const [
-              const FullType(String),
-              const FullType(dynamic),
-            ]),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(
+                Map, const [const FullType(String), const FullType(dynamic)])));
     }
     value = object.fetchPolicy;
     if (value != null) {
       result
         ..add('fetchPolicy')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(_i1.FetchPolicy),
-          ),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(_i1.FetchPolicy)));
     }
     return result;
   }
 
   @override
   GInsertMainQuestReq deserialize(
-    Serializers serializers,
-    Iterable<Object?> serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = new GInsertMainQuestReqBuilder();
 
     final iterator = serialized.iterator;
@@ -113,73 +87,42 @@ class _$GInsertMainQuestReqSerializer
       final Object? value = iterator.current;
       switch (key) {
         case 'vars':
-          result.vars.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(_i3.GInsertMainQuestVars),
-                )!
-                as _i3.GInsertMainQuestVars,
-          );
+          result.vars.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(_i3.GInsertMainQuestVars))!
+              as _i3.GInsertMainQuestVars);
           break;
         case 'operation':
-          result.operation =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(_i4.Operation),
-                  )!
-                  as _i4.Operation;
+          result.operation = serializers.deserialize(value,
+              specifiedType: const FullType(_i4.Operation))! as _i4.Operation;
           break;
         case 'requestId':
-          result.requestId =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )
-                  as String?;
+          result.requestId = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
           break;
         case 'optimisticResponse':
-          result.optimisticResponse.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(_i2.GInsertMainQuestData),
-                )!
-                as _i2.GInsertMainQuestData,
-          );
+          result.optimisticResponse.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(_i2.GInsertMainQuestData))!
+              as _i2.GInsertMainQuestData);
           break;
         case 'updateCacheHandlerKey':
-          result.updateCacheHandlerKey =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )
-                  as String?;
+          result.updateCacheHandlerKey = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
           break;
         case 'updateCacheHandlerContext':
-          result.updateCacheHandlerContext =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(Map, const [
-                      const FullType(String),
-                      const FullType(dynamic),
-                    ]),
-                  )
-                  as Map<String, dynamic>?;
+          result.updateCacheHandlerContext = serializers.deserialize(value,
+              specifiedType: const FullType(Map, const [
+                const FullType(String),
+                const FullType(dynamic)
+              ])) as Map<String, dynamic>?;
           break;
         case 'fetchPolicy':
-          result.fetchPolicy =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(_i1.FetchPolicy),
-                  )
-                  as _i1.FetchPolicy?;
+          result.fetchPolicy = serializers.deserialize(value,
+                  specifiedType: const FullType(_i1.FetchPolicy))
+              as _i1.FetchPolicy?;
           break;
         case 'executeOnListen':
-          result.executeOnListen =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(bool),
-                  )!
-                  as bool;
+          result.executeOnListen = serializers.deserialize(value,
+              specifiedType: const FullType(bool))! as bool;
           break;
       }
     }
@@ -197,10 +140,7 @@ class _$GInsertMainQuestReq extends GInsertMainQuestReq {
   final String? requestId;
   @override
   final _i2.GInsertMainQuestData? Function(
-    _i2.GInsertMainQuestData?,
-    _i2.GInsertMainQuestData?,
-  )?
-  updateResult;
+      _i2.GInsertMainQuestData?, _i2.GInsertMainQuestData?)? updateResult;
   @override
   final _i2.GInsertMainQuestData? optimisticResponse;
   @override
@@ -214,39 +154,33 @@ class _$GInsertMainQuestReq extends GInsertMainQuestReq {
   @override
   final _i4.Context? context;
 
-  factory _$GInsertMainQuestReq([
-    void Function(GInsertMainQuestReqBuilder)? updates,
-  ]) => (new GInsertMainQuestReqBuilder()..update(updates))._build();
+  factory _$GInsertMainQuestReq(
+          [void Function(GInsertMainQuestReqBuilder)? updates]) =>
+      (new GInsertMainQuestReqBuilder()..update(updates))._build();
 
-  _$GInsertMainQuestReq._({
-    required this.vars,
-    required this.operation,
-    this.requestId,
-    this.updateResult,
-    this.optimisticResponse,
-    this.updateCacheHandlerKey,
-    this.updateCacheHandlerContext,
-    this.fetchPolicy,
-    required this.executeOnListen,
-    this.context,
-  }) : super._() {
+  _$GInsertMainQuestReq._(
+      {required this.vars,
+      required this.operation,
+      this.requestId,
+      this.updateResult,
+      this.optimisticResponse,
+      this.updateCacheHandlerKey,
+      this.updateCacheHandlerContext,
+      this.fetchPolicy,
+      required this.executeOnListen,
+      this.context})
+      : super._() {
     BuiltValueNullFieldError.checkNotNull(vars, r'GInsertMainQuestReq', 'vars');
     BuiltValueNullFieldError.checkNotNull(
-      operation,
-      r'GInsertMainQuestReq',
-      'operation',
-    );
+        operation, r'GInsertMainQuestReq', 'operation');
     BuiltValueNullFieldError.checkNotNull(
-      executeOnListen,
-      r'GInsertMainQuestReq',
-      'executeOnListen',
-    );
+        executeOnListen, r'GInsertMainQuestReq', 'executeOnListen');
   }
 
   @override
   GInsertMainQuestReq rebuild(
-    void Function(GInsertMainQuestReqBuilder) updates,
-  ) => (toBuilder()..update(updates)).build();
+          void Function(GInsertMainQuestReqBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
 
   @override
   GInsertMainQuestReqBuilder toBuilder() =>
@@ -321,22 +255,15 @@ class GInsertMainQuestReqBuilder
   set requestId(String? requestId) => _$this._requestId = requestId;
 
   _i2.GInsertMainQuestData? Function(
-    _i2.GInsertMainQuestData?,
-    _i2.GInsertMainQuestData?,
-  )?
-  _updateResult;
+      _i2.GInsertMainQuestData?, _i2.GInsertMainQuestData?)? _updateResult;
   _i2.GInsertMainQuestData? Function(
-    _i2.GInsertMainQuestData?,
-    _i2.GInsertMainQuestData?,
-  )?
-  get updateResult => _$this._updateResult;
+          _i2.GInsertMainQuestData?, _i2.GInsertMainQuestData?)?
+      get updateResult => _$this._updateResult;
   set updateResult(
-    _i2.GInsertMainQuestData? Function(
-      _i2.GInsertMainQuestData?,
-      _i2.GInsertMainQuestData?,
-    )?
-    updateResult,
-  ) => _$this._updateResult = updateResult;
+          _i2.GInsertMainQuestData? Function(
+                  _i2.GInsertMainQuestData?, _i2.GInsertMainQuestData?)?
+              updateResult) =>
+      _$this._updateResult = updateResult;
 
   _i2.GInsertMainQuestDataBuilder? _optimisticResponse;
   _i2.GInsertMainQuestDataBuilder get optimisticResponse =>
@@ -353,8 +280,8 @@ class GInsertMainQuestReqBuilder
   Map<String, dynamic>? get updateCacheHandlerContext =>
       _$this._updateCacheHandlerContext;
   set updateCacheHandlerContext(
-    Map<String, dynamic>? updateCacheHandlerContext,
-  ) => _$this._updateCacheHandlerContext = updateCacheHandlerContext;
+          Map<String, dynamic>? updateCacheHandlerContext) =>
+      _$this._updateCacheHandlerContext = updateCacheHandlerContext;
 
   _i1.FetchPolicy? _fetchPolicy;
   _i1.FetchPolicy? get fetchPolicy => _$this._fetchPolicy;
@@ -409,15 +336,11 @@ class GInsertMainQuestReqBuilder
   _$GInsertMainQuestReq _build() {
     _$GInsertMainQuestReq _$result;
     try {
-      _$result =
-          _$v ??
+      _$result = _$v ??
           new _$GInsertMainQuestReq._(
             vars: vars.build(),
             operation: BuiltValueNullFieldError.checkNotNull(
-              operation,
-              r'GInsertMainQuestReq',
-              'operation',
-            ),
+                operation, r'GInsertMainQuestReq', 'operation'),
             requestId: requestId,
             updateResult: updateResult,
             optimisticResponse: _optimisticResponse?.build(),
@@ -425,10 +348,7 @@ class GInsertMainQuestReqBuilder
             updateCacheHandlerContext: updateCacheHandlerContext,
             fetchPolicy: fetchPolicy,
             executeOnListen: BuiltValueNullFieldError.checkNotNull(
-              executeOnListen,
-              r'GInsertMainQuestReq',
-              'executeOnListen',
-            ),
+                executeOnListen, r'GInsertMainQuestReq', 'executeOnListen'),
             context: context,
           );
     } catch (_) {
@@ -441,10 +361,7 @@ class GInsertMainQuestReqBuilder
         _optimisticResponse?.build();
       } catch (e) {
         throw new BuiltValueNestedFieldError(
-          r'GInsertMainQuestReq',
-          _$failedField,
-          e.toString(),
-        );
+            r'GInsertMainQuestReq', _$failedField, e.toString());
       }
       rethrow;
     }

--- a/app/backend/lib/graphql/quest/__generated__/InsertMainQuest.var.gql.dart
+++ b/app/backend/lib/graphql/quest/__generated__/InsertMainQuest.var.gql.dart
@@ -12,9 +12,9 @@ abstract class GInsertMainQuestVars
     implements Built<GInsertMainQuestVars, GInsertMainQuestVarsBuilder> {
   GInsertMainQuestVars._();
 
-  factory GInsertMainQuestVars([
-    void Function(GInsertMainQuestVarsBuilder b) updates,
-  ]) = _$GInsertMainQuestVars;
+  factory GInsertMainQuestVars(
+          [void Function(GInsertMainQuestVarsBuilder b) updates]) =
+      _$GInsertMainQuestVars;
 
   String? get userId;
   String? get title;
@@ -23,10 +23,14 @@ abstract class GInsertMainQuestVars
   static Serializer<GInsertMainQuestVars> get serializer =>
       _$gInsertMainQuestVarsSerializer;
 
-  Map<String, dynamic> toJson() =>
-      (_i1.serializers.serializeWith(GInsertMainQuestVars.serializer, this)
-          as Map<String, dynamic>);
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GInsertMainQuestVars.serializer,
+        this,
+      ) as Map<String, dynamic>);
 
   static GInsertMainQuestVars? fromJson(Map<String, dynamic> json) =>
-      _i1.serializers.deserializeWith(GInsertMainQuestVars.serializer, json);
+      _i1.serializers.deserializeWith(
+        GInsertMainQuestVars.serializer,
+        json,
+      );
 }

--- a/app/backend/lib/graphql/quest/__generated__/InsertMainQuest.var.gql.g.dart
+++ b/app/backend/lib/graphql/quest/__generated__/InsertMainQuest.var.gql.g.dart
@@ -14,60 +14,52 @@ class _$GInsertMainQuestVarsSerializer
   @override
   final Iterable<Type> types = const [
     GInsertMainQuestVars,
-    _$GInsertMainQuestVars,
+    _$GInsertMainQuestVars
   ];
   @override
   final String wireName = 'GInsertMainQuestVars';
 
   @override
   Iterable<Object?> serialize(
-    Serializers serializers,
-    GInsertMainQuestVars object, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, GInsertMainQuestVars object,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[];
     Object? value;
     value = object.userId;
     if (value != null) {
       result
         ..add('userId')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(String)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
     }
     value = object.title;
     if (value != null) {
       result
         ..add('title')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(String)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
     }
     value = object.description;
     if (value != null) {
       result
         ..add('description')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(String)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
     }
     value = object.note;
     if (value != null) {
       result
         ..add('note')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(String)),
-        );
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
     }
     return result;
   }
 
   @override
   GInsertMainQuestVars deserialize(
-    Serializers serializers,
-    Iterable<Object?> serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
     final result = new GInsertMainQuestVarsBuilder();
 
     final iterator = serialized.iterator;
@@ -77,36 +69,20 @@ class _$GInsertMainQuestVarsSerializer
       final Object? value = iterator.current;
       switch (key) {
         case 'userId':
-          result.userId =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )
-                  as String?;
+          result.userId = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
           break;
         case 'title':
-          result.title =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )
-                  as String?;
+          result.title = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
           break;
         case 'description':
-          result.description =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )
-                  as String?;
+          result.description = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
           break;
         case 'note':
-          result.note =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(String),
-                  )
-                  as String?;
+          result.note = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
           break;
       }
     }
@@ -125,21 +101,18 @@ class _$GInsertMainQuestVars extends GInsertMainQuestVars {
   @override
   final String? note;
 
-  factory _$GInsertMainQuestVars([
-    void Function(GInsertMainQuestVarsBuilder)? updates,
-  ]) => (new GInsertMainQuestVarsBuilder()..update(updates))._build();
+  factory _$GInsertMainQuestVars(
+          [void Function(GInsertMainQuestVarsBuilder)? updates]) =>
+      (new GInsertMainQuestVarsBuilder()..update(updates))._build();
 
-  _$GInsertMainQuestVars._({
-    this.userId,
-    this.title,
-    this.description,
-    this.note,
-  }) : super._();
+  _$GInsertMainQuestVars._(
+      {this.userId, this.title, this.description, this.note})
+      : super._();
 
   @override
   GInsertMainQuestVars rebuild(
-    void Function(GInsertMainQuestVarsBuilder) updates,
-  ) => (toBuilder()..update(updates)).build();
+          void Function(GInsertMainQuestVarsBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
 
   @override
   GInsertMainQuestVarsBuilder toBuilder() =>
@@ -226,8 +199,7 @@ class GInsertMainQuestVarsBuilder
   GInsertMainQuestVars build() => _build();
 
   _$GInsertMainQuestVars _build() {
-    final _$result =
-        _$v ??
+    final _$result = _$v ??
         new _$GInsertMainQuestVars._(
           userId: userId,
           title: title,

--- a/app/catalog/lib/widgetbook.directories.g.dart
+++ b/app/catalog/lib/widgetbook.directories.g.dart
@@ -1,3 +1,4 @@
+// dart format width=80
 // coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_import, prefer_relative_imports, directives_ordering
@@ -53,7 +54,7 @@ final directories = <_i1.WidgetbookNode>[
             ),
           ),
         ],
-      ),
+      )
     ],
   ),
   _i1.WidgetbookCategory(
@@ -68,7 +69,7 @@ final directories = <_i1.WidgetbookNode>[
               name: 'AuthScreen',
               builder: _i5.authScreenUseCase,
             ),
-          ),
+          )
         ],
       ),
       _i1.WidgetbookFolder(
@@ -80,7 +81,7 @@ final directories = <_i1.WidgetbookNode>[
               name: 'HomeScreen',
               builder: _i6.homeScreenUseCase,
             ),
-          ),
+          )
         ],
       ),
       _i1.WidgetbookFolder(
@@ -92,7 +93,7 @@ final directories = <_i1.WidgetbookNode>[
               name: 'SettingsScreen',
               builder: _i7.settingsScreenUseCase,
             ),
-          ),
+          )
         ],
       ),
       _i1.WidgetbookFolder(
@@ -104,7 +105,7 @@ final directories = <_i1.WidgetbookNode>[
               name: 'OnboardingScreen',
               builder: _i8.onboardingScreenUseCase,
             ),
-          ),
+          )
         ],
       ),
       _i1.WidgetbookFolder(
@@ -147,9 +148,9 @@ final directories = <_i1.WidgetbookNode>[
               name: 'QuestListTile',
               builder: _i12.tobeScaffoldUseCase,
             ),
-          ),
+          )
         ],
-      ),
+      )
     ],
   ),
 ];

--- a/app/catalog/linux/flutter/generated_plugin_registrant.cc
+++ b/app/catalog/linux/flutter/generated_plugin_registrant.cc
@@ -7,16 +7,16 @@
 #include "generated_plugin_registrant.h"
 
 #include <dynamic_color/dynamic_color_plugin.h>
-#include <isar_flutter_libs/isar_flutter_libs_plugin.h>
+#include <sqlite3_flutter_libs/sqlite3_flutter_libs_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) dynamic_color_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "DynamicColorPlugin");
   dynamic_color_plugin_register_with_registrar(dynamic_color_registrar);
-  g_autoptr(FlPluginRegistrar) isar_flutter_libs_registrar =
-      fl_plugin_registry_get_registrar_for_plugin(registry, "IsarFlutterLibsPlugin");
-  isar_flutter_libs_plugin_register_with_registrar(isar_flutter_libs_registrar);
+  g_autoptr(FlPluginRegistrar) sqlite3_flutter_libs_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "Sqlite3FlutterLibsPlugin");
+  sqlite3_flutter_libs_plugin_register_with_registrar(sqlite3_flutter_libs_registrar);
   g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
   url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);

--- a/app/catalog/linux/flutter/generated_plugins.cmake
+++ b/app/catalog/linux/flutter/generated_plugins.cmake
@@ -4,7 +4,7 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   dynamic_color
-  isar_flutter_libs
+  sqlite3_flutter_libs
   url_launcher_linux
 )
 

--- a/app/catalog/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/app/catalog/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -10,10 +10,10 @@ import firebase_analytics
 import firebase_auth
 import firebase_core
 import firebase_remote_config
-import isar_flutter_libs
 import package_info_plus
 import path_provider_foundation
 import shared_preferences_foundation
+import sqlite3_flutter_libs
 import url_launcher_macos
 import video_player_avfoundation
 
@@ -23,10 +23,10 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FLTFirebaseAuthPlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseAuthPlugin"))
   FLTFirebaseCorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseCorePlugin"))
   FLTFirebaseRemoteConfigPlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseRemoteConfigPlugin"))
-  IsarFlutterLibsPlugin.register(with: registry.registrar(forPlugin: "IsarFlutterLibsPlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
+  Sqlite3FlutterLibsPlugin.register(with: registry.registrar(forPlugin: "Sqlite3FlutterLibsPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
   FVPVideoPlayerPlugin.register(with: registry.registrar(forPlugin: "FVPVideoPlayerPlugin"))
 }

--- a/app/catalog/windows/flutter/generated_plugin_registrant.cc
+++ b/app/catalog/windows/flutter/generated_plugin_registrant.cc
@@ -9,7 +9,7 @@
 #include <dynamic_color/dynamic_color_plugin_c_api.h>
 #include <firebase_auth/firebase_auth_plugin_c_api.h>
 #include <firebase_core/firebase_core_plugin_c_api.h>
-#include <isar_flutter_libs/isar_flutter_libs_plugin.h>
+#include <sqlite3_flutter_libs/sqlite3_flutter_libs_plugin.h>
 #include <url_launcher_windows/url_launcher_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
@@ -19,8 +19,8 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("FirebaseAuthPluginCApi"));
   FirebaseCorePluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FirebaseCorePluginCApi"));
-  IsarFlutterLibsPluginRegisterWithRegistrar(
-      registry->GetRegistrarForPlugin("IsarFlutterLibsPlugin"));
+  Sqlite3FlutterLibsPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("Sqlite3FlutterLibsPlugin"));
   UrlLauncherWindowsRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("UrlLauncherWindows"));
 }

--- a/app/catalog/windows/flutter/generated_plugins.cmake
+++ b/app/catalog/windows/flutter/generated_plugins.cmake
@@ -6,7 +6,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
   dynamic_color
   firebase_auth
   firebase_core
-  isar_flutter_libs
+  sqlite3_flutter_libs
   url_launcher_windows
 )
 

--- a/app/mobile/pubspec.yaml
+++ b/app/mobile/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
   core_ui: any
   cupertino_icons: 1.0.8
   dynamic_color: 1.7.0
-  envied: 1.0.0
+  envied: 1.1.1
   feature_auth: any
   feature_debug: any
   feature_feed: any
@@ -50,9 +50,9 @@ dependencies:
 
 dev_dependencies:
   build_runner: 2.4.14
-  envied_generator: 1.0.0
+  envied_generator: 1.1.1
   go_router_builder: 2.7.3
-  riverpod_generator: 2.6.3
+  riverpod_generator: 2.6.5
   yumemi_lints: 4.0.0
 
 flutter:

--- a/core/analytics/pubspec.yaml
+++ b/core/analytics/pubspec.yaml
@@ -14,5 +14,5 @@ dependencies:
 
 dev_dependencies:
   build_runner: 2.4.14
-  riverpod_generator: 2.6.3
+  riverpod_generator: 2.6.5
   yumemi_lints: 4.0.0

--- a/core/analytics_firebase/pubspec.yaml
+++ b/core/analytics_firebase/pubspec.yaml
@@ -17,6 +17,6 @@ dependencies:
 
 dev_dependencies:
   build_runner: 2.4.14
-  riverpod_generator: 2.6.3
+  riverpod_generator: 2.6.5
   test: 1.25.14
   yumemi_lints: 4.0.0

--- a/core/authenticator/pubspec.yaml
+++ b/core/authenticator/pubspec.yaml
@@ -15,5 +15,5 @@ dependencies:
 
 dev_dependencies:
   build_runner: 2.4.14
-  riverpod_generator: 2.6.3
+  riverpod_generator: 2.6.5
   yumemi_lints: 4.0.0

--- a/core/data/lib/src/user_settings_repository.g.dart
+++ b/core/data/lib/src/user_settings_repository.g.dart
@@ -13,18 +13,18 @@ String _$userSettingsRepositoryHash() =>
 @ProviderFor(userSettingsRepository)
 final userSettingsRepositoryProvider =
     AutoDisposeProvider<UserSettingsRepository>.internal(
-      userSettingsRepository,
-      name: r'userSettingsRepositoryProvider',
-      debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
-          ? null
-          : _$userSettingsRepositoryHash,
-      dependencies: null,
-      allTransitiveDependencies: null,
-    );
+  userSettingsRepository,
+  name: r'userSettingsRepositoryProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$userSettingsRepositoryHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
 
 @Deprecated('Will be removed in 3.0. Use Ref instead')
 // ignore: unused_element
-typedef UserSettingsRepositoryRef =
-    AutoDisposeProviderRef<UserSettingsRepository>;
+typedef UserSettingsRepositoryRef
+    = AutoDisposeProviderRef<UserSettingsRepository>;
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/core/data/pubspec.yaml
+++ b/core/data/pubspec.yaml
@@ -19,6 +19,6 @@ dependencies:
 dev_dependencies:
   build_runner: 2.4.14
   core_testing: any
-  riverpod_generator: 2.6.3
+  riverpod_generator: 2.6.5
   test: 1.25.14
   yumemi_lints: 4.0.0

--- a/core/database/lib/src/quest/quest_dao.g.dart
+++ b/core/database/lib/src/quest/quest_dao.g.dart
@@ -13,9 +13,8 @@ String _$questDaoHash() => r'9fee4cd06c78399b499d0ff34997e0d8797bae19';
 final questDaoProvider = Provider<QuestDao>.internal(
   questDao,
   name: r'questDaoProvider',
-  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
-      ? null
-      : _$questDaoHash,
+  debugGetCreateSourceHash:
+      const bool.fromEnvironment('dart.vm.product') ? null : _$questDaoHash,
   dependencies: null,
   allTransitiveDependencies: null,
 );

--- a/core/database/pubspec.yaml
+++ b/core/database/pubspec.yaml
@@ -15,5 +15,5 @@ dependencies:
 
 dev_dependencies:
   build_runner: 2.4.14
-  riverpod_generator: 2.6.3
+  riverpod_generator: 2.6.5
   yumemi_lints: 4.0.0

--- a/core/database_drift/pubspec.yaml
+++ b/core/database_drift/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   core_common: any
   core_database: any
   core_model: any
-  drift: 2.22.1
+  drift: 2.26.1
   flutter:
     sdk: flutter
   path: 1.9.1
@@ -23,7 +23,7 @@ dependencies:
 dev_dependencies:
   build_runner: 2.4.14
   core_testing: any
-  drift_dev: 2.22.1
-  riverpod_generator: 2.6.3
+  drift_dev: 2.26.1
+  riverpod_generator: 2.6.5
   test: 1.25.14
   yumemi_lints: 4.0.0

--- a/core/datastore/lib/src/agreed_version_data_store.g.dart
+++ b/core/datastore/lib/src/agreed_version_data_store.g.dart
@@ -13,18 +13,18 @@ String _$agreedVersionDataStoreHash() =>
 @ProviderFor(agreedVersionDataStore)
 final agreedVersionDataStoreProvider =
     AutoDisposeProvider<AgreedVersionDataStore>.internal(
-      agreedVersionDataStore,
-      name: r'agreedVersionDataStoreProvider',
-      debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
-          ? null
-          : _$agreedVersionDataStoreHash,
-      dependencies: null,
-      allTransitiveDependencies: null,
-    );
+  agreedVersionDataStore,
+  name: r'agreedVersionDataStoreProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$agreedVersionDataStoreHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
 
 @Deprecated('Will be removed in 3.0. Use Ref instead')
 // ignore: unused_element
-typedef AgreedVersionDataStoreRef =
-    AutoDisposeProviderRef<AgreedVersionDataStore>;
+typedef AgreedVersionDataStoreRef
+    = AutoDisposeProviderRef<AgreedVersionDataStore>;
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/core/datastore/lib/src/data_store.g.dart
+++ b/core/datastore/lib/src/data_store.g.dart
@@ -15,9 +15,8 @@ String _$dataStoreHash() => r'464523b7a4205b8ddbf6653d4b6392fbfe393463';
 final dataStoreProvider = Provider<DataStore>.internal(
   dataStore,
   name: r'dataStoreProvider',
-  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
-      ? null
-      : _$dataStoreHash,
+  debugGetCreateSourceHash:
+      const bool.fromEnvironment('dart.vm.product') ? null : _$dataStoreHash,
   dependencies: null,
   allTransitiveDependencies: null,
 );

--- a/core/datastore/pubspec.yaml
+++ b/core/datastore/pubspec.yaml
@@ -15,5 +15,5 @@ dependencies:
 
 dev_dependencies:
   build_runner: 2.4.14
-  riverpod_generator: 2.6.3
+  riverpod_generator: 2.6.5
   yumemi_lints: 4.0.0

--- a/core/domain/lib/src/use_case/auth/sign_in_use_case.g.dart
+++ b/core/domain/lib/src/use_case/auth/sign_in_use_case.g.dart
@@ -51,14 +51,20 @@ class SignInUseCaseFamily extends Family<Raw<Future<void>>> {
     required String email,
     required String password,
   }) {
-    return SignInUseCaseProvider(email: email, password: password);
+    return SignInUseCaseProvider(
+      email: email,
+      password: password,
+    );
   }
 
   @override
   SignInUseCaseProvider getProviderOverride(
     covariant SignInUseCaseProvider provider,
   ) {
-    return call(email: provider.email, password: provider.password);
+    return call(
+      email: provider.email,
+      password: provider.password,
+    );
   }
 
   static const Iterable<ProviderOrFamily>? _dependencies = null;
@@ -83,24 +89,27 @@ class SignInUseCaseProvider extends AutoDisposeProvider<Raw<Future<void>>> {
   /// サインインする ユースケース
   ///
   /// Copied from [signInUseCase].
-  SignInUseCaseProvider({required String email, required String password})
-    : this._internal(
-        (ref) => signInUseCase(
-          ref as SignInUseCaseRef,
+  SignInUseCaseProvider({
+    required String email,
+    required String password,
+  }) : this._internal(
+          (ref) => signInUseCase(
+            ref as SignInUseCaseRef,
+            email: email,
+            password: password,
+          ),
+          from: signInUseCaseProvider,
+          name: r'signInUseCaseProvider',
+          debugGetCreateSourceHash:
+              const bool.fromEnvironment('dart.vm.product')
+                  ? null
+                  : _$signInUseCaseHash,
+          dependencies: SignInUseCaseFamily._dependencies,
+          allTransitiveDependencies:
+              SignInUseCaseFamily._allTransitiveDependencies,
           email: email,
           password: password,
-        ),
-        from: signInUseCaseProvider,
-        name: r'signInUseCaseProvider',
-        debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
-            ? null
-            : _$signInUseCaseHash,
-        dependencies: SignInUseCaseFamily._dependencies,
-        allTransitiveDependencies:
-            SignInUseCaseFamily._allTransitiveDependencies,
-        email: email,
-        password: password,
-      );
+        );
 
   SignInUseCaseProvider._internal(
     super._createNotifier, {
@@ -177,6 +186,5 @@ class _SignInUseCaseProviderElement
   @override
   String get password => (origin as SignInUseCaseProvider).password;
 }
-
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/core/domain/lib/src/use_case/feed/feed_list_stream_use_case.g.dart
+++ b/core/domain/lib/src/use_case/feed/feed_list_stream_use_case.g.dart
@@ -15,14 +15,14 @@ String _$feedListStreamUseCaseHash() =>
 @ProviderFor(feedListStreamUseCase)
 final feedListStreamUseCaseProvider =
     AutoDisposeStreamProvider<List<Feed>>.internal(
-      feedListStreamUseCase,
-      name: r'feedListStreamUseCaseProvider',
-      debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
-          ? null
-          : _$feedListStreamUseCaseHash,
-      dependencies: null,
-      allTransitiveDependencies: null,
-    );
+  feedListStreamUseCase,
+  name: r'feedListStreamUseCaseProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$feedListStreamUseCaseHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
 
 @Deprecated('Will be removed in 3.0. Use Ref instead')
 // ignore: unused_element

--- a/core/domain/lib/src/use_case/feed/feed_stream_by_id_use_case.g.dart
+++ b/core/domain/lib/src/use_case/feed/feed_stream_by_id_use_case.g.dart
@@ -48,15 +48,21 @@ class FeedStreamByIdUseCaseFamily extends Family<AsyncValue<Feed?>> {
   /// 該当のお知らせを取得する ユースケース
   ///
   /// Copied from [feedStreamByIdUseCase].
-  FeedStreamByIdUseCaseProvider call({required String id}) {
-    return FeedStreamByIdUseCaseProvider(id: id);
+  FeedStreamByIdUseCaseProvider call({
+    required String id,
+  }) {
+    return FeedStreamByIdUseCaseProvider(
+      id: id,
+    );
   }
 
   @override
   FeedStreamByIdUseCaseProvider getProviderOverride(
     covariant FeedStreamByIdUseCaseProvider provider,
   ) {
-    return call(id: provider.id);
+    return call(
+      id: provider.id,
+    );
   }
 
   static const Iterable<ProviderOrFamily>? _dependencies = null;
@@ -81,19 +87,24 @@ class FeedStreamByIdUseCaseProvider extends AutoDisposeStreamProvider<Feed?> {
   /// 該当のお知らせを取得する ユースケース
   ///
   /// Copied from [feedStreamByIdUseCase].
-  FeedStreamByIdUseCaseProvider({required String id})
-    : this._internal(
-        (ref) => feedStreamByIdUseCase(ref as FeedStreamByIdUseCaseRef, id: id),
-        from: feedStreamByIdUseCaseProvider,
-        name: r'feedStreamByIdUseCaseProvider',
-        debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
-            ? null
-            : _$feedStreamByIdUseCaseHash,
-        dependencies: FeedStreamByIdUseCaseFamily._dependencies,
-        allTransitiveDependencies:
-            FeedStreamByIdUseCaseFamily._allTransitiveDependencies,
-        id: id,
-      );
+  FeedStreamByIdUseCaseProvider({
+    required String id,
+  }) : this._internal(
+          (ref) => feedStreamByIdUseCase(
+            ref as FeedStreamByIdUseCaseRef,
+            id: id,
+          ),
+          from: feedStreamByIdUseCaseProvider,
+          name: r'feedStreamByIdUseCaseProvider',
+          debugGetCreateSourceHash:
+              const bool.fromEnvironment('dart.vm.product')
+                  ? null
+                  : _$feedStreamByIdUseCaseHash,
+          dependencies: FeedStreamByIdUseCaseFamily._dependencies,
+          allTransitiveDependencies:
+              FeedStreamByIdUseCaseFamily._allTransitiveDependencies,
+          id: id,
+        );
 
   FeedStreamByIdUseCaseProvider._internal(
     super._createNotifier, {
@@ -159,6 +170,5 @@ class _FeedStreamByIdUseCaseProviderElement
   @override
   String get id => (origin as FeedStreamByIdUseCaseProvider).id;
 }
-
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/core/domain/lib/src/use_case/feed/news_feed_list_stream_use_case.g.dart
+++ b/core/domain/lib/src/use_case/feed/news_feed_list_stream_use_case.g.dart
@@ -15,18 +15,18 @@ String _$newsFeedListStreamUseCaseHash() =>
 @ProviderFor(newsFeedListStreamUseCase)
 final newsFeedListStreamUseCaseProvider =
     AutoDisposeStreamProvider<List<NewsFeed>>.internal(
-      newsFeedListStreamUseCase,
-      name: r'newsFeedListStreamUseCaseProvider',
-      debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
-          ? null
-          : _$newsFeedListStreamUseCaseHash,
-      dependencies: null,
-      allTransitiveDependencies: null,
-    );
+  newsFeedListStreamUseCase,
+  name: r'newsFeedListStreamUseCaseProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$newsFeedListStreamUseCaseHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
 
 @Deprecated('Will be removed in 3.0. Use Ref instead')
 // ignore: unused_element
-typedef NewsFeedListStreamUseCaseRef =
-    AutoDisposeStreamProviderRef<List<NewsFeed>>;
+typedef NewsFeedListStreamUseCaseRef
+    = AutoDisposeStreamProviderRef<List<NewsFeed>>;
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/core/domain/lib/src/use_case/legal/agree_use_case.g.dart
+++ b/core/domain/lib/src/use_case/legal/agree_use_case.g.dart
@@ -47,15 +47,21 @@ class AgreeUseCaseFamily extends Family<Raw<FutureResult<void>>> {
   /// 同意する
   ///
   /// Copied from [agreeUseCase].
-  AgreeUseCaseProvider call({required RuleVersion agreeRuleVersion}) {
-    return AgreeUseCaseProvider(agreeRuleVersion: agreeRuleVersion);
+  AgreeUseCaseProvider call({
+    required RuleVersion agreeRuleVersion,
+  }) {
+    return AgreeUseCaseProvider(
+      agreeRuleVersion: agreeRuleVersion,
+    );
   }
 
   @override
   AgreeUseCaseProvider getProviderOverride(
     covariant AgreeUseCaseProvider provider,
   ) {
-    return call(agreeRuleVersion: provider.agreeRuleVersion);
+    return call(
+      agreeRuleVersion: provider.agreeRuleVersion,
+    );
   }
 
   static const Iterable<ProviderOrFamily>? _dependencies = null;
@@ -81,22 +87,24 @@ class AgreeUseCaseProvider
   /// 同意する
   ///
   /// Copied from [agreeUseCase].
-  AgreeUseCaseProvider({required RuleVersion agreeRuleVersion})
-    : this._internal(
-        (ref) => agreeUseCase(
-          ref as AgreeUseCaseRef,
+  AgreeUseCaseProvider({
+    required RuleVersion agreeRuleVersion,
+  }) : this._internal(
+          (ref) => agreeUseCase(
+            ref as AgreeUseCaseRef,
+            agreeRuleVersion: agreeRuleVersion,
+          ),
+          from: agreeUseCaseProvider,
+          name: r'agreeUseCaseProvider',
+          debugGetCreateSourceHash:
+              const bool.fromEnvironment('dart.vm.product')
+                  ? null
+                  : _$agreeUseCaseHash,
+          dependencies: AgreeUseCaseFamily._dependencies,
+          allTransitiveDependencies:
+              AgreeUseCaseFamily._allTransitiveDependencies,
           agreeRuleVersion: agreeRuleVersion,
-        ),
-        from: agreeUseCaseProvider,
-        name: r'agreeUseCaseProvider',
-        debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
-            ? null
-            : _$agreeUseCaseHash,
-        dependencies: AgreeUseCaseFamily._dependencies,
-        allTransitiveDependencies:
-            AgreeUseCaseFamily._allTransitiveDependencies,
-        agreeRuleVersion: agreeRuleVersion,
-      );
+        );
 
   AgreeUseCaseProvider._internal(
     super._createNotifier, {
@@ -164,6 +172,5 @@ class _AgreeUseCaseProviderElement
   RuleVersion get agreeRuleVersion =>
       (origin as AgreeUseCaseProvider).agreeRuleVersion;
 }
-
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/core/domain/lib/src/use_case/legal/fetch_agreed_rule_version_use_case.g.dart
+++ b/core/domain/lib/src/use_case/legal/fetch_agreed_rule_version_use_case.g.dart
@@ -15,14 +15,14 @@ String _$fetchAgreedRuleVersionUseCaseHash() =>
 @ProviderFor(fetchAgreedRuleVersionUseCase)
 final fetchAgreedRuleVersionUseCaseProvider =
     AutoDisposeProvider<RuleVersion?>.internal(
-      fetchAgreedRuleVersionUseCase,
-      name: r'fetchAgreedRuleVersionUseCaseProvider',
-      debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
-          ? null
-          : _$fetchAgreedRuleVersionUseCaseHash,
-      dependencies: null,
-      allTransitiveDependencies: null,
-    );
+  fetchAgreedRuleVersionUseCase,
+  name: r'fetchAgreedRuleVersionUseCaseProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$fetchAgreedRuleVersionUseCaseHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
 
 @Deprecated('Will be removed in 3.0. Use Ref instead')
 // ignore: unused_element

--- a/core/domain/lib/src/use_case/quest/add_quest_use_case.g.dart
+++ b/core/domain/lib/src/use_case/quest/add_quest_use_case.g.dart
@@ -98,24 +98,25 @@ class AddQuestUseCaseProvider
     required String description,
     required String note,
   }) : this._internal(
-         (ref) => addQuestUseCase(
-           ref as AddQuestUseCaseRef,
-           title: title,
-           description: description,
-           note: note,
-         ),
-         from: addQuestUseCaseProvider,
-         name: r'addQuestUseCaseProvider',
-         debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
-             ? null
-             : _$addQuestUseCaseHash,
-         dependencies: AddQuestUseCaseFamily._dependencies,
-         allTransitiveDependencies:
-             AddQuestUseCaseFamily._allTransitiveDependencies,
-         title: title,
-         description: description,
-         note: note,
-       );
+          (ref) => addQuestUseCase(
+            ref as AddQuestUseCaseRef,
+            title: title,
+            description: description,
+            note: note,
+          ),
+          from: addQuestUseCaseProvider,
+          name: r'addQuestUseCaseProvider',
+          debugGetCreateSourceHash:
+              const bool.fromEnvironment('dart.vm.product')
+                  ? null
+                  : _$addQuestUseCaseHash,
+          dependencies: AddQuestUseCaseFamily._dependencies,
+          allTransitiveDependencies:
+              AddQuestUseCaseFamily._allTransitiveDependencies,
+          title: title,
+          description: description,
+          note: note,
+        );
 
   AddQuestUseCaseProvider._internal(
     super._createNotifier, {
@@ -202,6 +203,5 @@ class _AddQuestUseCaseProviderElement
   @override
   String get note => (origin as AddQuestUseCaseProvider).note;
 }
-
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/core/domain/lib/src/use_case/quest/quest_count_stream_use_case.g.dart
+++ b/core/domain/lib/src/use_case/quest/quest_count_stream_use_case.g.dart
@@ -15,14 +15,14 @@ String _$questCountStreamUseCaseHash() =>
 @ProviderFor(questCountStreamUseCase)
 final questCountStreamUseCaseProvider =
     AutoDisposeStreamProvider<QuestCount>.internal(
-      questCountStreamUseCase,
-      name: r'questCountStreamUseCaseProvider',
-      debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
-          ? null
-          : _$questCountStreamUseCaseHash,
-      dependencies: null,
-      allTransitiveDependencies: null,
-    );
+  questCountStreamUseCase,
+  name: r'questCountStreamUseCaseProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$questCountStreamUseCaseHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
 
 @Deprecated('Will be removed in 3.0. Use Ref instead')
 // ignore: unused_element

--- a/core/domain/lib/src/use_case/quest/quest_list_stream_use_case.g.dart
+++ b/core/domain/lib/src/use_case/quest/quest_list_stream_use_case.g.dart
@@ -15,14 +15,14 @@ String _$questListStreamUseCaseHash() =>
 @ProviderFor(questListStreamUseCase)
 final questListStreamUseCaseProvider =
     AutoDisposeStreamProvider<List<Quest>>.internal(
-      questListStreamUseCase,
-      name: r'questListStreamUseCaseProvider',
-      debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
-          ? null
-          : _$questListStreamUseCaseHash,
-      dependencies: null,
-      allTransitiveDependencies: null,
-    );
+  questListStreamUseCase,
+  name: r'questListStreamUseCaseProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$questListStreamUseCaseHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
 
 @Deprecated('Will be removed in 3.0. Use Ref instead')
 // ignore: unused_element

--- a/core/domain/lib/src/use_case/quest/quest_stream_by_id_use_case.g.dart
+++ b/core/domain/lib/src/use_case/quest/quest_stream_by_id_use_case.g.dart
@@ -48,15 +48,21 @@ class QuestStreamByIdUseCaseFamily extends Family<AsyncValue<Quest?>> {
   /// 該当のクエストを取得する ユースケース
   ///
   /// Copied from [questStreamByIdUseCase].
-  QuestStreamByIdUseCaseProvider call({required String id}) {
-    return QuestStreamByIdUseCaseProvider(id: id);
+  QuestStreamByIdUseCaseProvider call({
+    required String id,
+  }) {
+    return QuestStreamByIdUseCaseProvider(
+      id: id,
+    );
   }
 
   @override
   QuestStreamByIdUseCaseProvider getProviderOverride(
     covariant QuestStreamByIdUseCaseProvider provider,
   ) {
-    return call(id: provider.id);
+    return call(
+      id: provider.id,
+    );
   }
 
   static const Iterable<ProviderOrFamily>? _dependencies = null;
@@ -81,20 +87,24 @@ class QuestStreamByIdUseCaseProvider extends AutoDisposeStreamProvider<Quest?> {
   /// 該当のクエストを取得する ユースケース
   ///
   /// Copied from [questStreamByIdUseCase].
-  QuestStreamByIdUseCaseProvider({required String id})
-    : this._internal(
-        (ref) =>
-            questStreamByIdUseCase(ref as QuestStreamByIdUseCaseRef, id: id),
-        from: questStreamByIdUseCaseProvider,
-        name: r'questStreamByIdUseCaseProvider',
-        debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
-            ? null
-            : _$questStreamByIdUseCaseHash,
-        dependencies: QuestStreamByIdUseCaseFamily._dependencies,
-        allTransitiveDependencies:
-            QuestStreamByIdUseCaseFamily._allTransitiveDependencies,
-        id: id,
-      );
+  QuestStreamByIdUseCaseProvider({
+    required String id,
+  }) : this._internal(
+          (ref) => questStreamByIdUseCase(
+            ref as QuestStreamByIdUseCaseRef,
+            id: id,
+          ),
+          from: questStreamByIdUseCaseProvider,
+          name: r'questStreamByIdUseCaseProvider',
+          debugGetCreateSourceHash:
+              const bool.fromEnvironment('dart.vm.product')
+                  ? null
+                  : _$questStreamByIdUseCaseHash,
+          dependencies: QuestStreamByIdUseCaseFamily._dependencies,
+          allTransitiveDependencies:
+              QuestStreamByIdUseCaseFamily._allTransitiveDependencies,
+          id: id,
+        );
 
   QuestStreamByIdUseCaseProvider._internal(
     super._createNotifier, {
@@ -160,6 +170,5 @@ class _QuestStreamByIdUseCaseProviderElement
   @override
   String get id => (origin as QuestStreamByIdUseCaseProvider).id;
 }
-
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/core/domain/lib/src/use_case/quest/recent_quest_list_stream_use_case.g.dart
+++ b/core/domain/lib/src/use_case/quest/recent_quest_list_stream_use_case.g.dart
@@ -15,18 +15,18 @@ String _$recentQuestListStreamUseCaseHash() =>
 @ProviderFor(recentQuestListStreamUseCase)
 final recentQuestListStreamUseCaseProvider =
     AutoDisposeStreamProvider<List<Quest>>.internal(
-      recentQuestListStreamUseCase,
-      name: r'recentQuestListStreamUseCaseProvider',
-      debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
-          ? null
-          : _$recentQuestListStreamUseCaseHash,
-      dependencies: null,
-      allTransitiveDependencies: null,
-    );
+  recentQuestListStreamUseCase,
+  name: r'recentQuestListStreamUseCaseProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$recentQuestListStreamUseCaseHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
 
 @Deprecated('Will be removed in 3.0. Use Ref instead')
 // ignore: unused_element
-typedef RecentQuestListStreamUseCaseRef =
-    AutoDisposeStreamProviderRef<List<Quest>>;
+typedef RecentQuestListStreamUseCaseRef
+    = AutoDisposeStreamProviderRef<List<Quest>>;
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/core/domain/lib/src/use_case/sync_use_case.g.dart
+++ b/core/domain/lib/src/use_case/sync_use_case.g.dart
@@ -15,9 +15,8 @@ String _$syncUseCaseHash() => r'3c36d8cc455234c7f69400d816fd35e87fc5ed15';
 final syncUseCaseProvider = AutoDisposeFutureProvider<void>.internal(
   syncUseCase,
   name: r'syncUseCaseProvider',
-  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
-      ? null
-      : _$syncUseCaseHash,
+  debugGetCreateSourceHash:
+      const bool.fromEnvironment('dart.vm.product') ? null : _$syncUseCaseHash,
   dependencies: null,
   allTransitiveDependencies: null,
 );

--- a/core/domain/lib/src/use_case/user_settings/update_theme_use_case.g.dart
+++ b/core/domain/lib/src/use_case/user_settings/update_theme_use_case.g.dart
@@ -48,15 +48,21 @@ class UpdateThemeUseCaseFamily extends Family<Raw<Future<void>>> {
   /// テーマ設定を更新する ユースケース
   ///
   /// Copied from [updateThemeUseCase].
-  UpdateThemeUseCaseProvider call({required Theme theme}) {
-    return UpdateThemeUseCaseProvider(theme: theme);
+  UpdateThemeUseCaseProvider call({
+    required Theme theme,
+  }) {
+    return UpdateThemeUseCaseProvider(
+      theme: theme,
+    );
   }
 
   @override
   UpdateThemeUseCaseProvider getProviderOverride(
     covariant UpdateThemeUseCaseProvider provider,
   ) {
-    return call(theme: provider.theme);
+    return call(
+      theme: provider.theme,
+    );
   }
 
   static const Iterable<ProviderOrFamily>? _dependencies = null;
@@ -82,19 +88,24 @@ class UpdateThemeUseCaseProvider
   /// テーマ設定を更新する ユースケース
   ///
   /// Copied from [updateThemeUseCase].
-  UpdateThemeUseCaseProvider({required Theme theme})
-    : this._internal(
-        (ref) => updateThemeUseCase(ref as UpdateThemeUseCaseRef, theme: theme),
-        from: updateThemeUseCaseProvider,
-        name: r'updateThemeUseCaseProvider',
-        debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
-            ? null
-            : _$updateThemeUseCaseHash,
-        dependencies: UpdateThemeUseCaseFamily._dependencies,
-        allTransitiveDependencies:
-            UpdateThemeUseCaseFamily._allTransitiveDependencies,
-        theme: theme,
-      );
+  UpdateThemeUseCaseProvider({
+    required Theme theme,
+  }) : this._internal(
+          (ref) => updateThemeUseCase(
+            ref as UpdateThemeUseCaseRef,
+            theme: theme,
+          ),
+          from: updateThemeUseCaseProvider,
+          name: r'updateThemeUseCaseProvider',
+          debugGetCreateSourceHash:
+              const bool.fromEnvironment('dart.vm.product')
+                  ? null
+                  : _$updateThemeUseCaseHash,
+          dependencies: UpdateThemeUseCaseFamily._dependencies,
+          allTransitiveDependencies:
+              UpdateThemeUseCaseFamily._allTransitiveDependencies,
+          theme: theme,
+        );
 
   UpdateThemeUseCaseProvider._internal(
     super._createNotifier, {
@@ -160,6 +171,5 @@ class _UpdateThemeUseCaseProviderElement
   @override
   Theme get theme => (origin as UpdateThemeUseCaseProvider).theme;
 }
-
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/core/domain/pubspec.yaml
+++ b/core/domain/pubspec.yaml
@@ -18,6 +18,6 @@ dependencies:
 dev_dependencies:
   build_runner: 2.4.14
   core_testing: any
-  riverpod_generator: 2.6.3
+  riverpod_generator: 2.6.5
   test: 1.25.14
   yumemi_lints: 4.0.0

--- a/core/domain/test/.test_optimizer.dart
+++ b/core/domain/test/.test_optimizer.dart
@@ -1,0 +1,14 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// Consider adding this file to your .gitignore.
+
+import 'package:test/test.dart';
+
+import 'use_case/auth/sign_in_use_case_test.dart' as _a;
+import 'use_case/quest/quest_count_stream_use_case_test.dart' as _b;
+
+void main() {
+
+  group('use_case/auth/sign_in_use_case_test.dart', () { _a.main(); });
+  group('use_case/quest/quest_count_stream_use_case_test.dart', () { _b.main(); });
+}
+

--- a/core/model/lib/src/auth/auth_state.freezed.dart
+++ b/core/model/lib/src/auth/auth_state.freezed.dart
@@ -1,3 +1,4 @@
+// dart format width=80
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint
@@ -9,182 +10,89 @@ part of 'auth_state.dart';
 // FreezedGenerator
 // **************************************************************************
 
+// dart format off
 T _$identity<T>(T value) => value;
-
-final _privateConstructorUsedError = UnsupportedError(
-  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
-);
 
 /// @nodoc
 mixin _$AuthState {
-  @optionalTypeArgs
-  TResult when<TResult extends Object?>({
-    required TResult Function() unauthenticated,
-    required TResult Function(User user) authenticated,
-  }) => throw _privateConstructorUsedError;
-  @optionalTypeArgs
-  TResult? whenOrNull<TResult extends Object?>({
-    TResult? Function()? unauthenticated,
-    TResult? Function(User user)? authenticated,
-  }) => throw _privateConstructorUsedError;
-  @optionalTypeArgs
-  TResult maybeWhen<TResult extends Object?>({
-    TResult Function()? unauthenticated,
-    TResult Function(User user)? authenticated,
-    required TResult orElse(),
-  }) => throw _privateConstructorUsedError;
-  @optionalTypeArgs
-  TResult map<TResult extends Object?>({
-    required TResult Function(AuthStateUnauthenticated value) unauthenticated,
-    required TResult Function(AuthStateAuthenticated value) authenticated,
-  }) => throw _privateConstructorUsedError;
-  @optionalTypeArgs
-  TResult? mapOrNull<TResult extends Object?>({
-    TResult? Function(AuthStateUnauthenticated value)? unauthenticated,
-    TResult? Function(AuthStateAuthenticated value)? authenticated,
-  }) => throw _privateConstructorUsedError;
-  @optionalTypeArgs
-  TResult maybeMap<TResult extends Object?>({
-    TResult Function(AuthStateUnauthenticated value)? unauthenticated,
-    TResult Function(AuthStateAuthenticated value)? authenticated,
-    required TResult orElse(),
-  }) => throw _privateConstructorUsedError;
-}
-
-/// @nodoc
-abstract class $AuthStateCopyWith<$Res> {
-  factory $AuthStateCopyWith(AuthState value, $Res Function(AuthState) then) =
-      _$AuthStateCopyWithImpl<$Res, AuthState>;
-}
-
-/// @nodoc
-class _$AuthStateCopyWithImpl<$Res, $Val extends AuthState>
-    implements $AuthStateCopyWith<$Res> {
-  _$AuthStateCopyWithImpl(this._value, this._then);
-
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
-
-  /// Create a copy of AuthState
-  /// with the given fields replaced by the non-null parameter values.
-}
-
-/// @nodoc
-abstract class _$$AuthStateUnauthenticatedImplCopyWith<$Res> {
-  factory _$$AuthStateUnauthenticatedImplCopyWith(
-    _$AuthStateUnauthenticatedImpl value,
-    $Res Function(_$AuthStateUnauthenticatedImpl) then,
-  ) = __$$AuthStateUnauthenticatedImplCopyWithImpl<$Res>;
-}
-
-/// @nodoc
-class __$$AuthStateUnauthenticatedImplCopyWithImpl<$Res>
-    extends _$AuthStateCopyWithImpl<$Res, _$AuthStateUnauthenticatedImpl>
-    implements _$$AuthStateUnauthenticatedImplCopyWith<$Res> {
-  __$$AuthStateUnauthenticatedImplCopyWithImpl(
-    _$AuthStateUnauthenticatedImpl _value,
-    $Res Function(_$AuthStateUnauthenticatedImpl) _then,
-  ) : super(_value, _then);
-
-  /// Create a copy of AuthState
-  /// with the given fields replaced by the non-null parameter values.
-}
-
-/// @nodoc
-
-class _$AuthStateUnauthenticatedImpl implements AuthStateUnauthenticated {
-  const _$AuthStateUnauthenticatedImpl();
-
-  @override
-  String toString() {
-    return 'AuthState.unauthenticated()';
-  }
-
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _$AuthStateUnauthenticatedImpl);
+        (other.runtimeType == runtimeType && other is AuthState);
   }
 
   @override
   int get hashCode => runtimeType.hashCode;
 
   @override
-  @optionalTypeArgs
-  TResult when<TResult extends Object?>({
-    required TResult Function() unauthenticated,
-    required TResult Function(User user) authenticated,
-  }) {
-    return unauthenticated();
+  String toString() {
+    return 'AuthState()';
   }
-
-  @override
-  @optionalTypeArgs
-  TResult? whenOrNull<TResult extends Object?>({
-    TResult? Function()? unauthenticated,
-    TResult? Function(User user)? authenticated,
-  }) {
-    return unauthenticated?.call();
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult maybeWhen<TResult extends Object?>({
-    TResult Function()? unauthenticated,
-    TResult Function(User user)? authenticated,
-    required TResult orElse(),
-  }) {
-    if (unauthenticated != null) {
-      return unauthenticated();
-    }
-    return orElse();
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult map<TResult extends Object?>({
-    required TResult Function(AuthStateUnauthenticated value) unauthenticated,
-    required TResult Function(AuthStateAuthenticated value) authenticated,
-  }) {
-    return unauthenticated(this);
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult? mapOrNull<TResult extends Object?>({
-    TResult? Function(AuthStateUnauthenticated value)? unauthenticated,
-    TResult? Function(AuthStateAuthenticated value)? authenticated,
-  }) {
-    return unauthenticated?.call(this);
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult maybeMap<TResult extends Object?>({
-    TResult Function(AuthStateUnauthenticated value)? unauthenticated,
-    TResult Function(AuthStateAuthenticated value)? authenticated,
-    required TResult orElse(),
-  }) {
-    if (unauthenticated != null) {
-      return unauthenticated(this);
-    }
-    return orElse();
-  }
-}
-
-abstract class AuthStateUnauthenticated implements AuthState {
-  const factory AuthStateUnauthenticated() = _$AuthStateUnauthenticatedImpl;
 }
 
 /// @nodoc
-abstract class _$$AuthStateAuthenticatedImplCopyWith<$Res> {
-  factory _$$AuthStateAuthenticatedImplCopyWith(
-    _$AuthStateAuthenticatedImpl value,
-    $Res Function(_$AuthStateAuthenticatedImpl) then,
-  ) = __$$AuthStateAuthenticatedImplCopyWithImpl<$Res>;
+class $AuthStateCopyWith<$Res> {
+  $AuthStateCopyWith(AuthState _, $Res Function(AuthState) __);
+}
+
+/// @nodoc
+
+class AuthStateUnauthenticated implements AuthState {
+  const AuthStateUnauthenticated();
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType && other is AuthStateUnauthenticated);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  String toString() {
+    return 'AuthState.unauthenticated()';
+  }
+}
+
+/// @nodoc
+
+class AuthStateAuthenticated implements AuthState {
+  const AuthStateAuthenticated({required this.user});
+
+  final User user;
+
+  /// Create a copy of AuthState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $AuthStateAuthenticatedCopyWith<AuthStateAuthenticated> get copyWith =>
+      _$AuthStateAuthenticatedCopyWithImpl<AuthStateAuthenticated>(
+          this, _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is AuthStateAuthenticated &&
+            (identical(other.user, user) || other.user == user));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, user);
+
+  @override
+  String toString() {
+    return 'AuthState.authenticated(user: $user)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $AuthStateAuthenticatedCopyWith<$Res>
+    implements $AuthStateCopyWith<$Res> {
+  factory $AuthStateAuthenticatedCopyWith(AuthStateAuthenticated value,
+          $Res Function(AuthStateAuthenticated) _then) =
+      _$AuthStateAuthenticatedCopyWithImpl;
   @useResult
   $Res call({User user});
 
@@ -192,27 +100,25 @@ abstract class _$$AuthStateAuthenticatedImplCopyWith<$Res> {
 }
 
 /// @nodoc
-class __$$AuthStateAuthenticatedImplCopyWithImpl<$Res>
-    extends _$AuthStateCopyWithImpl<$Res, _$AuthStateAuthenticatedImpl>
-    implements _$$AuthStateAuthenticatedImplCopyWith<$Res> {
-  __$$AuthStateAuthenticatedImplCopyWithImpl(
-    _$AuthStateAuthenticatedImpl _value,
-    $Res Function(_$AuthStateAuthenticatedImpl) _then,
-  ) : super(_value, _then);
+class _$AuthStateAuthenticatedCopyWithImpl<$Res>
+    implements $AuthStateAuthenticatedCopyWith<$Res> {
+  _$AuthStateAuthenticatedCopyWithImpl(this._self, this._then);
+
+  final AuthStateAuthenticated _self;
+  final $Res Function(AuthStateAuthenticated) _then;
 
   /// Create a copy of AuthState
   /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
-  @override
-  $Res call({Object? user = null}) {
-    return _then(
-      _$AuthStateAuthenticatedImpl(
-        user: null == user
-            ? _value.user
-            : user // ignore: cast_nullable_to_non_nullable
-                  as User,
-      ),
-    );
+  $Res call({
+    Object? user = null,
+  }) {
+    return _then(AuthStateAuthenticated(
+      user: null == user
+          ? _self.user
+          : user // ignore: cast_nullable_to_non_nullable
+              as User,
+    ));
   }
 
   /// Create a copy of AuthState
@@ -220,120 +126,10 @@ class __$$AuthStateAuthenticatedImplCopyWithImpl<$Res>
   @override
   @pragma('vm:prefer-inline')
   $UserCopyWith<$Res> get user {
-    return $UserCopyWith<$Res>(_value.user, (value) {
-      return _then(_value.copyWith(user: value));
+    return $UserCopyWith<$Res>(_self.user, (value) {
+      return _then(_self.copyWith(user: value));
     });
   }
 }
 
-/// @nodoc
-
-class _$AuthStateAuthenticatedImpl implements AuthStateAuthenticated {
-  const _$AuthStateAuthenticatedImpl({required this.user});
-
-  @override
-  final User user;
-
-  @override
-  String toString() {
-    return 'AuthState.authenticated(user: $user)';
-  }
-
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _$AuthStateAuthenticatedImpl &&
-            (identical(other.user, user) || other.user == user));
-  }
-
-  @override
-  int get hashCode => Object.hash(runtimeType, user);
-
-  /// Create a copy of AuthState
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  @pragma('vm:prefer-inline')
-  _$$AuthStateAuthenticatedImplCopyWith<_$AuthStateAuthenticatedImpl>
-  get copyWith =>
-      __$$AuthStateAuthenticatedImplCopyWithImpl<_$AuthStateAuthenticatedImpl>(
-        this,
-        _$identity,
-      );
-
-  @override
-  @optionalTypeArgs
-  TResult when<TResult extends Object?>({
-    required TResult Function() unauthenticated,
-    required TResult Function(User user) authenticated,
-  }) {
-    return authenticated(user);
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult? whenOrNull<TResult extends Object?>({
-    TResult? Function()? unauthenticated,
-    TResult? Function(User user)? authenticated,
-  }) {
-    return authenticated?.call(user);
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult maybeWhen<TResult extends Object?>({
-    TResult Function()? unauthenticated,
-    TResult Function(User user)? authenticated,
-    required TResult orElse(),
-  }) {
-    if (authenticated != null) {
-      return authenticated(user);
-    }
-    return orElse();
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult map<TResult extends Object?>({
-    required TResult Function(AuthStateUnauthenticated value) unauthenticated,
-    required TResult Function(AuthStateAuthenticated value) authenticated,
-  }) {
-    return authenticated(this);
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult? mapOrNull<TResult extends Object?>({
-    TResult? Function(AuthStateUnauthenticated value)? unauthenticated,
-    TResult? Function(AuthStateAuthenticated value)? authenticated,
-  }) {
-    return authenticated?.call(this);
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult maybeMap<TResult extends Object?>({
-    TResult Function(AuthStateUnauthenticated value)? unauthenticated,
-    TResult Function(AuthStateAuthenticated value)? authenticated,
-    required TResult orElse(),
-  }) {
-    if (authenticated != null) {
-      return authenticated(this);
-    }
-    return orElse();
-  }
-}
-
-abstract class AuthStateAuthenticated implements AuthState {
-  const factory AuthStateAuthenticated({required final User user}) =
-      _$AuthStateAuthenticatedImpl;
-
-  User get user;
-
-  /// Create a copy of AuthState
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$AuthStateAuthenticatedImplCopyWith<_$AuthStateAuthenticatedImpl>
-  get copyWith => throw _privateConstructorUsedError;
-}
+// dart format on

--- a/core/model/lib/src/auth/user.dart
+++ b/core/model/lib/src/auth/user.dart
@@ -8,6 +8,6 @@ typedef UserId = String;
 ///
 /// {@category Model}
 @freezed
-class User with _$User {
+abstract class User with _$User {
   const factory User({required UserId id, required String email}) = _User;
 }

--- a/core/model/lib/src/auth/user.freezed.dart
+++ b/core/model/lib/src/auth/user.freezed.dart
@@ -1,3 +1,4 @@
+// dart format width=80
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint
@@ -9,120 +10,26 @@ part of 'user.dart';
 // FreezedGenerator
 // **************************************************************************
 
+// dart format off
 T _$identity<T>(T value) => value;
-
-final _privateConstructorUsedError = UnsupportedError(
-  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
-);
 
 /// @nodoc
 mixin _$User {
-  String get id => throw _privateConstructorUsedError;
-  String get email => throw _privateConstructorUsedError;
+  UserId get id;
+  String get email;
 
   /// Create a copy of User
   /// with the given fields replaced by the non-null parameter values.
   @JsonKey(includeFromJson: false, includeToJson: false)
-  $UserCopyWith<User> get copyWith => throw _privateConstructorUsedError;
-}
-
-/// @nodoc
-abstract class $UserCopyWith<$Res> {
-  factory $UserCopyWith(User value, $Res Function(User) then) =
-      _$UserCopyWithImpl<$Res, User>;
-  @useResult
-  $Res call({String id, String email});
-}
-
-/// @nodoc
-class _$UserCopyWithImpl<$Res, $Val extends User>
-    implements $UserCopyWith<$Res> {
-  _$UserCopyWithImpl(this._value, this._then);
-
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
-
-  /// Create a copy of User
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
-  @override
-  $Res call({Object? id = null, Object? email = null}) {
-    return _then(
-      _value.copyWith(
-            id: null == id
-                ? _value.id
-                : id // ignore: cast_nullable_to_non_nullable
-                      as String,
-            email: null == email
-                ? _value.email
-                : email // ignore: cast_nullable_to_non_nullable
-                      as String,
-          )
-          as $Val,
-    );
-  }
-}
-
-/// @nodoc
-abstract class _$$UserImplCopyWith<$Res> implements $UserCopyWith<$Res> {
-  factory _$$UserImplCopyWith(
-    _$UserImpl value,
-    $Res Function(_$UserImpl) then,
-  ) = __$$UserImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call({String id, String email});
-}
-
-/// @nodoc
-class __$$UserImplCopyWithImpl<$Res>
-    extends _$UserCopyWithImpl<$Res, _$UserImpl>
-    implements _$$UserImplCopyWith<$Res> {
-  __$$UserImplCopyWithImpl(_$UserImpl _value, $Res Function(_$UserImpl) _then)
-    : super(_value, _then);
-
-  /// Create a copy of User
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({Object? id = null, Object? email = null}) {
-    return _then(
-      _$UserImpl(
-        id: null == id
-            ? _value.id
-            : id // ignore: cast_nullable_to_non_nullable
-                  as String,
-        email: null == email
-            ? _value.email
-            : email // ignore: cast_nullable_to_non_nullable
-                  as String,
-      ),
-    );
-  }
-}
-
-/// @nodoc
-
-class _$UserImpl implements _User {
-  const _$UserImpl({required this.id, required this.email});
-
-  @override
-  final String id;
-  @override
-  final String email;
-
-  @override
-  String toString() {
-    return 'User(id: $id, email: $email)';
-  }
+  $UserCopyWith<User> get copyWith =>
+      _$UserCopyWithImpl<User>(this as User, _$identity);
 
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$UserImpl &&
+            other is User &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.email, email) || other.email == email));
   }
@@ -130,28 +37,119 @@ class _$UserImpl implements _User {
   @override
   int get hashCode => Object.hash(runtimeType, id, email);
 
+  @override
+  String toString() {
+    return 'User(id: $id, email: $email)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $UserCopyWith<$Res> {
+  factory $UserCopyWith(User value, $Res Function(User) _then) =
+      _$UserCopyWithImpl;
+  @useResult
+  $Res call({UserId id, String email});
+}
+
+/// @nodoc
+class _$UserCopyWithImpl<$Res> implements $UserCopyWith<$Res> {
+  _$UserCopyWithImpl(this._self, this._then);
+
+  final User _self;
+  final $Res Function(User) _then;
+
   /// Create a copy of User
   /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? email = null,
+  }) {
+    return _then(_self.copyWith(
+      id: null == id
+          ? _self.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as UserId,
+      email: null == email
+          ? _self.email
+          : email // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _User implements User {
+  const _User({required this.id, required this.email});
+
+  @override
+  final UserId id;
+  @override
+  final String email;
+
+  /// Create a copy of User
+  /// with the given fields replaced by the non-null parameter values.
+  @override
   @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$UserCopyWith<_User> get copyWith =>
+      __$UserCopyWithImpl<_User>(this, _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _User &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.email, email) || other.email == email));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, id, email);
+
+  @override
+  String toString() {
+    return 'User(id: $id, email: $email)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$UserCopyWith<$Res> implements $UserCopyWith<$Res> {
+  factory _$UserCopyWith(_User value, $Res Function(_User) _then) =
+      __$UserCopyWithImpl;
+  @override
+  @useResult
+  $Res call({UserId id, String email});
+}
+
+/// @nodoc
+class __$UserCopyWithImpl<$Res> implements _$UserCopyWith<$Res> {
+  __$UserCopyWithImpl(this._self, this._then);
+
+  final _User _self;
+  final $Res Function(_User) _then;
+
+  /// Create a copy of User
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
-  _$$UserImplCopyWith<_$UserImpl> get copyWith =>
-      __$$UserImplCopyWithImpl<_$UserImpl>(this, _$identity);
+  $Res call({
+    Object? id = null,
+    Object? email = null,
+  }) {
+    return _then(_User(
+      id: null == id
+          ? _self.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as UserId,
+      email: null == email
+          ? _self.email
+          : email // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
 }
 
-abstract class _User implements User {
-  const factory _User({required final String id, required final String email}) =
-      _$UserImpl;
-
-  @override
-  String get id;
-  @override
-  String get email;
-
-  /// Create a copy of User
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$UserImplCopyWith<_$UserImpl> get copyWith =>
-      throw _privateConstructorUsedError;
-}
+// dart format on

--- a/core/model/lib/src/config/app_config.dart
+++ b/core/model/lib/src/config/app_config.dart
@@ -16,7 +16,7 @@ AppConfig appConfig(Ref ref) {
 ///
 /// {@category Model}
 @freezed
-class AppConfig with _$AppConfig {
+abstract class AppConfig with _$AppConfig {
   const factory AppConfig({
     required String appName,
     required String packageName,

--- a/core/model/lib/src/config/app_config.freezed.dart
+++ b/core/model/lib/src/config/app_config.freezed.dart
@@ -1,3 +1,4 @@
+// dart format width=80
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint
@@ -9,60 +10,94 @@ part of 'app_config.dart';
 // FreezedGenerator
 // **************************************************************************
 
+// dart format off
 T _$identity<T>(T value) => value;
-
-final _privateConstructorUsedError = UnsupportedError(
-  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
-);
 
 /// @nodoc
 mixin _$AppConfig {
-  String get appName => throw _privateConstructorUsedError;
-  String get packageName => throw _privateConstructorUsedError;
-  AppVersion get version => throw _privateConstructorUsedError;
-  String get buildNumber => throw _privateConstructorUsedError;
-  String get buildSignature => throw _privateConstructorUsedError;
-  Flavor get flavor => throw _privateConstructorUsedError;
-  String? get installerStore => throw _privateConstructorUsedError;
-  String get backendUrl => throw _privateConstructorUsedError;
-  String get websiteUrl => throw _privateConstructorUsedError;
+  String get appName;
+  String get packageName;
+  AppVersion get version;
+  String get buildNumber;
+  String get buildSignature;
+  Flavor get flavor;
+  String? get installerStore;
+  String get backendUrl;
+  String get websiteUrl;
 
   /// Create a copy of AppConfig
   /// with the given fields replaced by the non-null parameter values.
   @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
   $AppConfigCopyWith<AppConfig> get copyWith =>
-      throw _privateConstructorUsedError;
+      _$AppConfigCopyWithImpl<AppConfig>(this as AppConfig, _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is AppConfig &&
+            (identical(other.appName, appName) || other.appName == appName) &&
+            (identical(other.packageName, packageName) ||
+                other.packageName == packageName) &&
+            (identical(other.version, version) || other.version == version) &&
+            (identical(other.buildNumber, buildNumber) ||
+                other.buildNumber == buildNumber) &&
+            (identical(other.buildSignature, buildSignature) ||
+                other.buildSignature == buildSignature) &&
+            (identical(other.flavor, flavor) || other.flavor == flavor) &&
+            (identical(other.installerStore, installerStore) ||
+                other.installerStore == installerStore) &&
+            (identical(other.backendUrl, backendUrl) ||
+                other.backendUrl == backendUrl) &&
+            (identical(other.websiteUrl, websiteUrl) ||
+                other.websiteUrl == websiteUrl));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      appName,
+      packageName,
+      version,
+      buildNumber,
+      buildSignature,
+      flavor,
+      installerStore,
+      backendUrl,
+      websiteUrl);
+
+  @override
+  String toString() {
+    return 'AppConfig(appName: $appName, packageName: $packageName, version: $version, buildNumber: $buildNumber, buildSignature: $buildSignature, flavor: $flavor, installerStore: $installerStore, backendUrl: $backendUrl, websiteUrl: $websiteUrl)';
+  }
 }
 
 /// @nodoc
-abstract class $AppConfigCopyWith<$Res> {
-  factory $AppConfigCopyWith(AppConfig value, $Res Function(AppConfig) then) =
-      _$AppConfigCopyWithImpl<$Res, AppConfig>;
+abstract mixin class $AppConfigCopyWith<$Res> {
+  factory $AppConfigCopyWith(AppConfig value, $Res Function(AppConfig) _then) =
+      _$AppConfigCopyWithImpl;
   @useResult
-  $Res call({
-    String appName,
-    String packageName,
-    AppVersion version,
-    String buildNumber,
-    String buildSignature,
-    Flavor flavor,
-    String? installerStore,
-    String backendUrl,
-    String websiteUrl,
-  });
+  $Res call(
+      {String appName,
+      String packageName,
+      AppVersion version,
+      String buildNumber,
+      String buildSignature,
+      Flavor flavor,
+      String? installerStore,
+      String backendUrl,
+      String websiteUrl});
 
   $AppVersionCopyWith<$Res> get version;
 }
 
 /// @nodoc
-class _$AppConfigCopyWithImpl<$Res, $Val extends AppConfig>
-    implements $AppConfigCopyWith<$Res> {
-  _$AppConfigCopyWithImpl(this._value, this._then);
+class _$AppConfigCopyWithImpl<$Res> implements $AppConfigCopyWith<$Res> {
+  _$AppConfigCopyWithImpl(this._self, this._then);
 
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
+  final AppConfig _self;
+  final $Res Function(AppConfig) _then;
 
   /// Create a copy of AppConfig
   /// with the given fields replaced by the non-null parameter values.
@@ -79,47 +114,44 @@ class _$AppConfigCopyWithImpl<$Res, $Val extends AppConfig>
     Object? backendUrl = null,
     Object? websiteUrl = null,
   }) {
-    return _then(
-      _value.copyWith(
-            appName: null == appName
-                ? _value.appName
-                : appName // ignore: cast_nullable_to_non_nullable
-                      as String,
-            packageName: null == packageName
-                ? _value.packageName
-                : packageName // ignore: cast_nullable_to_non_nullable
-                      as String,
-            version: null == version
-                ? _value.version
-                : version // ignore: cast_nullable_to_non_nullable
-                      as AppVersion,
-            buildNumber: null == buildNumber
-                ? _value.buildNumber
-                : buildNumber // ignore: cast_nullable_to_non_nullable
-                      as String,
-            buildSignature: null == buildSignature
-                ? _value.buildSignature
-                : buildSignature // ignore: cast_nullable_to_non_nullable
-                      as String,
-            flavor: null == flavor
-                ? _value.flavor
-                : flavor // ignore: cast_nullable_to_non_nullable
-                      as Flavor,
-            installerStore: freezed == installerStore
-                ? _value.installerStore
-                : installerStore // ignore: cast_nullable_to_non_nullable
-                      as String?,
-            backendUrl: null == backendUrl
-                ? _value.backendUrl
-                : backendUrl // ignore: cast_nullable_to_non_nullable
-                      as String,
-            websiteUrl: null == websiteUrl
-                ? _value.websiteUrl
-                : websiteUrl // ignore: cast_nullable_to_non_nullable
-                      as String,
-          )
-          as $Val,
-    );
+    return _then(_self.copyWith(
+      appName: null == appName
+          ? _self.appName
+          : appName // ignore: cast_nullable_to_non_nullable
+              as String,
+      packageName: null == packageName
+          ? _self.packageName
+          : packageName // ignore: cast_nullable_to_non_nullable
+              as String,
+      version: null == version
+          ? _self.version
+          : version // ignore: cast_nullable_to_non_nullable
+              as AppVersion,
+      buildNumber: null == buildNumber
+          ? _self.buildNumber
+          : buildNumber // ignore: cast_nullable_to_non_nullable
+              as String,
+      buildSignature: null == buildSignature
+          ? _self.buildSignature
+          : buildSignature // ignore: cast_nullable_to_non_nullable
+              as String,
+      flavor: null == flavor
+          ? _self.flavor
+          : flavor // ignore: cast_nullable_to_non_nullable
+              as Flavor,
+      installerStore: freezed == installerStore
+          ? _self.installerStore
+          : installerStore // ignore: cast_nullable_to_non_nullable
+              as String?,
+      backendUrl: null == backendUrl
+          ? _self.backendUrl
+          : backendUrl // ignore: cast_nullable_to_non_nullable
+              as String,
+      websiteUrl: null == websiteUrl
+          ? _self.websiteUrl
+          : websiteUrl // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
   }
 
   /// Create a copy of AppConfig
@@ -127,118 +159,25 @@ class _$AppConfigCopyWithImpl<$Res, $Val extends AppConfig>
   @override
   @pragma('vm:prefer-inline')
   $AppVersionCopyWith<$Res> get version {
-    return $AppVersionCopyWith<$Res>(_value.version, (value) {
-      return _then(_value.copyWith(version: value) as $Val);
+    return $AppVersionCopyWith<$Res>(_self.version, (value) {
+      return _then(_self.copyWith(version: value));
     });
   }
 }
 
 /// @nodoc
-abstract class _$$AppConfigImplCopyWith<$Res>
-    implements $AppConfigCopyWith<$Res> {
-  factory _$$AppConfigImplCopyWith(
-    _$AppConfigImpl value,
-    $Res Function(_$AppConfigImpl) then,
-  ) = __$$AppConfigImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call({
-    String appName,
-    String packageName,
-    AppVersion version,
-    String buildNumber,
-    String buildSignature,
-    Flavor flavor,
-    String? installerStore,
-    String backendUrl,
-    String websiteUrl,
-  });
 
-  @override
-  $AppVersionCopyWith<$Res> get version;
-}
-
-/// @nodoc
-class __$$AppConfigImplCopyWithImpl<$Res>
-    extends _$AppConfigCopyWithImpl<$Res, _$AppConfigImpl>
-    implements _$$AppConfigImplCopyWith<$Res> {
-  __$$AppConfigImplCopyWithImpl(
-    _$AppConfigImpl _value,
-    $Res Function(_$AppConfigImpl) _then,
-  ) : super(_value, _then);
-
-  /// Create a copy of AppConfig
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? appName = null,
-    Object? packageName = null,
-    Object? version = null,
-    Object? buildNumber = null,
-    Object? buildSignature = null,
-    Object? flavor = null,
-    Object? installerStore = freezed,
-    Object? backendUrl = null,
-    Object? websiteUrl = null,
-  }) {
-    return _then(
-      _$AppConfigImpl(
-        appName: null == appName
-            ? _value.appName
-            : appName // ignore: cast_nullable_to_non_nullable
-                  as String,
-        packageName: null == packageName
-            ? _value.packageName
-            : packageName // ignore: cast_nullable_to_non_nullable
-                  as String,
-        version: null == version
-            ? _value.version
-            : version // ignore: cast_nullable_to_non_nullable
-                  as AppVersion,
-        buildNumber: null == buildNumber
-            ? _value.buildNumber
-            : buildNumber // ignore: cast_nullable_to_non_nullable
-                  as String,
-        buildSignature: null == buildSignature
-            ? _value.buildSignature
-            : buildSignature // ignore: cast_nullable_to_non_nullable
-                  as String,
-        flavor: null == flavor
-            ? _value.flavor
-            : flavor // ignore: cast_nullable_to_non_nullable
-                  as Flavor,
-        installerStore: freezed == installerStore
-            ? _value.installerStore
-            : installerStore // ignore: cast_nullable_to_non_nullable
-                  as String?,
-        backendUrl: null == backendUrl
-            ? _value.backendUrl
-            : backendUrl // ignore: cast_nullable_to_non_nullable
-                  as String,
-        websiteUrl: null == websiteUrl
-            ? _value.websiteUrl
-            : websiteUrl // ignore: cast_nullable_to_non_nullable
-                  as String,
-      ),
-    );
-  }
-}
-
-/// @nodoc
-
-class _$AppConfigImpl implements _AppConfig {
-  const _$AppConfigImpl({
-    required this.appName,
-    required this.packageName,
-    required this.version,
-    required this.buildNumber,
-    required this.buildSignature,
-    required this.flavor,
-    required this.installerStore,
-    required this.backendUrl,
-    required this.websiteUrl,
-  });
+class _AppConfig implements AppConfig {
+  const _AppConfig(
+      {required this.appName,
+      required this.packageName,
+      required this.version,
+      required this.buildNumber,
+      required this.buildSignature,
+      required this.flavor,
+      required this.installerStore,
+      required this.backendUrl,
+      required this.websiteUrl});
 
   @override
   final String appName;
@@ -259,16 +198,19 @@ class _$AppConfigImpl implements _AppConfig {
   @override
   final String websiteUrl;
 
+  /// Create a copy of AppConfig
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  String toString() {
-    return 'AppConfig(appName: $appName, packageName: $packageName, version: $version, buildNumber: $buildNumber, buildSignature: $buildSignature, flavor: $flavor, installerStore: $installerStore, backendUrl: $backendUrl, websiteUrl: $websiteUrl)';
-  }
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$AppConfigCopyWith<_AppConfig> get copyWith =>
+      __$AppConfigCopyWithImpl<_AppConfig>(this, _$identity);
 
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$AppConfigImpl &&
+            other is _AppConfig &&
             (identical(other.appName, appName) || other.appName == appName) &&
             (identical(other.packageName, packageName) ||
                 other.packageName == packageName) &&
@@ -288,63 +230,117 @@ class _$AppConfigImpl implements _AppConfig {
 
   @override
   int get hashCode => Object.hash(
-    runtimeType,
-    appName,
-    packageName,
-    version,
-    buildNumber,
-    buildSignature,
-    flavor,
-    installerStore,
-    backendUrl,
-    websiteUrl,
-  );
+      runtimeType,
+      appName,
+      packageName,
+      version,
+      buildNumber,
+      buildSignature,
+      flavor,
+      installerStore,
+      backendUrl,
+      websiteUrl);
+
+  @override
+  String toString() {
+    return 'AppConfig(appName: $appName, packageName: $packageName, version: $version, buildNumber: $buildNumber, buildSignature: $buildSignature, flavor: $flavor, installerStore: $installerStore, backendUrl: $backendUrl, websiteUrl: $websiteUrl)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$AppConfigCopyWith<$Res>
+    implements $AppConfigCopyWith<$Res> {
+  factory _$AppConfigCopyWith(
+          _AppConfig value, $Res Function(_AppConfig) _then) =
+      __$AppConfigCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {String appName,
+      String packageName,
+      AppVersion version,
+      String buildNumber,
+      String buildSignature,
+      Flavor flavor,
+      String? installerStore,
+      String backendUrl,
+      String websiteUrl});
+
+  @override
+  $AppVersionCopyWith<$Res> get version;
+}
+
+/// @nodoc
+class __$AppConfigCopyWithImpl<$Res> implements _$AppConfigCopyWith<$Res> {
+  __$AppConfigCopyWithImpl(this._self, this._then);
+
+  final _AppConfig _self;
+  final $Res Function(_AppConfig) _then;
 
   /// Create a copy of AppConfig
   /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
-  _$$AppConfigImplCopyWith<_$AppConfigImpl> get copyWith =>
-      __$$AppConfigImplCopyWithImpl<_$AppConfigImpl>(this, _$identity);
-}
-
-abstract class _AppConfig implements AppConfig {
-  const factory _AppConfig({
-    required final String appName,
-    required final String packageName,
-    required final AppVersion version,
-    required final String buildNumber,
-    required final String buildSignature,
-    required final Flavor flavor,
-    required final String? installerStore,
-    required final String backendUrl,
-    required final String websiteUrl,
-  }) = _$AppConfigImpl;
-
-  @override
-  String get appName;
-  @override
-  String get packageName;
-  @override
-  AppVersion get version;
-  @override
-  String get buildNumber;
-  @override
-  String get buildSignature;
-  @override
-  Flavor get flavor;
-  @override
-  String? get installerStore;
-  @override
-  String get backendUrl;
-  @override
-  String get websiteUrl;
+  $Res call({
+    Object? appName = null,
+    Object? packageName = null,
+    Object? version = null,
+    Object? buildNumber = null,
+    Object? buildSignature = null,
+    Object? flavor = null,
+    Object? installerStore = freezed,
+    Object? backendUrl = null,
+    Object? websiteUrl = null,
+  }) {
+    return _then(_AppConfig(
+      appName: null == appName
+          ? _self.appName
+          : appName // ignore: cast_nullable_to_non_nullable
+              as String,
+      packageName: null == packageName
+          ? _self.packageName
+          : packageName // ignore: cast_nullable_to_non_nullable
+              as String,
+      version: null == version
+          ? _self.version
+          : version // ignore: cast_nullable_to_non_nullable
+              as AppVersion,
+      buildNumber: null == buildNumber
+          ? _self.buildNumber
+          : buildNumber // ignore: cast_nullable_to_non_nullable
+              as String,
+      buildSignature: null == buildSignature
+          ? _self.buildSignature
+          : buildSignature // ignore: cast_nullable_to_non_nullable
+              as String,
+      flavor: null == flavor
+          ? _self.flavor
+          : flavor // ignore: cast_nullable_to_non_nullable
+              as Flavor,
+      installerStore: freezed == installerStore
+          ? _self.installerStore
+          : installerStore // ignore: cast_nullable_to_non_nullable
+              as String?,
+      backendUrl: null == backendUrl
+          ? _self.backendUrl
+          : backendUrl // ignore: cast_nullable_to_non_nullable
+              as String,
+      websiteUrl: null == websiteUrl
+          ? _self.websiteUrl
+          : websiteUrl // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
 
   /// Create a copy of AppConfig
   /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$AppConfigImplCopyWith<_$AppConfigImpl> get copyWith =>
-      throw _privateConstructorUsedError;
+  @pragma('vm:prefer-inline')
+  $AppVersionCopyWith<$Res> get version {
+    return $AppVersionCopyWith<$Res>(_self.version, (value) {
+      return _then(_self.copyWith(version: value));
+    });
+  }
 }
+
+// dart format on

--- a/core/model/lib/src/config/app_config.g.dart
+++ b/core/model/lib/src/config/app_config.g.dart
@@ -13,9 +13,8 @@ String _$appConfigHash() => r'f0440cee6ceb982d73b68d935eab7f72da37beb9';
 final appConfigProvider = Provider<AppConfig>.internal(
   appConfig,
   name: r'appConfigProvider',
-  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
-      ? null
-      : _$appConfigHash,
+  debugGetCreateSourceHash:
+      const bool.fromEnvironment('dart.vm.product') ? null : _$appConfigHash,
   dependencies: null,
   allTransitiveDependencies: null,
 );

--- a/core/model/lib/src/config/app_version.dart
+++ b/core/model/lib/src/config/app_version.dart
@@ -6,7 +6,7 @@ part 'app_version.freezed.dart';
 ///
 /// {@category Model}
 @freezed
-class AppVersion with _$AppVersion {
+abstract class AppVersion with _$AppVersion {
   const factory AppVersion({
     required int major,
     required int minor,

--- a/core/model/lib/src/config/app_version.freezed.dart
+++ b/core/model/lib/src/config/app_version.freezed.dart
@@ -1,3 +1,4 @@
+// dart format width=80
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint
@@ -9,149 +10,27 @@ part of 'app_version.dart';
 // FreezedGenerator
 // **************************************************************************
 
+// dart format off
 T _$identity<T>(T value) => value;
-
-final _privateConstructorUsedError = UnsupportedError(
-  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
-);
 
 /// @nodoc
 mixin _$AppVersion {
-  int get major => throw _privateConstructorUsedError;
-  int get minor => throw _privateConstructorUsedError;
-  int get patch => throw _privateConstructorUsedError;
+  int get major;
+  int get minor;
+  int get patch;
 
   /// Create a copy of AppVersion
   /// with the given fields replaced by the non-null parameter values.
   @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
   $AppVersionCopyWith<AppVersion> get copyWith =>
-      throw _privateConstructorUsedError;
-}
-
-/// @nodoc
-abstract class $AppVersionCopyWith<$Res> {
-  factory $AppVersionCopyWith(
-    AppVersion value,
-    $Res Function(AppVersion) then,
-  ) = _$AppVersionCopyWithImpl<$Res, AppVersion>;
-  @useResult
-  $Res call({int major, int minor, int patch});
-}
-
-/// @nodoc
-class _$AppVersionCopyWithImpl<$Res, $Val extends AppVersion>
-    implements $AppVersionCopyWith<$Res> {
-  _$AppVersionCopyWithImpl(this._value, this._then);
-
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
-
-  /// Create a copy of AppVersion
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? major = null,
-    Object? minor = null,
-    Object? patch = null,
-  }) {
-    return _then(
-      _value.copyWith(
-            major: null == major
-                ? _value.major
-                : major // ignore: cast_nullable_to_non_nullable
-                      as int,
-            minor: null == minor
-                ? _value.minor
-                : minor // ignore: cast_nullable_to_non_nullable
-                      as int,
-            patch: null == patch
-                ? _value.patch
-                : patch // ignore: cast_nullable_to_non_nullable
-                      as int,
-          )
-          as $Val,
-    );
-  }
-}
-
-/// @nodoc
-abstract class _$$AppVersionImplCopyWith<$Res>
-    implements $AppVersionCopyWith<$Res> {
-  factory _$$AppVersionImplCopyWith(
-    _$AppVersionImpl value,
-    $Res Function(_$AppVersionImpl) then,
-  ) = __$$AppVersionImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call({int major, int minor, int patch});
-}
-
-/// @nodoc
-class __$$AppVersionImplCopyWithImpl<$Res>
-    extends _$AppVersionCopyWithImpl<$Res, _$AppVersionImpl>
-    implements _$$AppVersionImplCopyWith<$Res> {
-  __$$AppVersionImplCopyWithImpl(
-    _$AppVersionImpl _value,
-    $Res Function(_$AppVersionImpl) _then,
-  ) : super(_value, _then);
-
-  /// Create a copy of AppVersion
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? major = null,
-    Object? minor = null,
-    Object? patch = null,
-  }) {
-    return _then(
-      _$AppVersionImpl(
-        major: null == major
-            ? _value.major
-            : major // ignore: cast_nullable_to_non_nullable
-                  as int,
-        minor: null == minor
-            ? _value.minor
-            : minor // ignore: cast_nullable_to_non_nullable
-                  as int,
-        patch: null == patch
-            ? _value.patch
-            : patch // ignore: cast_nullable_to_non_nullable
-                  as int,
-      ),
-    );
-  }
-}
-
-/// @nodoc
-
-class _$AppVersionImpl extends _AppVersion {
-  const _$AppVersionImpl({
-    required this.major,
-    required this.minor,
-    required this.patch,
-  }) : super._();
-
-  @override
-  final int major;
-  @override
-  final int minor;
-  @override
-  final int patch;
-
-  @override
-  String toString() {
-    return 'AppVersion(major: $major, minor: $minor, patch: $patch)';
-  }
+      _$AppVersionCopyWithImpl<AppVersion>(this as AppVersion, _$identity);
 
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$AppVersionImpl &&
+            other is AppVersion &&
             (identical(other.major, major) || other.major == major) &&
             (identical(other.minor, minor) || other.minor == minor) &&
             (identical(other.patch, patch) || other.patch == patch));
@@ -160,34 +39,137 @@ class _$AppVersionImpl extends _AppVersion {
   @override
   int get hashCode => Object.hash(runtimeType, major, minor, patch);
 
+  @override
+  String toString() {
+    return 'AppVersion(major: $major, minor: $minor, patch: $patch)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $AppVersionCopyWith<$Res> {
+  factory $AppVersionCopyWith(
+          AppVersion value, $Res Function(AppVersion) _then) =
+      _$AppVersionCopyWithImpl;
+  @useResult
+  $Res call({int major, int minor, int patch});
+}
+
+/// @nodoc
+class _$AppVersionCopyWithImpl<$Res> implements $AppVersionCopyWith<$Res> {
+  _$AppVersionCopyWithImpl(this._self, this._then);
+
+  final AppVersion _self;
+  final $Res Function(AppVersion) _then;
+
   /// Create a copy of AppVersion
   /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? major = null,
+    Object? minor = null,
+    Object? patch = null,
+  }) {
+    return _then(_self.copyWith(
+      major: null == major
+          ? _self.major
+          : major // ignore: cast_nullable_to_non_nullable
+              as int,
+      minor: null == minor
+          ? _self.minor
+          : minor // ignore: cast_nullable_to_non_nullable
+              as int,
+      patch: null == patch
+          ? _self.patch
+          : patch // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _AppVersion extends AppVersion {
+  const _AppVersion(
+      {required this.major, required this.minor, required this.patch})
+      : super._();
+
+  @override
+  final int major;
+  @override
+  final int minor;
+  @override
+  final int patch;
+
+  /// Create a copy of AppVersion
+  /// with the given fields replaced by the non-null parameter values.
+  @override
   @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$AppVersionCopyWith<_AppVersion> get copyWith =>
+      __$AppVersionCopyWithImpl<_AppVersion>(this, _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _AppVersion &&
+            (identical(other.major, major) || other.major == major) &&
+            (identical(other.minor, minor) || other.minor == minor) &&
+            (identical(other.patch, patch) || other.patch == patch));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, major, minor, patch);
+
+  @override
+  String toString() {
+    return 'AppVersion(major: $major, minor: $minor, patch: $patch)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$AppVersionCopyWith<$Res>
+    implements $AppVersionCopyWith<$Res> {
+  factory _$AppVersionCopyWith(
+          _AppVersion value, $Res Function(_AppVersion) _then) =
+      __$AppVersionCopyWithImpl;
+  @override
+  @useResult
+  $Res call({int major, int minor, int patch});
+}
+
+/// @nodoc
+class __$AppVersionCopyWithImpl<$Res> implements _$AppVersionCopyWith<$Res> {
+  __$AppVersionCopyWithImpl(this._self, this._then);
+
+  final _AppVersion _self;
+  final $Res Function(_AppVersion) _then;
+
+  /// Create a copy of AppVersion
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
-  _$$AppVersionImplCopyWith<_$AppVersionImpl> get copyWith =>
-      __$$AppVersionImplCopyWithImpl<_$AppVersionImpl>(this, _$identity);
+  $Res call({
+    Object? major = null,
+    Object? minor = null,
+    Object? patch = null,
+  }) {
+    return _then(_AppVersion(
+      major: null == major
+          ? _self.major
+          : major // ignore: cast_nullable_to_non_nullable
+              as int,
+      minor: null == minor
+          ? _self.minor
+          : minor // ignore: cast_nullable_to_non_nullable
+              as int,
+      patch: null == patch
+          ? _self.patch
+          : patch // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
+  }
 }
 
-abstract class _AppVersion extends AppVersion {
-  const factory _AppVersion({
-    required final int major,
-    required final int minor,
-    required final int patch,
-  }) = _$AppVersionImpl;
-  const _AppVersion._() : super._();
-
-  @override
-  int get major;
-  @override
-  int get minor;
-  @override
-  int get patch;
-
-  /// Create a copy of AppVersion
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$AppVersionImplCopyWith<_$AppVersionImpl> get copyWith =>
-      throw _privateConstructorUsedError;
-}
+// dart format on

--- a/core/model/lib/src/config/remote_config.dart
+++ b/core/model/lib/src/config/remote_config.dart
@@ -15,7 +15,7 @@ RemoteConfig remoteConfig(Ref ref) {
 ///
 /// {@category Model}
 @freezed
-class RemoteConfig with _$RemoteConfig {
+abstract class RemoteConfig with _$RemoteConfig {
   const factory RemoteConfig({required UpdateVersion updateVersion}) =
       _RemoteConfig;
 }

--- a/core/model/lib/src/config/remote_config.freezed.dart
+++ b/core/model/lib/src/config/remote_config.freezed.dart
@@ -1,3 +1,4 @@
+// dart format width=80
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint
@@ -9,130 +10,26 @@ part of 'remote_config.dart';
 // FreezedGenerator
 // **************************************************************************
 
+// dart format off
 T _$identity<T>(T value) => value;
-
-final _privateConstructorUsedError = UnsupportedError(
-  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
-);
 
 /// @nodoc
 mixin _$RemoteConfig {
-  UpdateVersion get updateVersion => throw _privateConstructorUsedError;
+  UpdateVersion get updateVersion;
 
   /// Create a copy of RemoteConfig
   /// with the given fields replaced by the non-null parameter values.
   @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
   $RemoteConfigCopyWith<RemoteConfig> get copyWith =>
-      throw _privateConstructorUsedError;
-}
-
-/// @nodoc
-abstract class $RemoteConfigCopyWith<$Res> {
-  factory $RemoteConfigCopyWith(
-    RemoteConfig value,
-    $Res Function(RemoteConfig) then,
-  ) = _$RemoteConfigCopyWithImpl<$Res, RemoteConfig>;
-  @useResult
-  $Res call({UpdateVersion updateVersion});
-
-  $UpdateVersionCopyWith<$Res> get updateVersion;
-}
-
-/// @nodoc
-class _$RemoteConfigCopyWithImpl<$Res, $Val extends RemoteConfig>
-    implements $RemoteConfigCopyWith<$Res> {
-  _$RemoteConfigCopyWithImpl(this._value, this._then);
-
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
-
-  /// Create a copy of RemoteConfig
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({Object? updateVersion = null}) {
-    return _then(
-      _value.copyWith(
-            updateVersion: null == updateVersion
-                ? _value.updateVersion
-                : updateVersion // ignore: cast_nullable_to_non_nullable
-                      as UpdateVersion,
-          )
-          as $Val,
-    );
-  }
-
-  /// Create a copy of RemoteConfig
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $UpdateVersionCopyWith<$Res> get updateVersion {
-    return $UpdateVersionCopyWith<$Res>(_value.updateVersion, (value) {
-      return _then(_value.copyWith(updateVersion: value) as $Val);
-    });
-  }
-}
-
-/// @nodoc
-abstract class _$$RemoteConfigImplCopyWith<$Res>
-    implements $RemoteConfigCopyWith<$Res> {
-  factory _$$RemoteConfigImplCopyWith(
-    _$RemoteConfigImpl value,
-    $Res Function(_$RemoteConfigImpl) then,
-  ) = __$$RemoteConfigImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call({UpdateVersion updateVersion});
-
-  @override
-  $UpdateVersionCopyWith<$Res> get updateVersion;
-}
-
-/// @nodoc
-class __$$RemoteConfigImplCopyWithImpl<$Res>
-    extends _$RemoteConfigCopyWithImpl<$Res, _$RemoteConfigImpl>
-    implements _$$RemoteConfigImplCopyWith<$Res> {
-  __$$RemoteConfigImplCopyWithImpl(
-    _$RemoteConfigImpl _value,
-    $Res Function(_$RemoteConfigImpl) _then,
-  ) : super(_value, _then);
-
-  /// Create a copy of RemoteConfig
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({Object? updateVersion = null}) {
-    return _then(
-      _$RemoteConfigImpl(
-        updateVersion: null == updateVersion
-            ? _value.updateVersion
-            : updateVersion // ignore: cast_nullable_to_non_nullable
-                  as UpdateVersion,
-      ),
-    );
-  }
-}
-
-/// @nodoc
-
-class _$RemoteConfigImpl implements _RemoteConfig {
-  const _$RemoteConfigImpl({required this.updateVersion});
-
-  @override
-  final UpdateVersion updateVersion;
-
-  @override
-  String toString() {
-    return 'RemoteConfig(updateVersion: $updateVersion)';
-  }
+      _$RemoteConfigCopyWithImpl<RemoteConfig>(
+          this as RemoteConfig, _$identity);
 
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$RemoteConfigImpl &&
+            other is RemoteConfig &&
             (identical(other.updateVersion, updateVersion) ||
                 other.updateVersion == updateVersion));
   }
@@ -140,26 +37,136 @@ class _$RemoteConfigImpl implements _RemoteConfig {
   @override
   int get hashCode => Object.hash(runtimeType, updateVersion);
 
+  @override
+  String toString() {
+    return 'RemoteConfig(updateVersion: $updateVersion)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $RemoteConfigCopyWith<$Res> {
+  factory $RemoteConfigCopyWith(
+          RemoteConfig value, $Res Function(RemoteConfig) _then) =
+      _$RemoteConfigCopyWithImpl;
+  @useResult
+  $Res call({UpdateVersion updateVersion});
+
+  $UpdateVersionCopyWith<$Res> get updateVersion;
+}
+
+/// @nodoc
+class _$RemoteConfigCopyWithImpl<$Res> implements $RemoteConfigCopyWith<$Res> {
+  _$RemoteConfigCopyWithImpl(this._self, this._then);
+
+  final RemoteConfig _self;
+  final $Res Function(RemoteConfig) _then;
+
   /// Create a copy of RemoteConfig
   /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? updateVersion = null,
+  }) {
+    return _then(_self.copyWith(
+      updateVersion: null == updateVersion
+          ? _self.updateVersion
+          : updateVersion // ignore: cast_nullable_to_non_nullable
+              as UpdateVersion,
+    ));
+  }
+
+  /// Create a copy of RemoteConfig
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
-  _$$RemoteConfigImplCopyWith<_$RemoteConfigImpl> get copyWith =>
-      __$$RemoteConfigImplCopyWithImpl<_$RemoteConfigImpl>(this, _$identity);
+  $UpdateVersionCopyWith<$Res> get updateVersion {
+    return $UpdateVersionCopyWith<$Res>(_self.updateVersion, (value) {
+      return _then(_self.copyWith(updateVersion: value));
+    });
+  }
 }
 
-abstract class _RemoteConfig implements RemoteConfig {
-  const factory _RemoteConfig({required final UpdateVersion updateVersion}) =
-      _$RemoteConfigImpl;
+/// @nodoc
+
+class _RemoteConfig implements RemoteConfig {
+  const _RemoteConfig({required this.updateVersion});
 
   @override
-  UpdateVersion get updateVersion;
+  final UpdateVersion updateVersion;
 
   /// Create a copy of RemoteConfig
   /// with the given fields replaced by the non-null parameter values.
   @override
   @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$RemoteConfigImplCopyWith<_$RemoteConfigImpl> get copyWith =>
-      throw _privateConstructorUsedError;
+  @pragma('vm:prefer-inline')
+  _$RemoteConfigCopyWith<_RemoteConfig> get copyWith =>
+      __$RemoteConfigCopyWithImpl<_RemoteConfig>(this, _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _RemoteConfig &&
+            (identical(other.updateVersion, updateVersion) ||
+                other.updateVersion == updateVersion));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, updateVersion);
+
+  @override
+  String toString() {
+    return 'RemoteConfig(updateVersion: $updateVersion)';
+  }
 }
+
+/// @nodoc
+abstract mixin class _$RemoteConfigCopyWith<$Res>
+    implements $RemoteConfigCopyWith<$Res> {
+  factory _$RemoteConfigCopyWith(
+          _RemoteConfig value, $Res Function(_RemoteConfig) _then) =
+      __$RemoteConfigCopyWithImpl;
+  @override
+  @useResult
+  $Res call({UpdateVersion updateVersion});
+
+  @override
+  $UpdateVersionCopyWith<$Res> get updateVersion;
+}
+
+/// @nodoc
+class __$RemoteConfigCopyWithImpl<$Res>
+    implements _$RemoteConfigCopyWith<$Res> {
+  __$RemoteConfigCopyWithImpl(this._self, this._then);
+
+  final _RemoteConfig _self;
+  final $Res Function(_RemoteConfig) _then;
+
+  /// Create a copy of RemoteConfig
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? updateVersion = null,
+  }) {
+    return _then(_RemoteConfig(
+      updateVersion: null == updateVersion
+          ? _self.updateVersion
+          : updateVersion // ignore: cast_nullable_to_non_nullable
+              as UpdateVersion,
+    ));
+  }
+
+  /// Create a copy of RemoteConfig
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $UpdateVersionCopyWith<$Res> get updateVersion {
+    return $UpdateVersionCopyWith<$Res>(_self.updateVersion, (value) {
+      return _then(_self.copyWith(updateVersion: value));
+    });
+  }
+}
+
+// dart format on

--- a/core/model/lib/src/config/remote_config.g.dart
+++ b/core/model/lib/src/config/remote_config.g.dart
@@ -13,9 +13,8 @@ String _$remoteConfigHash() => r'ff9193125ebcbb6296a7a1fb948365491e052d6c';
 final remoteConfigProvider = Provider<RemoteConfig>.internal(
   remoteConfig,
   name: r'remoteConfigProvider',
-  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
-      ? null
-      : _$remoteConfigHash,
+  debugGetCreateSourceHash:
+      const bool.fromEnvironment('dart.vm.product') ? null : _$remoteConfigHash,
   dependencies: null,
   allTransitiveDependencies: null,
 );

--- a/core/model/lib/src/config/update_version.dart
+++ b/core/model/lib/src/config/update_version.dart
@@ -7,7 +7,7 @@ part 'update_version.freezed.dart';
 ///
 /// {@category Model}
 @freezed
-abstract class UpdateVersion implements _$UpdateVersion {
+abstract class UpdateVersion with _$UpdateVersion {
   const factory UpdateVersion({
     required AppVersion force,
     required AppVersion optional,

--- a/core/model/lib/src/config/update_version.freezed.dart
+++ b/core/model/lib/src/config/update_version.freezed.dart
@@ -1,3 +1,4 @@
+// dart format width=80
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint
@@ -9,155 +10,27 @@ part of 'update_version.dart';
 // FreezedGenerator
 // **************************************************************************
 
+// dart format off
 T _$identity<T>(T value) => value;
-
-final _privateConstructorUsedError = UnsupportedError(
-  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
-);
 
 /// @nodoc
 mixin _$UpdateVersion {
-  AppVersion get force => throw _privateConstructorUsedError;
-  AppVersion get optional => throw _privateConstructorUsedError;
+  AppVersion get force;
+  AppVersion get optional;
 
   /// Create a copy of UpdateVersion
   /// with the given fields replaced by the non-null parameter values.
   @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
   $UpdateVersionCopyWith<UpdateVersion> get copyWith =>
-      throw _privateConstructorUsedError;
-}
-
-/// @nodoc
-abstract class $UpdateVersionCopyWith<$Res> {
-  factory $UpdateVersionCopyWith(
-    UpdateVersion value,
-    $Res Function(UpdateVersion) then,
-  ) = _$UpdateVersionCopyWithImpl<$Res, UpdateVersion>;
-  @useResult
-  $Res call({AppVersion force, AppVersion optional});
-
-  $AppVersionCopyWith<$Res> get force;
-  $AppVersionCopyWith<$Res> get optional;
-}
-
-/// @nodoc
-class _$UpdateVersionCopyWithImpl<$Res, $Val extends UpdateVersion>
-    implements $UpdateVersionCopyWith<$Res> {
-  _$UpdateVersionCopyWithImpl(this._value, this._then);
-
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
-
-  /// Create a copy of UpdateVersion
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({Object? force = null, Object? optional = null}) {
-    return _then(
-      _value.copyWith(
-            force: null == force
-                ? _value.force
-                : force // ignore: cast_nullable_to_non_nullable
-                      as AppVersion,
-            optional: null == optional
-                ? _value.optional
-                : optional // ignore: cast_nullable_to_non_nullable
-                      as AppVersion,
-          )
-          as $Val,
-    );
-  }
-
-  /// Create a copy of UpdateVersion
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $AppVersionCopyWith<$Res> get force {
-    return $AppVersionCopyWith<$Res>(_value.force, (value) {
-      return _then(_value.copyWith(force: value) as $Val);
-    });
-  }
-
-  /// Create a copy of UpdateVersion
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $AppVersionCopyWith<$Res> get optional {
-    return $AppVersionCopyWith<$Res>(_value.optional, (value) {
-      return _then(_value.copyWith(optional: value) as $Val);
-    });
-  }
-}
-
-/// @nodoc
-abstract class _$$UpdateVersionImplCopyWith<$Res>
-    implements $UpdateVersionCopyWith<$Res> {
-  factory _$$UpdateVersionImplCopyWith(
-    _$UpdateVersionImpl value,
-    $Res Function(_$UpdateVersionImpl) then,
-  ) = __$$UpdateVersionImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call({AppVersion force, AppVersion optional});
-
-  @override
-  $AppVersionCopyWith<$Res> get force;
-  @override
-  $AppVersionCopyWith<$Res> get optional;
-}
-
-/// @nodoc
-class __$$UpdateVersionImplCopyWithImpl<$Res>
-    extends _$UpdateVersionCopyWithImpl<$Res, _$UpdateVersionImpl>
-    implements _$$UpdateVersionImplCopyWith<$Res> {
-  __$$UpdateVersionImplCopyWithImpl(
-    _$UpdateVersionImpl _value,
-    $Res Function(_$UpdateVersionImpl) _then,
-  ) : super(_value, _then);
-
-  /// Create a copy of UpdateVersion
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({Object? force = null, Object? optional = null}) {
-    return _then(
-      _$UpdateVersionImpl(
-        force: null == force
-            ? _value.force
-            : force // ignore: cast_nullable_to_non_nullable
-                  as AppVersion,
-        optional: null == optional
-            ? _value.optional
-            : optional // ignore: cast_nullable_to_non_nullable
-                  as AppVersion,
-      ),
-    );
-  }
-}
-
-/// @nodoc
-
-class _$UpdateVersionImpl extends _UpdateVersion {
-  const _$UpdateVersionImpl({required this.force, required this.optional})
-    : super._();
-
-  @override
-  final AppVersion force;
-  @override
-  final AppVersion optional;
-
-  @override
-  String toString() {
-    return 'UpdateVersion(force: $force, optional: $optional)';
-  }
+      _$UpdateVersionCopyWithImpl<UpdateVersion>(
+          this as UpdateVersion, _$identity);
 
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$UpdateVersionImpl &&
+            other is UpdateVersion &&
             (identical(other.force, force) || other.force == force) &&
             (identical(other.optional, optional) ||
                 other.optional == optional));
@@ -166,31 +39,174 @@ class _$UpdateVersionImpl extends _UpdateVersion {
   @override
   int get hashCode => Object.hash(runtimeType, force, optional);
 
+  @override
+  String toString() {
+    return 'UpdateVersion(force: $force, optional: $optional)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $UpdateVersionCopyWith<$Res> {
+  factory $UpdateVersionCopyWith(
+          UpdateVersion value, $Res Function(UpdateVersion) _then) =
+      _$UpdateVersionCopyWithImpl;
+  @useResult
+  $Res call({AppVersion force, AppVersion optional});
+
+  $AppVersionCopyWith<$Res> get force;
+  $AppVersionCopyWith<$Res> get optional;
+}
+
+/// @nodoc
+class _$UpdateVersionCopyWithImpl<$Res>
+    implements $UpdateVersionCopyWith<$Res> {
+  _$UpdateVersionCopyWithImpl(this._self, this._then);
+
+  final UpdateVersion _self;
+  final $Res Function(UpdateVersion) _then;
+
   /// Create a copy of UpdateVersion
   /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? force = null,
+    Object? optional = null,
+  }) {
+    return _then(_self.copyWith(
+      force: null == force
+          ? _self.force
+          : force // ignore: cast_nullable_to_non_nullable
+              as AppVersion,
+      optional: null == optional
+          ? _self.optional
+          : optional // ignore: cast_nullable_to_non_nullable
+              as AppVersion,
+    ));
+  }
+
+  /// Create a copy of UpdateVersion
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
-  _$$UpdateVersionImplCopyWith<_$UpdateVersionImpl> get copyWith =>
-      __$$UpdateVersionImplCopyWithImpl<_$UpdateVersionImpl>(this, _$identity);
+  $AppVersionCopyWith<$Res> get force {
+    return $AppVersionCopyWith<$Res>(_self.force, (value) {
+      return _then(_self.copyWith(force: value));
+    });
+  }
+
+  /// Create a copy of UpdateVersion
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $AppVersionCopyWith<$Res> get optional {
+    return $AppVersionCopyWith<$Res>(_self.optional, (value) {
+      return _then(_self.copyWith(optional: value));
+    });
+  }
 }
 
-abstract class _UpdateVersion extends UpdateVersion {
-  const factory _UpdateVersion({
-    required final AppVersion force,
-    required final AppVersion optional,
-  }) = _$UpdateVersionImpl;
-  const _UpdateVersion._() : super._();
+/// @nodoc
+
+class _UpdateVersion extends UpdateVersion {
+  const _UpdateVersion({required this.force, required this.optional})
+      : super._();
 
   @override
-  AppVersion get force;
+  final AppVersion force;
   @override
-  AppVersion get optional;
+  final AppVersion optional;
 
   /// Create a copy of UpdateVersion
   /// with the given fields replaced by the non-null parameter values.
   @override
   @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$UpdateVersionImplCopyWith<_$UpdateVersionImpl> get copyWith =>
-      throw _privateConstructorUsedError;
+  @pragma('vm:prefer-inline')
+  _$UpdateVersionCopyWith<_UpdateVersion> get copyWith =>
+      __$UpdateVersionCopyWithImpl<_UpdateVersion>(this, _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _UpdateVersion &&
+            (identical(other.force, force) || other.force == force) &&
+            (identical(other.optional, optional) ||
+                other.optional == optional));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, force, optional);
+
+  @override
+  String toString() {
+    return 'UpdateVersion(force: $force, optional: $optional)';
+  }
 }
+
+/// @nodoc
+abstract mixin class _$UpdateVersionCopyWith<$Res>
+    implements $UpdateVersionCopyWith<$Res> {
+  factory _$UpdateVersionCopyWith(
+          _UpdateVersion value, $Res Function(_UpdateVersion) _then) =
+      __$UpdateVersionCopyWithImpl;
+  @override
+  @useResult
+  $Res call({AppVersion force, AppVersion optional});
+
+  @override
+  $AppVersionCopyWith<$Res> get force;
+  @override
+  $AppVersionCopyWith<$Res> get optional;
+}
+
+/// @nodoc
+class __$UpdateVersionCopyWithImpl<$Res>
+    implements _$UpdateVersionCopyWith<$Res> {
+  __$UpdateVersionCopyWithImpl(this._self, this._then);
+
+  final _UpdateVersion _self;
+  final $Res Function(_UpdateVersion) _then;
+
+  /// Create a copy of UpdateVersion
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? force = null,
+    Object? optional = null,
+  }) {
+    return _then(_UpdateVersion(
+      force: null == force
+          ? _self.force
+          : force // ignore: cast_nullable_to_non_nullable
+              as AppVersion,
+      optional: null == optional
+          ? _self.optional
+          : optional // ignore: cast_nullable_to_non_nullable
+              as AppVersion,
+    ));
+  }
+
+  /// Create a copy of UpdateVersion
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $AppVersionCopyWith<$Res> get force {
+    return $AppVersionCopyWith<$Res>(_self.force, (value) {
+      return _then(_self.copyWith(force: value));
+    });
+  }
+
+  /// Create a copy of UpdateVersion
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $AppVersionCopyWith<$Res> get optional {
+    return $AppVersionCopyWith<$Res>(_self.optional, (value) {
+      return _then(_self.copyWith(optional: value));
+    });
+  }
+}
+
+// dart format on

--- a/core/model/lib/src/feed/feed.dart
+++ b/core/model/lib/src/feed/feed.dart
@@ -8,7 +8,7 @@ typedef FeedId = String;
 ///
 /// {@category Model}
 @freezed
-class Feed with _$Feed {
+abstract class Feed with _$Feed {
   const factory Feed({
     required FeedId id,
     required String name,

--- a/core/model/lib/src/feed/feed.freezed.dart
+++ b/core/model/lib/src/feed/feed.freezed.dart
@@ -1,3 +1,4 @@
+// dart format width=80
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint
@@ -9,157 +10,28 @@ part of 'feed.dart';
 // FreezedGenerator
 // **************************************************************************
 
+// dart format off
 T _$identity<T>(T value) => value;
-
-final _privateConstructorUsedError = UnsupportedError(
-  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
-);
 
 /// @nodoc
 mixin _$Feed {
-  String get id => throw _privateConstructorUsedError;
-  String get name => throw _privateConstructorUsedError;
-  String get description => throw _privateConstructorUsedError;
-  String get content => throw _privateConstructorUsedError;
+  FeedId get id;
+  String get name;
+  String get description;
+  String get content;
 
   /// Create a copy of Feed
   /// with the given fields replaced by the non-null parameter values.
   @JsonKey(includeFromJson: false, includeToJson: false)
-  $FeedCopyWith<Feed> get copyWith => throw _privateConstructorUsedError;
-}
-
-/// @nodoc
-abstract class $FeedCopyWith<$Res> {
-  factory $FeedCopyWith(Feed value, $Res Function(Feed) then) =
-      _$FeedCopyWithImpl<$Res, Feed>;
-  @useResult
-  $Res call({String id, String name, String description, String content});
-}
-
-/// @nodoc
-class _$FeedCopyWithImpl<$Res, $Val extends Feed>
-    implements $FeedCopyWith<$Res> {
-  _$FeedCopyWithImpl(this._value, this._then);
-
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
-
-  /// Create a copy of Feed
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? id = null,
-    Object? name = null,
-    Object? description = null,
-    Object? content = null,
-  }) {
-    return _then(
-      _value.copyWith(
-            id: null == id
-                ? _value.id
-                : id // ignore: cast_nullable_to_non_nullable
-                      as String,
-            name: null == name
-                ? _value.name
-                : name // ignore: cast_nullable_to_non_nullable
-                      as String,
-            description: null == description
-                ? _value.description
-                : description // ignore: cast_nullable_to_non_nullable
-                      as String,
-            content: null == content
-                ? _value.content
-                : content // ignore: cast_nullable_to_non_nullable
-                      as String,
-          )
-          as $Val,
-    );
-  }
-}
-
-/// @nodoc
-abstract class _$$FeedImplCopyWith<$Res> implements $FeedCopyWith<$Res> {
-  factory _$$FeedImplCopyWith(
-    _$FeedImpl value,
-    $Res Function(_$FeedImpl) then,
-  ) = __$$FeedImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call({String id, String name, String description, String content});
-}
-
-/// @nodoc
-class __$$FeedImplCopyWithImpl<$Res>
-    extends _$FeedCopyWithImpl<$Res, _$FeedImpl>
-    implements _$$FeedImplCopyWith<$Res> {
-  __$$FeedImplCopyWithImpl(_$FeedImpl _value, $Res Function(_$FeedImpl) _then)
-    : super(_value, _then);
-
-  /// Create a copy of Feed
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? id = null,
-    Object? name = null,
-    Object? description = null,
-    Object? content = null,
-  }) {
-    return _then(
-      _$FeedImpl(
-        id: null == id
-            ? _value.id
-            : id // ignore: cast_nullable_to_non_nullable
-                  as String,
-        name: null == name
-            ? _value.name
-            : name // ignore: cast_nullable_to_non_nullable
-                  as String,
-        description: null == description
-            ? _value.description
-            : description // ignore: cast_nullable_to_non_nullable
-                  as String,
-        content: null == content
-            ? _value.content
-            : content // ignore: cast_nullable_to_non_nullable
-                  as String,
-      ),
-    );
-  }
-}
-
-/// @nodoc
-
-class _$FeedImpl implements _Feed {
-  const _$FeedImpl({
-    required this.id,
-    required this.name,
-    required this.description,
-    required this.content,
-  });
-
-  @override
-  final String id;
-  @override
-  final String name;
-  @override
-  final String description;
-  @override
-  final String content;
-
-  @override
-  String toString() {
-    return 'Feed(id: $id, name: $name, description: $description, content: $content)';
-  }
+  $FeedCopyWith<Feed> get copyWith =>
+      _$FeedCopyWithImpl<Feed>(this as Feed, _$identity);
 
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$FeedImpl &&
+            other is Feed &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.name, name) || other.name == name) &&
             (identical(other.description, description) ||
@@ -170,36 +42,150 @@ class _$FeedImpl implements _Feed {
   @override
   int get hashCode => Object.hash(runtimeType, id, name, description, content);
 
+  @override
+  String toString() {
+    return 'Feed(id: $id, name: $name, description: $description, content: $content)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $FeedCopyWith<$Res> {
+  factory $FeedCopyWith(Feed value, $Res Function(Feed) _then) =
+      _$FeedCopyWithImpl;
+  @useResult
+  $Res call({FeedId id, String name, String description, String content});
+}
+
+/// @nodoc
+class _$FeedCopyWithImpl<$Res> implements $FeedCopyWith<$Res> {
+  _$FeedCopyWithImpl(this._self, this._then);
+
+  final Feed _self;
+  final $Res Function(Feed) _then;
+
   /// Create a copy of Feed
   /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? name = null,
+    Object? description = null,
+    Object? content = null,
+  }) {
+    return _then(_self.copyWith(
+      id: null == id
+          ? _self.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as FeedId,
+      name: null == name
+          ? _self.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+      description: null == description
+          ? _self.description
+          : description // ignore: cast_nullable_to_non_nullable
+              as String,
+      content: null == content
+          ? _self.content
+          : content // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _Feed implements Feed {
+  const _Feed(
+      {required this.id,
+      required this.name,
+      required this.description,
+      required this.content});
+
+  @override
+  final FeedId id;
+  @override
+  final String name;
+  @override
+  final String description;
+  @override
+  final String content;
+
+  /// Create a copy of Feed
+  /// with the given fields replaced by the non-null parameter values.
+  @override
   @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$FeedCopyWith<_Feed> get copyWith =>
+      __$FeedCopyWithImpl<_Feed>(this, _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _Feed &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.name, name) || other.name == name) &&
+            (identical(other.description, description) ||
+                other.description == description) &&
+            (identical(other.content, content) || other.content == content));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, id, name, description, content);
+
+  @override
+  String toString() {
+    return 'Feed(id: $id, name: $name, description: $description, content: $content)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$FeedCopyWith<$Res> implements $FeedCopyWith<$Res> {
+  factory _$FeedCopyWith(_Feed value, $Res Function(_Feed) _then) =
+      __$FeedCopyWithImpl;
+  @override
+  @useResult
+  $Res call({FeedId id, String name, String description, String content});
+}
+
+/// @nodoc
+class __$FeedCopyWithImpl<$Res> implements _$FeedCopyWith<$Res> {
+  __$FeedCopyWithImpl(this._self, this._then);
+
+  final _Feed _self;
+  final $Res Function(_Feed) _then;
+
+  /// Create a copy of Feed
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
-  _$$FeedImplCopyWith<_$FeedImpl> get copyWith =>
-      __$$FeedImplCopyWithImpl<_$FeedImpl>(this, _$identity);
+  $Res call({
+    Object? id = null,
+    Object? name = null,
+    Object? description = null,
+    Object? content = null,
+  }) {
+    return _then(_Feed(
+      id: null == id
+          ? _self.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as FeedId,
+      name: null == name
+          ? _self.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+      description: null == description
+          ? _self.description
+          : description // ignore: cast_nullable_to_non_nullable
+              as String,
+      content: null == content
+          ? _self.content
+          : content // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
 }
 
-abstract class _Feed implements Feed {
-  const factory _Feed({
-    required final String id,
-    required final String name,
-    required final String description,
-    required final String content,
-  }) = _$FeedImpl;
-
-  @override
-  String get id;
-  @override
-  String get name;
-  @override
-  String get description;
-  @override
-  String get content;
-
-  /// Create a copy of Feed
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$FeedImplCopyWith<_$FeedImpl> get copyWith =>
-      throw _privateConstructorUsedError;
-}
+// dart format on

--- a/core/model/lib/src/feed/news_feed.dart
+++ b/core/model/lib/src/feed/news_feed.dart
@@ -8,7 +8,7 @@ typedef NewsFeedSlug = String;
 ///
 /// {@category Model}
 @freezed
-class NewsFeed with _$NewsFeed {
+abstract class NewsFeed with _$NewsFeed {
   const factory NewsFeed({
     required String title,
     required NewsFeedSlug slug,

--- a/core/model/lib/src/feed/news_feed.freezed.dart
+++ b/core/model/lib/src/feed/news_feed.freezed.dart
@@ -1,3 +1,4 @@
+// dart format width=80
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint
@@ -9,187 +10,29 @@ part of 'news_feed.dart';
 // FreezedGenerator
 // **************************************************************************
 
+// dart format off
 T _$identity<T>(T value) => value;
-
-final _privateConstructorUsedError = UnsupportedError(
-  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
-);
 
 /// @nodoc
 mixin _$NewsFeed {
-  String get title => throw _privateConstructorUsedError;
-  String get slug => throw _privateConstructorUsedError;
-  DateTime get publishedAt => throw _privateConstructorUsedError;
-  String get excerpt => throw _privateConstructorUsedError;
-  String? get coverImageUrl => throw _privateConstructorUsedError;
+  String get title;
+  NewsFeedSlug get slug;
+  DateTime get publishedAt;
+  String get excerpt;
+  String? get coverImageUrl;
 
   /// Create a copy of NewsFeed
   /// with the given fields replaced by the non-null parameter values.
   @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
   $NewsFeedCopyWith<NewsFeed> get copyWith =>
-      throw _privateConstructorUsedError;
-}
-
-/// @nodoc
-abstract class $NewsFeedCopyWith<$Res> {
-  factory $NewsFeedCopyWith(NewsFeed value, $Res Function(NewsFeed) then) =
-      _$NewsFeedCopyWithImpl<$Res, NewsFeed>;
-  @useResult
-  $Res call({
-    String title,
-    String slug,
-    DateTime publishedAt,
-    String excerpt,
-    String? coverImageUrl,
-  });
-}
-
-/// @nodoc
-class _$NewsFeedCopyWithImpl<$Res, $Val extends NewsFeed>
-    implements $NewsFeedCopyWith<$Res> {
-  _$NewsFeedCopyWithImpl(this._value, this._then);
-
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
-
-  /// Create a copy of NewsFeed
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? title = null,
-    Object? slug = null,
-    Object? publishedAt = null,
-    Object? excerpt = null,
-    Object? coverImageUrl = freezed,
-  }) {
-    return _then(
-      _value.copyWith(
-            title: null == title
-                ? _value.title
-                : title // ignore: cast_nullable_to_non_nullable
-                      as String,
-            slug: null == slug
-                ? _value.slug
-                : slug // ignore: cast_nullable_to_non_nullable
-                      as String,
-            publishedAt: null == publishedAt
-                ? _value.publishedAt
-                : publishedAt // ignore: cast_nullable_to_non_nullable
-                      as DateTime,
-            excerpt: null == excerpt
-                ? _value.excerpt
-                : excerpt // ignore: cast_nullable_to_non_nullable
-                      as String,
-            coverImageUrl: freezed == coverImageUrl
-                ? _value.coverImageUrl
-                : coverImageUrl // ignore: cast_nullable_to_non_nullable
-                      as String?,
-          )
-          as $Val,
-    );
-  }
-}
-
-/// @nodoc
-abstract class _$$NewsFeedImplCopyWith<$Res>
-    implements $NewsFeedCopyWith<$Res> {
-  factory _$$NewsFeedImplCopyWith(
-    _$NewsFeedImpl value,
-    $Res Function(_$NewsFeedImpl) then,
-  ) = __$$NewsFeedImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call({
-    String title,
-    String slug,
-    DateTime publishedAt,
-    String excerpt,
-    String? coverImageUrl,
-  });
-}
-
-/// @nodoc
-class __$$NewsFeedImplCopyWithImpl<$Res>
-    extends _$NewsFeedCopyWithImpl<$Res, _$NewsFeedImpl>
-    implements _$$NewsFeedImplCopyWith<$Res> {
-  __$$NewsFeedImplCopyWithImpl(
-    _$NewsFeedImpl _value,
-    $Res Function(_$NewsFeedImpl) _then,
-  ) : super(_value, _then);
-
-  /// Create a copy of NewsFeed
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? title = null,
-    Object? slug = null,
-    Object? publishedAt = null,
-    Object? excerpt = null,
-    Object? coverImageUrl = freezed,
-  }) {
-    return _then(
-      _$NewsFeedImpl(
-        title: null == title
-            ? _value.title
-            : title // ignore: cast_nullable_to_non_nullable
-                  as String,
-        slug: null == slug
-            ? _value.slug
-            : slug // ignore: cast_nullable_to_non_nullable
-                  as String,
-        publishedAt: null == publishedAt
-            ? _value.publishedAt
-            : publishedAt // ignore: cast_nullable_to_non_nullable
-                  as DateTime,
-        excerpt: null == excerpt
-            ? _value.excerpt
-            : excerpt // ignore: cast_nullable_to_non_nullable
-                  as String,
-        coverImageUrl: freezed == coverImageUrl
-            ? _value.coverImageUrl
-            : coverImageUrl // ignore: cast_nullable_to_non_nullable
-                  as String?,
-      ),
-    );
-  }
-}
-
-/// @nodoc
-
-class _$NewsFeedImpl implements _NewsFeed {
-  const _$NewsFeedImpl({
-    required this.title,
-    required this.slug,
-    required this.publishedAt,
-    required this.excerpt,
-    required this.coverImageUrl,
-  });
-
-  @override
-  final String title;
-  @override
-  final String slug;
-  @override
-  final DateTime publishedAt;
-  @override
-  final String excerpt;
-  @override
-  final String? coverImageUrl;
-
-  @override
-  String toString() {
-    return 'NewsFeed(title: $title, slug: $slug, publishedAt: $publishedAt, excerpt: $excerpt, coverImageUrl: $coverImageUrl)';
-  }
+      _$NewsFeedCopyWithImpl<NewsFeed>(this as NewsFeed, _$identity);
 
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$NewsFeedImpl &&
+            other is NewsFeed &&
             (identical(other.title, title) || other.title == title) &&
             (identical(other.slug, slug) || other.slug == slug) &&
             (identical(other.publishedAt, publishedAt) ||
@@ -201,47 +44,179 @@ class _$NewsFeedImpl implements _NewsFeed {
 
   @override
   int get hashCode => Object.hash(
-    runtimeType,
-    title,
-    slug,
-    publishedAt,
-    excerpt,
-    coverImageUrl,
-  );
+      runtimeType, title, slug, publishedAt, excerpt, coverImageUrl);
+
+  @override
+  String toString() {
+    return 'NewsFeed(title: $title, slug: $slug, publishedAt: $publishedAt, excerpt: $excerpt, coverImageUrl: $coverImageUrl)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $NewsFeedCopyWith<$Res> {
+  factory $NewsFeedCopyWith(NewsFeed value, $Res Function(NewsFeed) _then) =
+      _$NewsFeedCopyWithImpl;
+  @useResult
+  $Res call(
+      {String title,
+      NewsFeedSlug slug,
+      DateTime publishedAt,
+      String excerpt,
+      String? coverImageUrl});
+}
+
+/// @nodoc
+class _$NewsFeedCopyWithImpl<$Res> implements $NewsFeedCopyWith<$Res> {
+  _$NewsFeedCopyWithImpl(this._self, this._then);
+
+  final NewsFeed _self;
+  final $Res Function(NewsFeed) _then;
 
   /// Create a copy of NewsFeed
   /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? title = null,
+    Object? slug = null,
+    Object? publishedAt = null,
+    Object? excerpt = null,
+    Object? coverImageUrl = freezed,
+  }) {
+    return _then(_self.copyWith(
+      title: null == title
+          ? _self.title
+          : title // ignore: cast_nullable_to_non_nullable
+              as String,
+      slug: null == slug
+          ? _self.slug
+          : slug // ignore: cast_nullable_to_non_nullable
+              as NewsFeedSlug,
+      publishedAt: null == publishedAt
+          ? _self.publishedAt
+          : publishedAt // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+      excerpt: null == excerpt
+          ? _self.excerpt
+          : excerpt // ignore: cast_nullable_to_non_nullable
+              as String,
+      coverImageUrl: freezed == coverImageUrl
+          ? _self.coverImageUrl
+          : coverImageUrl // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _NewsFeed implements NewsFeed {
+  const _NewsFeed(
+      {required this.title,
+      required this.slug,
+      required this.publishedAt,
+      required this.excerpt,
+      required this.coverImageUrl});
+
+  @override
+  final String title;
+  @override
+  final NewsFeedSlug slug;
+  @override
+  final DateTime publishedAt;
+  @override
+  final String excerpt;
+  @override
+  final String? coverImageUrl;
+
+  /// Create a copy of NewsFeed
+  /// with the given fields replaced by the non-null parameter values.
+  @override
   @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$NewsFeedCopyWith<_NewsFeed> get copyWith =>
+      __$NewsFeedCopyWithImpl<_NewsFeed>(this, _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _NewsFeed &&
+            (identical(other.title, title) || other.title == title) &&
+            (identical(other.slug, slug) || other.slug == slug) &&
+            (identical(other.publishedAt, publishedAt) ||
+                other.publishedAt == publishedAt) &&
+            (identical(other.excerpt, excerpt) || other.excerpt == excerpt) &&
+            (identical(other.coverImageUrl, coverImageUrl) ||
+                other.coverImageUrl == coverImageUrl));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      runtimeType, title, slug, publishedAt, excerpt, coverImageUrl);
+
+  @override
+  String toString() {
+    return 'NewsFeed(title: $title, slug: $slug, publishedAt: $publishedAt, excerpt: $excerpt, coverImageUrl: $coverImageUrl)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$NewsFeedCopyWith<$Res>
+    implements $NewsFeedCopyWith<$Res> {
+  factory _$NewsFeedCopyWith(_NewsFeed value, $Res Function(_NewsFeed) _then) =
+      __$NewsFeedCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {String title,
+      NewsFeedSlug slug,
+      DateTime publishedAt,
+      String excerpt,
+      String? coverImageUrl});
+}
+
+/// @nodoc
+class __$NewsFeedCopyWithImpl<$Res> implements _$NewsFeedCopyWith<$Res> {
+  __$NewsFeedCopyWithImpl(this._self, this._then);
+
+  final _NewsFeed _self;
+  final $Res Function(_NewsFeed) _then;
+
+  /// Create a copy of NewsFeed
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
-  _$$NewsFeedImplCopyWith<_$NewsFeedImpl> get copyWith =>
-      __$$NewsFeedImplCopyWithImpl<_$NewsFeedImpl>(this, _$identity);
+  $Res call({
+    Object? title = null,
+    Object? slug = null,
+    Object? publishedAt = null,
+    Object? excerpt = null,
+    Object? coverImageUrl = freezed,
+  }) {
+    return _then(_NewsFeed(
+      title: null == title
+          ? _self.title
+          : title // ignore: cast_nullable_to_non_nullable
+              as String,
+      slug: null == slug
+          ? _self.slug
+          : slug // ignore: cast_nullable_to_non_nullable
+              as NewsFeedSlug,
+      publishedAt: null == publishedAt
+          ? _self.publishedAt
+          : publishedAt // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+      excerpt: null == excerpt
+          ? _self.excerpt
+          : excerpt // ignore: cast_nullable_to_non_nullable
+              as String,
+      coverImageUrl: freezed == coverImageUrl
+          ? _self.coverImageUrl
+          : coverImageUrl // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
+  }
 }
 
-abstract class _NewsFeed implements NewsFeed {
-  const factory _NewsFeed({
-    required final String title,
-    required final String slug,
-    required final DateTime publishedAt,
-    required final String excerpt,
-    required final String? coverImageUrl,
-  }) = _$NewsFeedImpl;
-
-  @override
-  String get title;
-  @override
-  String get slug;
-  @override
-  DateTime get publishedAt;
-  @override
-  String get excerpt;
-  @override
-  String? get coverImageUrl;
-
-  /// Create a copy of NewsFeed
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$NewsFeedImplCopyWith<_$NewsFeedImpl> get copyWith =>
-      throw _privateConstructorUsedError;
-}
+// dart format on

--- a/core/model/lib/src/quest/quest.dart
+++ b/core/model/lib/src/quest/quest.dart
@@ -9,7 +9,7 @@ typedef QuestId = String;
 ///
 /// {@category Model}
 @freezed
-class Quest with _$Quest {
+abstract class Quest with _$Quest {
   const factory Quest({
     required QuestId id,
     required String title,

--- a/core/model/lib/src/quest/quest.freezed.dart
+++ b/core/model/lib/src/quest/quest.freezed.dart
@@ -1,3 +1,4 @@
+// dart format width=80
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint
@@ -9,57 +10,80 @@ part of 'quest.dart';
 // FreezedGenerator
 // **************************************************************************
 
+// dart format off
 T _$identity<T>(T value) => value;
-
-final _privateConstructorUsedError = UnsupportedError(
-  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
-);
 
 /// @nodoc
 mixin _$Quest {
-  String get id => throw _privateConstructorUsedError;
-  String get title => throw _privateConstructorUsedError;
-  String get description => throw _privateConstructorUsedError;
-  DateTime? get begunAt => throw _privateConstructorUsedError;
-  DateTime? get endedAt => throw _privateConstructorUsedError;
-  String? get categoryId => throw _privateConstructorUsedError;
-  QuestStatus get status => throw _privateConstructorUsedError;
-  String? get coverImageUrl => throw _privateConstructorUsedError;
-  String get note => throw _privateConstructorUsedError;
+  QuestId get id;
+  String get title;
+  String get description;
+  DateTime? get begunAt;
+  DateTime? get endedAt;
+  String? get categoryId;
+  QuestStatus get status;
+  String? get coverImageUrl;
+  String get note;
 
   /// Create a copy of Quest
   /// with the given fields replaced by the non-null parameter values.
   @JsonKey(includeFromJson: false, includeToJson: false)
-  $QuestCopyWith<Quest> get copyWith => throw _privateConstructorUsedError;
+  @pragma('vm:prefer-inline')
+  $QuestCopyWith<Quest> get copyWith =>
+      _$QuestCopyWithImpl<Quest>(this as Quest, _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is Quest &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.title, title) || other.title == title) &&
+            (identical(other.description, description) ||
+                other.description == description) &&
+            (identical(other.begunAt, begunAt) || other.begunAt == begunAt) &&
+            (identical(other.endedAt, endedAt) || other.endedAt == endedAt) &&
+            (identical(other.categoryId, categoryId) ||
+                other.categoryId == categoryId) &&
+            (identical(other.status, status) || other.status == status) &&
+            (identical(other.coverImageUrl, coverImageUrl) ||
+                other.coverImageUrl == coverImageUrl) &&
+            (identical(other.note, note) || other.note == note));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, id, title, description, begunAt,
+      endedAt, categoryId, status, coverImageUrl, note);
+
+  @override
+  String toString() {
+    return 'Quest(id: $id, title: $title, description: $description, begunAt: $begunAt, endedAt: $endedAt, categoryId: $categoryId, status: $status, coverImageUrl: $coverImageUrl, note: $note)';
+  }
 }
 
 /// @nodoc
-abstract class $QuestCopyWith<$Res> {
-  factory $QuestCopyWith(Quest value, $Res Function(Quest) then) =
-      _$QuestCopyWithImpl<$Res, Quest>;
+abstract mixin class $QuestCopyWith<$Res> {
+  factory $QuestCopyWith(Quest value, $Res Function(Quest) _then) =
+      _$QuestCopyWithImpl;
   @useResult
-  $Res call({
-    String id,
-    String title,
-    String description,
-    DateTime? begunAt,
-    DateTime? endedAt,
-    String? categoryId,
-    QuestStatus status,
-    String? coverImageUrl,
-    String note,
-  });
+  $Res call(
+      {QuestId id,
+      String title,
+      String description,
+      DateTime? begunAt,
+      DateTime? endedAt,
+      String? categoryId,
+      QuestStatus status,
+      String? coverImageUrl,
+      String note});
 }
 
 /// @nodoc
-class _$QuestCopyWithImpl<$Res, $Val extends Quest>
-    implements $QuestCopyWith<$Res> {
-  _$QuestCopyWithImpl(this._value, this._then);
+class _$QuestCopyWithImpl<$Res> implements $QuestCopyWith<$Res> {
+  _$QuestCopyWithImpl(this._self, this._then);
 
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
+  final Quest _self;
+  final $Res Function(Quest) _then;
 
   /// Create a copy of Quest
   /// with the given fields replaced by the non-null parameter values.
@@ -76,155 +100,63 @@ class _$QuestCopyWithImpl<$Res, $Val extends Quest>
     Object? coverImageUrl = freezed,
     Object? note = null,
   }) {
-    return _then(
-      _value.copyWith(
-            id: null == id
-                ? _value.id
-                : id // ignore: cast_nullable_to_non_nullable
-                      as String,
-            title: null == title
-                ? _value.title
-                : title // ignore: cast_nullable_to_non_nullable
-                      as String,
-            description: null == description
-                ? _value.description
-                : description // ignore: cast_nullable_to_non_nullable
-                      as String,
-            begunAt: freezed == begunAt
-                ? _value.begunAt
-                : begunAt // ignore: cast_nullable_to_non_nullable
-                      as DateTime?,
-            endedAt: freezed == endedAt
-                ? _value.endedAt
-                : endedAt // ignore: cast_nullable_to_non_nullable
-                      as DateTime?,
-            categoryId: freezed == categoryId
-                ? _value.categoryId
-                : categoryId // ignore: cast_nullable_to_non_nullable
-                      as String?,
-            status: null == status
-                ? _value.status
-                : status // ignore: cast_nullable_to_non_nullable
-                      as QuestStatus,
-            coverImageUrl: freezed == coverImageUrl
-                ? _value.coverImageUrl
-                : coverImageUrl // ignore: cast_nullable_to_non_nullable
-                      as String?,
-            note: null == note
-                ? _value.note
-                : note // ignore: cast_nullable_to_non_nullable
-                      as String,
-          )
-          as $Val,
-    );
-  }
-}
-
-/// @nodoc
-abstract class _$$QuestImplCopyWith<$Res> implements $QuestCopyWith<$Res> {
-  factory _$$QuestImplCopyWith(
-    _$QuestImpl value,
-    $Res Function(_$QuestImpl) then,
-  ) = __$$QuestImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call({
-    String id,
-    String title,
-    String description,
-    DateTime? begunAt,
-    DateTime? endedAt,
-    String? categoryId,
-    QuestStatus status,
-    String? coverImageUrl,
-    String note,
-  });
-}
-
-/// @nodoc
-class __$$QuestImplCopyWithImpl<$Res>
-    extends _$QuestCopyWithImpl<$Res, _$QuestImpl>
-    implements _$$QuestImplCopyWith<$Res> {
-  __$$QuestImplCopyWithImpl(
-    _$QuestImpl _value,
-    $Res Function(_$QuestImpl) _then,
-  ) : super(_value, _then);
-
-  /// Create a copy of Quest
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? id = null,
-    Object? title = null,
-    Object? description = null,
-    Object? begunAt = freezed,
-    Object? endedAt = freezed,
-    Object? categoryId = freezed,
-    Object? status = null,
-    Object? coverImageUrl = freezed,
-    Object? note = null,
-  }) {
-    return _then(
-      _$QuestImpl(
-        id: null == id
-            ? _value.id
-            : id // ignore: cast_nullable_to_non_nullable
-                  as String,
-        title: null == title
-            ? _value.title
-            : title // ignore: cast_nullable_to_non_nullable
-                  as String,
-        description: null == description
-            ? _value.description
-            : description // ignore: cast_nullable_to_non_nullable
-                  as String,
-        begunAt: freezed == begunAt
-            ? _value.begunAt
-            : begunAt // ignore: cast_nullable_to_non_nullable
-                  as DateTime?,
-        endedAt: freezed == endedAt
-            ? _value.endedAt
-            : endedAt // ignore: cast_nullable_to_non_nullable
-                  as DateTime?,
-        categoryId: freezed == categoryId
-            ? _value.categoryId
-            : categoryId // ignore: cast_nullable_to_non_nullable
-                  as String?,
-        status: null == status
-            ? _value.status
-            : status // ignore: cast_nullable_to_non_nullable
-                  as QuestStatus,
-        coverImageUrl: freezed == coverImageUrl
-            ? _value.coverImageUrl
-            : coverImageUrl // ignore: cast_nullable_to_non_nullable
-                  as String?,
-        note: null == note
-            ? _value.note
-            : note // ignore: cast_nullable_to_non_nullable
-                  as String,
-      ),
-    );
+    return _then(_self.copyWith(
+      id: null == id
+          ? _self.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as QuestId,
+      title: null == title
+          ? _self.title
+          : title // ignore: cast_nullable_to_non_nullable
+              as String,
+      description: null == description
+          ? _self.description
+          : description // ignore: cast_nullable_to_non_nullable
+              as String,
+      begunAt: freezed == begunAt
+          ? _self.begunAt
+          : begunAt // ignore: cast_nullable_to_non_nullable
+              as DateTime?,
+      endedAt: freezed == endedAt
+          ? _self.endedAt
+          : endedAt // ignore: cast_nullable_to_non_nullable
+              as DateTime?,
+      categoryId: freezed == categoryId
+          ? _self.categoryId
+          : categoryId // ignore: cast_nullable_to_non_nullable
+              as String?,
+      status: null == status
+          ? _self.status
+          : status // ignore: cast_nullable_to_non_nullable
+              as QuestStatus,
+      coverImageUrl: freezed == coverImageUrl
+          ? _self.coverImageUrl
+          : coverImageUrl // ignore: cast_nullable_to_non_nullable
+              as String?,
+      note: null == note
+          ? _self.note
+          : note // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
   }
 }
 
 /// @nodoc
 
-class _$QuestImpl implements _Quest {
-  const _$QuestImpl({
-    required this.id,
-    required this.title,
-    required this.description,
-    required this.begunAt,
-    required this.endedAt,
-    required this.categoryId,
-    required this.status,
-    required this.coverImageUrl,
-    required this.note,
-  });
+class _Quest implements Quest {
+  const _Quest(
+      {required this.id,
+      required this.title,
+      required this.description,
+      required this.begunAt,
+      required this.endedAt,
+      required this.categoryId,
+      required this.status,
+      required this.coverImageUrl,
+      required this.note});
 
   @override
-  final String id;
+  final QuestId id;
   @override
   final String title;
   @override
@@ -242,16 +174,19 @@ class _$QuestImpl implements _Quest {
   @override
   final String note;
 
+  /// Create a copy of Quest
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  String toString() {
-    return 'Quest(id: $id, title: $title, description: $description, begunAt: $begunAt, endedAt: $endedAt, categoryId: $categoryId, status: $status, coverImageUrl: $coverImageUrl, note: $note)';
-  }
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$QuestCopyWith<_Quest> get copyWith =>
+      __$QuestCopyWithImpl<_Quest>(this, _$identity);
 
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$QuestImpl &&
+            other is _Quest &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.title, title) || other.title == title) &&
             (identical(other.description, description) ||
@@ -267,64 +202,94 @@ class _$QuestImpl implements _Quest {
   }
 
   @override
-  int get hashCode => Object.hash(
-    runtimeType,
-    id,
-    title,
-    description,
-    begunAt,
-    endedAt,
-    categoryId,
-    status,
-    coverImageUrl,
-    note,
-  );
+  int get hashCode => Object.hash(runtimeType, id, title, description, begunAt,
+      endedAt, categoryId, status, coverImageUrl, note);
+
+  @override
+  String toString() {
+    return 'Quest(id: $id, title: $title, description: $description, begunAt: $begunAt, endedAt: $endedAt, categoryId: $categoryId, status: $status, coverImageUrl: $coverImageUrl, note: $note)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$QuestCopyWith<$Res> implements $QuestCopyWith<$Res> {
+  factory _$QuestCopyWith(_Quest value, $Res Function(_Quest) _then) =
+      __$QuestCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {QuestId id,
+      String title,
+      String description,
+      DateTime? begunAt,
+      DateTime? endedAt,
+      String? categoryId,
+      QuestStatus status,
+      String? coverImageUrl,
+      String note});
+}
+
+/// @nodoc
+class __$QuestCopyWithImpl<$Res> implements _$QuestCopyWith<$Res> {
+  __$QuestCopyWithImpl(this._self, this._then);
+
+  final _Quest _self;
+  final $Res Function(_Quest) _then;
 
   /// Create a copy of Quest
   /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
-  _$$QuestImplCopyWith<_$QuestImpl> get copyWith =>
-      __$$QuestImplCopyWithImpl<_$QuestImpl>(this, _$identity);
+  $Res call({
+    Object? id = null,
+    Object? title = null,
+    Object? description = null,
+    Object? begunAt = freezed,
+    Object? endedAt = freezed,
+    Object? categoryId = freezed,
+    Object? status = null,
+    Object? coverImageUrl = freezed,
+    Object? note = null,
+  }) {
+    return _then(_Quest(
+      id: null == id
+          ? _self.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as QuestId,
+      title: null == title
+          ? _self.title
+          : title // ignore: cast_nullable_to_non_nullable
+              as String,
+      description: null == description
+          ? _self.description
+          : description // ignore: cast_nullable_to_non_nullable
+              as String,
+      begunAt: freezed == begunAt
+          ? _self.begunAt
+          : begunAt // ignore: cast_nullable_to_non_nullable
+              as DateTime?,
+      endedAt: freezed == endedAt
+          ? _self.endedAt
+          : endedAt // ignore: cast_nullable_to_non_nullable
+              as DateTime?,
+      categoryId: freezed == categoryId
+          ? _self.categoryId
+          : categoryId // ignore: cast_nullable_to_non_nullable
+              as String?,
+      status: null == status
+          ? _self.status
+          : status // ignore: cast_nullable_to_non_nullable
+              as QuestStatus,
+      coverImageUrl: freezed == coverImageUrl
+          ? _self.coverImageUrl
+          : coverImageUrl // ignore: cast_nullable_to_non_nullable
+              as String?,
+      note: null == note
+          ? _self.note
+          : note // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
 }
 
-abstract class _Quest implements Quest {
-  const factory _Quest({
-    required final String id,
-    required final String title,
-    required final String description,
-    required final DateTime? begunAt,
-    required final DateTime? endedAt,
-    required final String? categoryId,
-    required final QuestStatus status,
-    required final String? coverImageUrl,
-    required final String note,
-  }) = _$QuestImpl;
-
-  @override
-  String get id;
-  @override
-  String get title;
-  @override
-  String get description;
-  @override
-  DateTime? get begunAt;
-  @override
-  DateTime? get endedAt;
-  @override
-  String? get categoryId;
-  @override
-  QuestStatus get status;
-  @override
-  String? get coverImageUrl;
-  @override
-  String get note;
-
-  /// Create a copy of Quest
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$QuestImplCopyWith<_$QuestImpl> get copyWith =>
-      throw _privateConstructorUsedError;
-}
+// dart format on

--- a/core/model/lib/src/quest/quest_count.dart
+++ b/core/model/lib/src/quest/quest_count.dart
@@ -6,7 +6,7 @@ part 'quest_count.freezed.dart';
 ///
 /// {@category Model}
 @freezed
-class QuestCount with _$QuestCount {
+abstract class QuestCount with _$QuestCount {
   const factory QuestCount({
     required int backlog,
     required int ready,

--- a/core/model/lib/src/quest/quest_count.freezed.dart
+++ b/core/model/lib/src/quest/quest_count.freezed.dart
@@ -1,3 +1,4 @@
+// dart format width=80
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint
@@ -9,54 +10,71 @@ part of 'quest_count.dart';
 // FreezedGenerator
 // **************************************************************************
 
+// dart format off
 T _$identity<T>(T value) => value;
-
-final _privateConstructorUsedError = UnsupportedError(
-  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
-);
 
 /// @nodoc
 mixin _$QuestCount {
-  int get backlog => throw _privateConstructorUsedError;
-  int get ready => throw _privateConstructorUsedError;
-  int get inProgress => throw _privateConstructorUsedError;
-  int get suspend => throw _privateConstructorUsedError;
-  int get completed => throw _privateConstructorUsedError;
-  int get abort => throw _privateConstructorUsedError;
+  int get backlog;
+  int get ready;
+  int get inProgress;
+  int get suspend;
+  int get completed;
+  int get abort;
 
   /// Create a copy of QuestCount
   /// with the given fields replaced by the non-null parameter values.
   @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
   $QuestCountCopyWith<QuestCount> get copyWith =>
-      throw _privateConstructorUsedError;
+      _$QuestCountCopyWithImpl<QuestCount>(this as QuestCount, _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is QuestCount &&
+            (identical(other.backlog, backlog) || other.backlog == backlog) &&
+            (identical(other.ready, ready) || other.ready == ready) &&
+            (identical(other.inProgress, inProgress) ||
+                other.inProgress == inProgress) &&
+            (identical(other.suspend, suspend) || other.suspend == suspend) &&
+            (identical(other.completed, completed) ||
+                other.completed == completed) &&
+            (identical(other.abort, abort) || other.abort == abort));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      runtimeType, backlog, ready, inProgress, suspend, completed, abort);
+
+  @override
+  String toString() {
+    return 'QuestCount(backlog: $backlog, ready: $ready, inProgress: $inProgress, suspend: $suspend, completed: $completed, abort: $abort)';
+  }
 }
 
 /// @nodoc
-abstract class $QuestCountCopyWith<$Res> {
+abstract mixin class $QuestCountCopyWith<$Res> {
   factory $QuestCountCopyWith(
-    QuestCount value,
-    $Res Function(QuestCount) then,
-  ) = _$QuestCountCopyWithImpl<$Res, QuestCount>;
+          QuestCount value, $Res Function(QuestCount) _then) =
+      _$QuestCountCopyWithImpl;
   @useResult
-  $Res call({
-    int backlog,
-    int ready,
-    int inProgress,
-    int suspend,
-    int completed,
-    int abort,
-  });
+  $Res call(
+      {int backlog,
+      int ready,
+      int inProgress,
+      int suspend,
+      int completed,
+      int abort});
 }
 
 /// @nodoc
-class _$QuestCountCopyWithImpl<$Res, $Val extends QuestCount>
-    implements $QuestCountCopyWith<$Res> {
-  _$QuestCountCopyWithImpl(this._value, this._then);
+class _$QuestCountCopyWithImpl<$Res> implements $QuestCountCopyWith<$Res> {
+  _$QuestCountCopyWithImpl(this._self, this._then);
 
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
+  final QuestCount _self;
+  final $Res Function(QuestCount) _then;
 
   /// Create a copy of QuestCount
   /// with the given fields replaced by the non-null parameter values.
@@ -70,120 +88,46 @@ class _$QuestCountCopyWithImpl<$Res, $Val extends QuestCount>
     Object? completed = null,
     Object? abort = null,
   }) {
-    return _then(
-      _value.copyWith(
-            backlog: null == backlog
-                ? _value.backlog
-                : backlog // ignore: cast_nullable_to_non_nullable
-                      as int,
-            ready: null == ready
-                ? _value.ready
-                : ready // ignore: cast_nullable_to_non_nullable
-                      as int,
-            inProgress: null == inProgress
-                ? _value.inProgress
-                : inProgress // ignore: cast_nullable_to_non_nullable
-                      as int,
-            suspend: null == suspend
-                ? _value.suspend
-                : suspend // ignore: cast_nullable_to_non_nullable
-                      as int,
-            completed: null == completed
-                ? _value.completed
-                : completed // ignore: cast_nullable_to_non_nullable
-                      as int,
-            abort: null == abort
-                ? _value.abort
-                : abort // ignore: cast_nullable_to_non_nullable
-                      as int,
-          )
-          as $Val,
-    );
-  }
-}
-
-/// @nodoc
-abstract class _$$QuestCountImplCopyWith<$Res>
-    implements $QuestCountCopyWith<$Res> {
-  factory _$$QuestCountImplCopyWith(
-    _$QuestCountImpl value,
-    $Res Function(_$QuestCountImpl) then,
-  ) = __$$QuestCountImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call({
-    int backlog,
-    int ready,
-    int inProgress,
-    int suspend,
-    int completed,
-    int abort,
-  });
-}
-
-/// @nodoc
-class __$$QuestCountImplCopyWithImpl<$Res>
-    extends _$QuestCountCopyWithImpl<$Res, _$QuestCountImpl>
-    implements _$$QuestCountImplCopyWith<$Res> {
-  __$$QuestCountImplCopyWithImpl(
-    _$QuestCountImpl _value,
-    $Res Function(_$QuestCountImpl) _then,
-  ) : super(_value, _then);
-
-  /// Create a copy of QuestCount
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? backlog = null,
-    Object? ready = null,
-    Object? inProgress = null,
-    Object? suspend = null,
-    Object? completed = null,
-    Object? abort = null,
-  }) {
-    return _then(
-      _$QuestCountImpl(
-        backlog: null == backlog
-            ? _value.backlog
-            : backlog // ignore: cast_nullable_to_non_nullable
-                  as int,
-        ready: null == ready
-            ? _value.ready
-            : ready // ignore: cast_nullable_to_non_nullable
-                  as int,
-        inProgress: null == inProgress
-            ? _value.inProgress
-            : inProgress // ignore: cast_nullable_to_non_nullable
-                  as int,
-        suspend: null == suspend
-            ? _value.suspend
-            : suspend // ignore: cast_nullable_to_non_nullable
-                  as int,
-        completed: null == completed
-            ? _value.completed
-            : completed // ignore: cast_nullable_to_non_nullable
-                  as int,
-        abort: null == abort
-            ? _value.abort
-            : abort // ignore: cast_nullable_to_non_nullable
-                  as int,
-      ),
-    );
+    return _then(_self.copyWith(
+      backlog: null == backlog
+          ? _self.backlog
+          : backlog // ignore: cast_nullable_to_non_nullable
+              as int,
+      ready: null == ready
+          ? _self.ready
+          : ready // ignore: cast_nullable_to_non_nullable
+              as int,
+      inProgress: null == inProgress
+          ? _self.inProgress
+          : inProgress // ignore: cast_nullable_to_non_nullable
+              as int,
+      suspend: null == suspend
+          ? _self.suspend
+          : suspend // ignore: cast_nullable_to_non_nullable
+              as int,
+      completed: null == completed
+          ? _self.completed
+          : completed // ignore: cast_nullable_to_non_nullable
+              as int,
+      abort: null == abort
+          ? _self.abort
+          : abort // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
   }
 }
 
 /// @nodoc
 
-class _$QuestCountImpl extends _QuestCount {
-  const _$QuestCountImpl({
-    required this.backlog,
-    required this.ready,
-    required this.inProgress,
-    required this.suspend,
-    required this.completed,
-    required this.abort,
-  }) : super._();
+class _QuestCount extends QuestCount {
+  const _QuestCount(
+      {required this.backlog,
+      required this.ready,
+      required this.inProgress,
+      required this.suspend,
+      required this.completed,
+      required this.abort})
+      : super._();
 
   @override
   final int backlog;
@@ -198,16 +142,19 @@ class _$QuestCountImpl extends _QuestCount {
   @override
   final int abort;
 
+  /// Create a copy of QuestCount
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  String toString() {
-    return 'QuestCount(backlog: $backlog, ready: $ready, inProgress: $inProgress, suspend: $suspend, completed: $completed, abort: $abort)';
-  }
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$QuestCountCopyWith<_QuestCount> get copyWith =>
+      __$QuestCountCopyWithImpl<_QuestCount>(this, _$identity);
 
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$QuestCountImpl &&
+            other is _QuestCount &&
             (identical(other.backlog, backlog) || other.backlog == backlog) &&
             (identical(other.ready, ready) || other.ready == ready) &&
             (identical(other.inProgress, inProgress) ||
@@ -220,52 +167,77 @@ class _$QuestCountImpl extends _QuestCount {
 
   @override
   int get hashCode => Object.hash(
-    runtimeType,
-    backlog,
-    ready,
-    inProgress,
-    suspend,
-    completed,
-    abort,
-  );
+      runtimeType, backlog, ready, inProgress, suspend, completed, abort);
+
+  @override
+  String toString() {
+    return 'QuestCount(backlog: $backlog, ready: $ready, inProgress: $inProgress, suspend: $suspend, completed: $completed, abort: $abort)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$QuestCountCopyWith<$Res>
+    implements $QuestCountCopyWith<$Res> {
+  factory _$QuestCountCopyWith(
+          _QuestCount value, $Res Function(_QuestCount) _then) =
+      __$QuestCountCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {int backlog,
+      int ready,
+      int inProgress,
+      int suspend,
+      int completed,
+      int abort});
+}
+
+/// @nodoc
+class __$QuestCountCopyWithImpl<$Res> implements _$QuestCountCopyWith<$Res> {
+  __$QuestCountCopyWithImpl(this._self, this._then);
+
+  final _QuestCount _self;
+  final $Res Function(_QuestCount) _then;
 
   /// Create a copy of QuestCount
   /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
-  _$$QuestCountImplCopyWith<_$QuestCountImpl> get copyWith =>
-      __$$QuestCountImplCopyWithImpl<_$QuestCountImpl>(this, _$identity);
+  $Res call({
+    Object? backlog = null,
+    Object? ready = null,
+    Object? inProgress = null,
+    Object? suspend = null,
+    Object? completed = null,
+    Object? abort = null,
+  }) {
+    return _then(_QuestCount(
+      backlog: null == backlog
+          ? _self.backlog
+          : backlog // ignore: cast_nullable_to_non_nullable
+              as int,
+      ready: null == ready
+          ? _self.ready
+          : ready // ignore: cast_nullable_to_non_nullable
+              as int,
+      inProgress: null == inProgress
+          ? _self.inProgress
+          : inProgress // ignore: cast_nullable_to_non_nullable
+              as int,
+      suspend: null == suspend
+          ? _self.suspend
+          : suspend // ignore: cast_nullable_to_non_nullable
+              as int,
+      completed: null == completed
+          ? _self.completed
+          : completed // ignore: cast_nullable_to_non_nullable
+              as int,
+      abort: null == abort
+          ? _self.abort
+          : abort // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
+  }
 }
 
-abstract class _QuestCount extends QuestCount {
-  const factory _QuestCount({
-    required final int backlog,
-    required final int ready,
-    required final int inProgress,
-    required final int suspend,
-    required final int completed,
-    required final int abort,
-  }) = _$QuestCountImpl;
-  const _QuestCount._() : super._();
-
-  @override
-  int get backlog;
-  @override
-  int get ready;
-  @override
-  int get inProgress;
-  @override
-  int get suspend;
-  @override
-  int get completed;
-  @override
-  int get abort;
-
-  /// Create a copy of QuestCount
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$QuestCountImplCopyWith<_$QuestCountImpl> get copyWith =>
-      throw _privateConstructorUsedError;
-}
+// dart format on

--- a/core/model/lib/src/rule.dart
+++ b/core/model/lib/src/rule.dart
@@ -9,7 +9,7 @@ extension type RuleVersion(int value) implements int {}
 ///
 /// {@category Model}
 @freezed
-class Rule with _$Rule {
+abstract class Rule with _$Rule {
   const factory Rule({required RuleVersion version, required String content}) =
       _Rule;
 }

--- a/core/model/lib/src/rule.freezed.dart
+++ b/core/model/lib/src/rule.freezed.dart
@@ -1,3 +1,4 @@
+// dart format width=80
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint
@@ -9,120 +10,26 @@ part of 'rule.dart';
 // FreezedGenerator
 // **************************************************************************
 
+// dart format off
 T _$identity<T>(T value) => value;
-
-final _privateConstructorUsedError = UnsupportedError(
-  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
-);
 
 /// @nodoc
 mixin _$Rule {
-  RuleVersion get version => throw _privateConstructorUsedError;
-  String get content => throw _privateConstructorUsedError;
+  RuleVersion get version;
+  String get content;
 
   /// Create a copy of Rule
   /// with the given fields replaced by the non-null parameter values.
   @JsonKey(includeFromJson: false, includeToJson: false)
-  $RuleCopyWith<Rule> get copyWith => throw _privateConstructorUsedError;
-}
-
-/// @nodoc
-abstract class $RuleCopyWith<$Res> {
-  factory $RuleCopyWith(Rule value, $Res Function(Rule) then) =
-      _$RuleCopyWithImpl<$Res, Rule>;
-  @useResult
-  $Res call({RuleVersion version, String content});
-}
-
-/// @nodoc
-class _$RuleCopyWithImpl<$Res, $Val extends Rule>
-    implements $RuleCopyWith<$Res> {
-  _$RuleCopyWithImpl(this._value, this._then);
-
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
-
-  /// Create a copy of Rule
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
-  @override
-  $Res call({Object? version = null, Object? content = null}) {
-    return _then(
-      _value.copyWith(
-            version: null == version
-                ? _value.version
-                : version // ignore: cast_nullable_to_non_nullable
-                      as RuleVersion,
-            content: null == content
-                ? _value.content
-                : content // ignore: cast_nullable_to_non_nullable
-                      as String,
-          )
-          as $Val,
-    );
-  }
-}
-
-/// @nodoc
-abstract class _$$RuleImplCopyWith<$Res> implements $RuleCopyWith<$Res> {
-  factory _$$RuleImplCopyWith(
-    _$RuleImpl value,
-    $Res Function(_$RuleImpl) then,
-  ) = __$$RuleImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call({RuleVersion version, String content});
-}
-
-/// @nodoc
-class __$$RuleImplCopyWithImpl<$Res>
-    extends _$RuleCopyWithImpl<$Res, _$RuleImpl>
-    implements _$$RuleImplCopyWith<$Res> {
-  __$$RuleImplCopyWithImpl(_$RuleImpl _value, $Res Function(_$RuleImpl) _then)
-    : super(_value, _then);
-
-  /// Create a copy of Rule
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({Object? version = null, Object? content = null}) {
-    return _then(
-      _$RuleImpl(
-        version: null == version
-            ? _value.version
-            : version // ignore: cast_nullable_to_non_nullable
-                  as RuleVersion,
-        content: null == content
-            ? _value.content
-            : content // ignore: cast_nullable_to_non_nullable
-                  as String,
-      ),
-    );
-  }
-}
-
-/// @nodoc
-
-class _$RuleImpl implements _Rule {
-  const _$RuleImpl({required this.version, required this.content});
-
-  @override
-  final RuleVersion version;
-  @override
-  final String content;
-
-  @override
-  String toString() {
-    return 'Rule(version: $version, content: $content)';
-  }
+  $RuleCopyWith<Rule> get copyWith =>
+      _$RuleCopyWithImpl<Rule>(this as Rule, _$identity);
 
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$RuleImpl &&
+            other is Rule &&
             (identical(other.version, version) || other.version == version) &&
             (identical(other.content, content) || other.content == content));
   }
@@ -130,30 +37,119 @@ class _$RuleImpl implements _Rule {
   @override
   int get hashCode => Object.hash(runtimeType, version, content);
 
+  @override
+  String toString() {
+    return 'Rule(version: $version, content: $content)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $RuleCopyWith<$Res> {
+  factory $RuleCopyWith(Rule value, $Res Function(Rule) _then) =
+      _$RuleCopyWithImpl;
+  @useResult
+  $Res call({RuleVersion version, String content});
+}
+
+/// @nodoc
+class _$RuleCopyWithImpl<$Res> implements $RuleCopyWith<$Res> {
+  _$RuleCopyWithImpl(this._self, this._then);
+
+  final Rule _self;
+  final $Res Function(Rule) _then;
+
   /// Create a copy of Rule
   /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? version = null,
+    Object? content = null,
+  }) {
+    return _then(_self.copyWith(
+      version: null == version
+          ? _self.version
+          : version // ignore: cast_nullable_to_non_nullable
+              as RuleVersion,
+      content: null == content
+          ? _self.content
+          : content // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _Rule implements Rule {
+  const _Rule({required this.version, required this.content});
+
+  @override
+  final RuleVersion version;
+  @override
+  final String content;
+
+  /// Create a copy of Rule
+  /// with the given fields replaced by the non-null parameter values.
+  @override
   @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$RuleCopyWith<_Rule> get copyWith =>
+      __$RuleCopyWithImpl<_Rule>(this, _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _Rule &&
+            (identical(other.version, version) || other.version == version) &&
+            (identical(other.content, content) || other.content == content));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, version, content);
+
+  @override
+  String toString() {
+    return 'Rule(version: $version, content: $content)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$RuleCopyWith<$Res> implements $RuleCopyWith<$Res> {
+  factory _$RuleCopyWith(_Rule value, $Res Function(_Rule) _then) =
+      __$RuleCopyWithImpl;
+  @override
+  @useResult
+  $Res call({RuleVersion version, String content});
+}
+
+/// @nodoc
+class __$RuleCopyWithImpl<$Res> implements _$RuleCopyWith<$Res> {
+  __$RuleCopyWithImpl(this._self, this._then);
+
+  final _Rule _self;
+  final $Res Function(_Rule) _then;
+
+  /// Create a copy of Rule
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
-  _$$RuleImplCopyWith<_$RuleImpl> get copyWith =>
-      __$$RuleImplCopyWithImpl<_$RuleImpl>(this, _$identity);
+  $Res call({
+    Object? version = null,
+    Object? content = null,
+  }) {
+    return _then(_Rule(
+      version: null == version
+          ? _self.version
+          : version // ignore: cast_nullable_to_non_nullable
+              as RuleVersion,
+      content: null == content
+          ? _self.content
+          : content // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
 }
 
-abstract class _Rule implements Rule {
-  const factory _Rule({
-    required final RuleVersion version,
-    required final String content,
-  }) = _$RuleImpl;
-
-  @override
-  RuleVersion get version;
-  @override
-  String get content;
-
-  /// Create a copy of Rule
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$RuleImplCopyWith<_$RuleImpl> get copyWith =>
-      throw _privateConstructorUsedError;
-}
+// dart format on

--- a/core/model/pubspec.yaml
+++ b/core/model/pubspec.yaml
@@ -9,13 +9,13 @@ resolution: workspace
 
 dependencies:
   core_common: any
-  freezed_annotation: 2.4.4
+  freezed_annotation: 3.0.0
   riverpod: 2.6.1
   riverpod_annotation: 2.6.1
 
 dev_dependencies:
   build_runner: 2.4.14
-  freezed: 2.5.7
-  riverpod_generator: 2.6.3
+  freezed: 3.0.6
+  riverpod_generator: 2.6.5
   test: 1.25.14
   yumemi_lints: 4.0.0

--- a/core/network/lib/src/dio_client.g.dart
+++ b/core/network/lib/src/dio_client.g.dart
@@ -13,9 +13,8 @@ String _$dioClientHash() => r'a65b292cb36b609ad2a6dd9f88984d9e1cc1c1cc';
 final dioClientProvider = Provider<Dio>.internal(
   dioClient,
   name: r'dioClientProvider',
-  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
-      ? null
-      : _$dioClientHash,
+  debugGetCreateSourceHash:
+      const bool.fromEnvironment('dart.vm.product') ? null : _$dioClientHash,
   dependencies: null,
   allTransitiveDependencies: null,
 );

--- a/core/network/lib/src/news/news_remote_data_source.g.dart
+++ b/core/network/lib/src/news/news_remote_data_source.g.dart
@@ -9,7 +9,11 @@ part of 'news_remote_data_source.dart';
 // ignore_for_file: unnecessary_brace_in_string_interps,no_leading_underscores_for_local_identifiers,unused_element,unnecessary_string_interpolations
 
 class _NewsRemoteDataSource implements NewsRemoteDataSource {
-  _NewsRemoteDataSource(this._dio, {this.baseUrl, this.errorLogger});
+  _NewsRemoteDataSource(
+    this._dio, {
+    this.baseUrl,
+    this.errorLogger,
+  });
 
   final Dio _dio;
 
@@ -23,16 +27,22 @@ class _NewsRemoteDataSource implements NewsRemoteDataSource {
     final queryParameters = <String, dynamic>{};
     final _headers = <String, dynamic>{};
     const Map<String, dynamic>? _data = null;
-    final _options = _setStreamType<List<NetworkNews>>(
-      Options(method: 'GET', headers: _headers, extra: _extra)
-          .compose(
-            _dio.options,
-            '/v1/news',
-            queryParameters: queryParameters,
-            data: _data,
-          )
-          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
-    );
+    final _options = _setStreamType<List<NetworkNews>>(Options(
+      method: 'GET',
+      headers: _headers,
+      extra: _extra,
+    )
+        .compose(
+          _dio.options,
+          '/v1/news',
+          queryParameters: queryParameters,
+          data: _data,
+        )
+        .copyWith(
+            baseUrl: _combineBaseUrls(
+          _dio.options.baseUrl,
+          baseUrl,
+        )));
     final _result = await _dio.fetch<List<dynamic>>(_options);
     late List<NetworkNews> _value;
     try {
@@ -59,7 +69,10 @@ class _NewsRemoteDataSource implements NewsRemoteDataSource {
     return requestOptions;
   }
 
-  String _combineBaseUrls(String dioBaseUrl, String? baseUrl) {
+  String _combineBaseUrls(
+    String dioBaseUrl,
+    String? baseUrl,
+  ) {
     if (baseUrl == null || baseUrl.trim().isEmpty) {
       return dioBaseUrl;
     }

--- a/core/network/lib/src/quest/main_quest_remote_data_source.g.dart
+++ b/core/network/lib/src/quest/main_quest_remote_data_source.g.dart
@@ -9,7 +9,11 @@ part of 'main_quest_remote_data_source.dart';
 // ignore_for_file: unnecessary_brace_in_string_interps,no_leading_underscores_for_local_identifiers,unused_element,unnecessary_string_interpolations
 
 class _QuestRemoteDataSource implements QuestRemoteDataSource {
-  _QuestRemoteDataSource(this._dio, {this.baseUrl, this.errorLogger});
+  _QuestRemoteDataSource(
+    this._dio, {
+    this.baseUrl,
+    this.errorLogger,
+  });
 
   final Dio _dio;
 
@@ -18,30 +22,34 @@ class _QuestRemoteDataSource implements QuestRemoteDataSource {
   final ParseErrorLogger? errorLogger;
 
   @override
-  Future<List<NetworkMainQuest>> getMainQuestList({
-    required String userId,
-  }) async {
+  Future<List<NetworkMainQuest>> getMainQuestList(
+      {required String userId}) async {
     final _extra = <String, dynamic>{};
     final queryParameters = <String, dynamic>{r'userId': userId};
     final _headers = <String, dynamic>{};
     const Map<String, dynamic>? _data = null;
-    final _options = _setStreamType<List<NetworkMainQuest>>(
-      Options(method: 'GET', headers: _headers, extra: _extra)
-          .compose(
-            _dio.options,
-            '/v1/quests',
-            queryParameters: queryParameters,
-            data: _data,
-          )
-          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
-    );
+    final _options = _setStreamType<List<NetworkMainQuest>>(Options(
+      method: 'GET',
+      headers: _headers,
+      extra: _extra,
+    )
+        .compose(
+          _dio.options,
+          '/v1/quests',
+          queryParameters: queryParameters,
+          data: _data,
+        )
+        .copyWith(
+            baseUrl: _combineBaseUrls(
+          _dio.options.baseUrl,
+          baseUrl,
+        )));
     final _result = await _dio.fetch<List<dynamic>>(_options);
     late List<NetworkMainQuest> _value;
     try {
       _value = _result.data!
-          .map(
-            (dynamic i) => NetworkMainQuest.fromJson(i as Map<String, dynamic>),
-          )
+          .map((dynamic i) =>
+              NetworkMainQuest.fromJson(i as Map<String, dynamic>))
           .toList();
     } on Object catch (e, s) {
       errorLogger?.logError(e, s, _options);
@@ -66,16 +74,22 @@ class _QuestRemoteDataSource implements QuestRemoteDataSource {
       'description': description,
       'note': note,
     };
-    final _options = _setStreamType<String>(
-      Options(method: 'POST', headers: _headers, extra: _extra)
-          .compose(
-            _dio.options,
-            '/v1/quests',
-            queryParameters: queryParameters,
-            data: _data,
-          )
-          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
-    );
+    final _options = _setStreamType<String>(Options(
+      method: 'POST',
+      headers: _headers,
+      extra: _extra,
+    )
+        .compose(
+          _dio.options,
+          '/v1/quests',
+          queryParameters: queryParameters,
+          data: _data,
+        )
+        .copyWith(
+            baseUrl: _combineBaseUrls(
+          _dio.options.baseUrl,
+          baseUrl,
+        )));
     final _result = await _dio.fetch<String>(_options);
     late String _value;
     try {
@@ -100,7 +114,10 @@ class _QuestRemoteDataSource implements QuestRemoteDataSource {
     return requestOptions;
   }
 
-  String _combineBaseUrls(String dioBaseUrl, String? baseUrl) {
+  String _combineBaseUrls(
+    String dioBaseUrl,
+    String? baseUrl,
+  ) {
     if (baseUrl == null || baseUrl.trim().isEmpty) {
       return dioBaseUrl;
     }

--- a/core/network/pubspec.yaml
+++ b/core/network/pubspec.yaml
@@ -13,14 +13,14 @@ dependencies:
   core_model: any
   core_network_model: any
   dio: 5.7.0
-  freezed_annotation: 2.4.4
+  freezed_annotation: 3.0.0
   retrofit: 4.4.2
   riverpod: 2.6.1
   riverpod_annotation: 2.6.1
 
 dev_dependencies:
   build_runner: 2.4.14
-  freezed: 2.5.7
+  freezed: 3.0.6
   retrofit_generator: 9.1.7
-  riverpod_generator: 2.6.3
+  riverpod_generator: 2.6.5
   yumemi_lints: 4.0.0

--- a/core/network_model/lib/src/news/network_news.dart
+++ b/core/network_model/lib/src/news/network_news.dart
@@ -8,7 +8,7 @@ part 'network_news.g.dart';
 ///
 /// {@category Model}
 @freezed
-class NetworkNews with _$NetworkNews {
+abstract class NetworkNews with _$NetworkNews {
   const factory NetworkNews({
     required String title,
     required String slug,

--- a/core/network_model/lib/src/news/network_news.freezed.dart
+++ b/core/network_model/lib/src/news/network_news.freezed.dart
@@ -1,3 +1,4 @@
+// dart format width=80
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint
@@ -9,199 +10,32 @@ part of 'network_news.dart';
 // FreezedGenerator
 // **************************************************************************
 
+// dart format off
 T _$identity<T>(T value) => value;
-
-final _privateConstructorUsedError = UnsupportedError(
-  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
-);
-
-NetworkNews _$NetworkNewsFromJson(Map<String, dynamic> json) {
-  return _NetworkNews.fromJson(json);
-}
 
 /// @nodoc
 mixin _$NetworkNews {
-  String get title => throw _privateConstructorUsedError;
-  String get slug => throw _privateConstructorUsedError;
-  DateTime get publishedAt => throw _privateConstructorUsedError;
-  String get excerpt => throw _privateConstructorUsedError;
-  String? get coverImageUrl => throw _privateConstructorUsedError;
-
-  /// Serializes this NetworkNews to a JSON map.
-  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  String get title;
+  String get slug;
+  DateTime get publishedAt;
+  String get excerpt;
+  String? get coverImageUrl;
 
   /// Create a copy of NetworkNews
   /// with the given fields replaced by the non-null parameter values.
   @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
   $NetworkNewsCopyWith<NetworkNews> get copyWith =>
-      throw _privateConstructorUsedError;
-}
+      _$NetworkNewsCopyWithImpl<NetworkNews>(this as NetworkNews, _$identity);
 
-/// @nodoc
-abstract class $NetworkNewsCopyWith<$Res> {
-  factory $NetworkNewsCopyWith(
-    NetworkNews value,
-    $Res Function(NetworkNews) then,
-  ) = _$NetworkNewsCopyWithImpl<$Res, NetworkNews>;
-  @useResult
-  $Res call({
-    String title,
-    String slug,
-    DateTime publishedAt,
-    String excerpt,
-    String? coverImageUrl,
-  });
-}
-
-/// @nodoc
-class _$NetworkNewsCopyWithImpl<$Res, $Val extends NetworkNews>
-    implements $NetworkNewsCopyWith<$Res> {
-  _$NetworkNewsCopyWithImpl(this._value, this._then);
-
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
-
-  /// Create a copy of NetworkNews
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? title = null,
-    Object? slug = null,
-    Object? publishedAt = null,
-    Object? excerpt = null,
-    Object? coverImageUrl = freezed,
-  }) {
-    return _then(
-      _value.copyWith(
-            title: null == title
-                ? _value.title
-                : title // ignore: cast_nullable_to_non_nullable
-                      as String,
-            slug: null == slug
-                ? _value.slug
-                : slug // ignore: cast_nullable_to_non_nullable
-                      as String,
-            publishedAt: null == publishedAt
-                ? _value.publishedAt
-                : publishedAt // ignore: cast_nullable_to_non_nullable
-                      as DateTime,
-            excerpt: null == excerpt
-                ? _value.excerpt
-                : excerpt // ignore: cast_nullable_to_non_nullable
-                      as String,
-            coverImageUrl: freezed == coverImageUrl
-                ? _value.coverImageUrl
-                : coverImageUrl // ignore: cast_nullable_to_non_nullable
-                      as String?,
-          )
-          as $Val,
-    );
-  }
-}
-
-/// @nodoc
-abstract class _$$NetworkNewsImplCopyWith<$Res>
-    implements $NetworkNewsCopyWith<$Res> {
-  factory _$$NetworkNewsImplCopyWith(
-    _$NetworkNewsImpl value,
-    $Res Function(_$NetworkNewsImpl) then,
-  ) = __$$NetworkNewsImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call({
-    String title,
-    String slug,
-    DateTime publishedAt,
-    String excerpt,
-    String? coverImageUrl,
-  });
-}
-
-/// @nodoc
-class __$$NetworkNewsImplCopyWithImpl<$Res>
-    extends _$NetworkNewsCopyWithImpl<$Res, _$NetworkNewsImpl>
-    implements _$$NetworkNewsImplCopyWith<$Res> {
-  __$$NetworkNewsImplCopyWithImpl(
-    _$NetworkNewsImpl _value,
-    $Res Function(_$NetworkNewsImpl) _then,
-  ) : super(_value, _then);
-
-  /// Create a copy of NetworkNews
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? title = null,
-    Object? slug = null,
-    Object? publishedAt = null,
-    Object? excerpt = null,
-    Object? coverImageUrl = freezed,
-  }) {
-    return _then(
-      _$NetworkNewsImpl(
-        title: null == title
-            ? _value.title
-            : title // ignore: cast_nullable_to_non_nullable
-                  as String,
-        slug: null == slug
-            ? _value.slug
-            : slug // ignore: cast_nullable_to_non_nullable
-                  as String,
-        publishedAt: null == publishedAt
-            ? _value.publishedAt
-            : publishedAt // ignore: cast_nullable_to_non_nullable
-                  as DateTime,
-        excerpt: null == excerpt
-            ? _value.excerpt
-            : excerpt // ignore: cast_nullable_to_non_nullable
-                  as String,
-        coverImageUrl: freezed == coverImageUrl
-            ? _value.coverImageUrl
-            : coverImageUrl // ignore: cast_nullable_to_non_nullable
-                  as String?,
-      ),
-    );
-  }
-}
-
-/// @nodoc
-@JsonSerializable()
-class _$NetworkNewsImpl implements _NetworkNews {
-  const _$NetworkNewsImpl({
-    required this.title,
-    required this.slug,
-    required this.publishedAt,
-    required this.excerpt,
-    required this.coverImageUrl,
-  });
-
-  factory _$NetworkNewsImpl.fromJson(Map<String, dynamic> json) =>
-      _$$NetworkNewsImplFromJson(json);
-
-  @override
-  final String title;
-  @override
-  final String slug;
-  @override
-  final DateTime publishedAt;
-  @override
-  final String excerpt;
-  @override
-  final String? coverImageUrl;
-
-  @override
-  String toString() {
-    return 'NetworkNews(title: $title, slug: $slug, publishedAt: $publishedAt, excerpt: $excerpt, coverImageUrl: $coverImageUrl)';
-  }
+  /// Serializes this NetworkNews to a JSON map.
+  Map<String, dynamic> toJson();
 
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$NetworkNewsImpl &&
+            other is NetworkNews &&
             (identical(other.title, title) || other.title == title) &&
             (identical(other.slug, slug) || other.slug == slug) &&
             (identical(other.publishedAt, publishedAt) ||
@@ -214,55 +48,191 @@ class _$NetworkNewsImpl implements _NetworkNews {
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
-    runtimeType,
-    title,
-    slug,
-    publishedAt,
-    excerpt,
-    coverImageUrl,
-  );
-
-  /// Create a copy of NetworkNews
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  @pragma('vm:prefer-inline')
-  _$$NetworkNewsImplCopyWith<_$NetworkNewsImpl> get copyWith =>
-      __$$NetworkNewsImplCopyWithImpl<_$NetworkNewsImpl>(this, _$identity);
+      runtimeType, title, slug, publishedAt, excerpt, coverImageUrl);
 
   @override
-  Map<String, dynamic> toJson() {
-    return _$$NetworkNewsImplToJson(this);
+  String toString() {
+    return 'NetworkNews(title: $title, slug: $slug, publishedAt: $publishedAt, excerpt: $excerpt, coverImageUrl: $coverImageUrl)';
   }
 }
 
-abstract class _NetworkNews implements NetworkNews {
-  const factory _NetworkNews({
-    required final String title,
-    required final String slug,
-    required final DateTime publishedAt,
-    required final String excerpt,
-    required final String? coverImageUrl,
-  }) = _$NetworkNewsImpl;
+/// @nodoc
+abstract mixin class $NetworkNewsCopyWith<$Res> {
+  factory $NetworkNewsCopyWith(
+          NetworkNews value, $Res Function(NetworkNews) _then) =
+      _$NetworkNewsCopyWithImpl;
+  @useResult
+  $Res call(
+      {String title,
+      String slug,
+      DateTime publishedAt,
+      String excerpt,
+      String? coverImageUrl});
+}
 
-  factory _NetworkNews.fromJson(Map<String, dynamic> json) =
-      _$NetworkNewsImpl.fromJson;
+/// @nodoc
+class _$NetworkNewsCopyWithImpl<$Res> implements $NetworkNewsCopyWith<$Res> {
+  _$NetworkNewsCopyWithImpl(this._self, this._then);
+
+  final NetworkNews _self;
+  final $Res Function(NetworkNews) _then;
+
+  /// Create a copy of NetworkNews
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? title = null,
+    Object? slug = null,
+    Object? publishedAt = null,
+    Object? excerpt = null,
+    Object? coverImageUrl = freezed,
+  }) {
+    return _then(_self.copyWith(
+      title: null == title
+          ? _self.title
+          : title // ignore: cast_nullable_to_non_nullable
+              as String,
+      slug: null == slug
+          ? _self.slug
+          : slug // ignore: cast_nullable_to_non_nullable
+              as String,
+      publishedAt: null == publishedAt
+          ? _self.publishedAt
+          : publishedAt // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+      excerpt: null == excerpt
+          ? _self.excerpt
+          : excerpt // ignore: cast_nullable_to_non_nullable
+              as String,
+      coverImageUrl: freezed == coverImageUrl
+          ? _self.coverImageUrl
+          : coverImageUrl // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _NetworkNews implements NetworkNews {
+  const _NetworkNews(
+      {required this.title,
+      required this.slug,
+      required this.publishedAt,
+      required this.excerpt,
+      required this.coverImageUrl});
+  factory _NetworkNews.fromJson(Map<String, dynamic> json) =>
+      _$NetworkNewsFromJson(json);
 
   @override
-  String get title;
+  final String title;
   @override
-  String get slug;
+  final String slug;
   @override
-  DateTime get publishedAt;
+  final DateTime publishedAt;
   @override
-  String get excerpt;
+  final String excerpt;
   @override
-  String? get coverImageUrl;
+  final String? coverImageUrl;
 
   /// Create a copy of NetworkNews
   /// with the given fields replaced by the non-null parameter values.
   @override
   @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$NetworkNewsImplCopyWith<_$NetworkNewsImpl> get copyWith =>
-      throw _privateConstructorUsedError;
+  @pragma('vm:prefer-inline')
+  _$NetworkNewsCopyWith<_NetworkNews> get copyWith =>
+      __$NetworkNewsCopyWithImpl<_NetworkNews>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$NetworkNewsToJson(
+      this,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _NetworkNews &&
+            (identical(other.title, title) || other.title == title) &&
+            (identical(other.slug, slug) || other.slug == slug) &&
+            (identical(other.publishedAt, publishedAt) ||
+                other.publishedAt == publishedAt) &&
+            (identical(other.excerpt, excerpt) || other.excerpt == excerpt) &&
+            (identical(other.coverImageUrl, coverImageUrl) ||
+                other.coverImageUrl == coverImageUrl));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType, title, slug, publishedAt, excerpt, coverImageUrl);
+
+  @override
+  String toString() {
+    return 'NetworkNews(title: $title, slug: $slug, publishedAt: $publishedAt, excerpt: $excerpt, coverImageUrl: $coverImageUrl)';
+  }
 }
+
+/// @nodoc
+abstract mixin class _$NetworkNewsCopyWith<$Res>
+    implements $NetworkNewsCopyWith<$Res> {
+  factory _$NetworkNewsCopyWith(
+          _NetworkNews value, $Res Function(_NetworkNews) _then) =
+      __$NetworkNewsCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {String title,
+      String slug,
+      DateTime publishedAt,
+      String excerpt,
+      String? coverImageUrl});
+}
+
+/// @nodoc
+class __$NetworkNewsCopyWithImpl<$Res> implements _$NetworkNewsCopyWith<$Res> {
+  __$NetworkNewsCopyWithImpl(this._self, this._then);
+
+  final _NetworkNews _self;
+  final $Res Function(_NetworkNews) _then;
+
+  /// Create a copy of NetworkNews
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? title = null,
+    Object? slug = null,
+    Object? publishedAt = null,
+    Object? excerpt = null,
+    Object? coverImageUrl = freezed,
+  }) {
+    return _then(_NetworkNews(
+      title: null == title
+          ? _self.title
+          : title // ignore: cast_nullable_to_non_nullable
+              as String,
+      slug: null == slug
+          ? _self.slug
+          : slug // ignore: cast_nullable_to_non_nullable
+              as String,
+      publishedAt: null == publishedAt
+          ? _self.publishedAt
+          : publishedAt // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+      excerpt: null == excerpt
+          ? _self.excerpt
+          : excerpt // ignore: cast_nullable_to_non_nullable
+              as String,
+      coverImageUrl: freezed == coverImageUrl
+          ? _self.coverImageUrl
+          : coverImageUrl // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
+  }
+}
+
+// dart format on

--- a/core/network_model/lib/src/news/network_news.g.dart
+++ b/core/network_model/lib/src/news/network_news.g.dart
@@ -6,8 +6,7 @@ part of 'network_news.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$NetworkNewsImpl _$$NetworkNewsImplFromJson(Map<String, dynamic> json) =>
-    _$NetworkNewsImpl(
+_NetworkNews _$NetworkNewsFromJson(Map<String, dynamic> json) => _NetworkNews(
       title: json['title'] as String,
       slug: json['slug'] as String,
       publishedAt: DateTime.parse(json['publishedAt'] as String),
@@ -15,7 +14,7 @@ _$NetworkNewsImpl _$$NetworkNewsImplFromJson(Map<String, dynamic> json) =>
       coverImageUrl: json['coverImageUrl'] as String?,
     );
 
-Map<String, dynamic> _$$NetworkNewsImplToJson(_$NetworkNewsImpl instance) =>
+Map<String, dynamic> _$NetworkNewsToJson(_NetworkNews instance) =>
     <String, dynamic>{
       'title': instance.title,
       'slug': instance.slug,

--- a/core/network_model/lib/src/quest/create_main_quest_request.dart
+++ b/core/network_model/lib/src/quest/create_main_quest_request.dart
@@ -8,7 +8,7 @@ part 'create_main_quest_request.g.dart';
 ///
 /// {@category Model}
 @freezed
-class CreateMainQuestRequest with _$CreateMainQuestRequest {
+abstract class CreateMainQuestRequest with _$CreateMainQuestRequest {
   const factory CreateMainQuestRequest({
     required String userId,
     required String title,

--- a/core/network_model/lib/src/quest/create_main_quest_request.freezed.dart
+++ b/core/network_model/lib/src/quest/create_main_quest_request.freezed.dart
@@ -1,3 +1,4 @@
+// dart format width=80
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint
@@ -9,179 +10,32 @@ part of 'create_main_quest_request.dart';
 // FreezedGenerator
 // **************************************************************************
 
+// dart format off
 T _$identity<T>(T value) => value;
-
-final _privateConstructorUsedError = UnsupportedError(
-  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
-);
-
-CreateMainQuestRequest _$CreateMainQuestRequestFromJson(
-  Map<String, dynamic> json,
-) {
-  return _CreateMainQuestRequest.fromJson(json);
-}
 
 /// @nodoc
 mixin _$CreateMainQuestRequest {
-  String get userId => throw _privateConstructorUsedError;
-  String get title => throw _privateConstructorUsedError;
-  String get description => throw _privateConstructorUsedError;
-  String get note => throw _privateConstructorUsedError;
-
-  /// Serializes this CreateMainQuestRequest to a JSON map.
-  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  String get userId;
+  String get title;
+  String get description;
+  String get note;
 
   /// Create a copy of CreateMainQuestRequest
   /// with the given fields replaced by the non-null parameter values.
   @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
   $CreateMainQuestRequestCopyWith<CreateMainQuestRequest> get copyWith =>
-      throw _privateConstructorUsedError;
-}
+      _$CreateMainQuestRequestCopyWithImpl<CreateMainQuestRequest>(
+          this as CreateMainQuestRequest, _$identity);
 
-/// @nodoc
-abstract class $CreateMainQuestRequestCopyWith<$Res> {
-  factory $CreateMainQuestRequestCopyWith(
-    CreateMainQuestRequest value,
-    $Res Function(CreateMainQuestRequest) then,
-  ) = _$CreateMainQuestRequestCopyWithImpl<$Res, CreateMainQuestRequest>;
-  @useResult
-  $Res call({String userId, String title, String description, String note});
-}
-
-/// @nodoc
-class _$CreateMainQuestRequestCopyWithImpl<
-  $Res,
-  $Val extends CreateMainQuestRequest
->
-    implements $CreateMainQuestRequestCopyWith<$Res> {
-  _$CreateMainQuestRequestCopyWithImpl(this._value, this._then);
-
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
-
-  /// Create a copy of CreateMainQuestRequest
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? userId = null,
-    Object? title = null,
-    Object? description = null,
-    Object? note = null,
-  }) {
-    return _then(
-      _value.copyWith(
-            userId: null == userId
-                ? _value.userId
-                : userId // ignore: cast_nullable_to_non_nullable
-                      as String,
-            title: null == title
-                ? _value.title
-                : title // ignore: cast_nullable_to_non_nullable
-                      as String,
-            description: null == description
-                ? _value.description
-                : description // ignore: cast_nullable_to_non_nullable
-                      as String,
-            note: null == note
-                ? _value.note
-                : note // ignore: cast_nullable_to_non_nullable
-                      as String,
-          )
-          as $Val,
-    );
-  }
-}
-
-/// @nodoc
-abstract class _$$CreateMainQuestRequestImplCopyWith<$Res>
-    implements $CreateMainQuestRequestCopyWith<$Res> {
-  factory _$$CreateMainQuestRequestImplCopyWith(
-    _$CreateMainQuestRequestImpl value,
-    $Res Function(_$CreateMainQuestRequestImpl) then,
-  ) = __$$CreateMainQuestRequestImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call({String userId, String title, String description, String note});
-}
-
-/// @nodoc
-class __$$CreateMainQuestRequestImplCopyWithImpl<$Res>
-    extends
-        _$CreateMainQuestRequestCopyWithImpl<$Res, _$CreateMainQuestRequestImpl>
-    implements _$$CreateMainQuestRequestImplCopyWith<$Res> {
-  __$$CreateMainQuestRequestImplCopyWithImpl(
-    _$CreateMainQuestRequestImpl _value,
-    $Res Function(_$CreateMainQuestRequestImpl) _then,
-  ) : super(_value, _then);
-
-  /// Create a copy of CreateMainQuestRequest
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? userId = null,
-    Object? title = null,
-    Object? description = null,
-    Object? note = null,
-  }) {
-    return _then(
-      _$CreateMainQuestRequestImpl(
-        userId: null == userId
-            ? _value.userId
-            : userId // ignore: cast_nullable_to_non_nullable
-                  as String,
-        title: null == title
-            ? _value.title
-            : title // ignore: cast_nullable_to_non_nullable
-                  as String,
-        description: null == description
-            ? _value.description
-            : description // ignore: cast_nullable_to_non_nullable
-                  as String,
-        note: null == note
-            ? _value.note
-            : note // ignore: cast_nullable_to_non_nullable
-                  as String,
-      ),
-    );
-  }
-}
-
-/// @nodoc
-@JsonSerializable()
-class _$CreateMainQuestRequestImpl implements _CreateMainQuestRequest {
-  const _$CreateMainQuestRequestImpl({
-    required this.userId,
-    required this.title,
-    required this.description,
-    required this.note,
-  });
-
-  factory _$CreateMainQuestRequestImpl.fromJson(Map<String, dynamic> json) =>
-      _$$CreateMainQuestRequestImplFromJson(json);
-
-  @override
-  final String userId;
-  @override
-  final String title;
-  @override
-  final String description;
-  @override
-  final String note;
-
-  @override
-  String toString() {
-    return 'CreateMainQuestRequest(userId: $userId, title: $title, description: $description, note: $note)';
-  }
+  /// Serializes this CreateMainQuestRequest to a JSON map.
+  Map<String, dynamic> toJson();
 
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$CreateMainQuestRequestImpl &&
+            other is CreateMainQuestRequest &&
             (identical(other.userId, userId) || other.userId == userId) &&
             (identical(other.title, title) || other.title == title) &&
             (identical(other.description, description) ||
@@ -194,48 +48,167 @@ class _$CreateMainQuestRequestImpl implements _CreateMainQuestRequest {
   int get hashCode =>
       Object.hash(runtimeType, userId, title, description, note);
 
-  /// Create a copy of CreateMainQuestRequest
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  @pragma('vm:prefer-inline')
-  _$$CreateMainQuestRequestImplCopyWith<_$CreateMainQuestRequestImpl>
-  get copyWith =>
-      __$$CreateMainQuestRequestImplCopyWithImpl<_$CreateMainQuestRequestImpl>(
-        this,
-        _$identity,
-      );
-
-  @override
-  Map<String, dynamic> toJson() {
-    return _$$CreateMainQuestRequestImplToJson(this);
+  String toString() {
+    return 'CreateMainQuestRequest(userId: $userId, title: $title, description: $description, note: $note)';
   }
 }
 
-abstract class _CreateMainQuestRequest implements CreateMainQuestRequest {
-  const factory _CreateMainQuestRequest({
-    required final String userId,
-    required final String title,
-    required final String description,
-    required final String note,
-  }) = _$CreateMainQuestRequestImpl;
+/// @nodoc
+abstract mixin class $CreateMainQuestRequestCopyWith<$Res> {
+  factory $CreateMainQuestRequestCopyWith(CreateMainQuestRequest value,
+          $Res Function(CreateMainQuestRequest) _then) =
+      _$CreateMainQuestRequestCopyWithImpl;
+  @useResult
+  $Res call({String userId, String title, String description, String note});
+}
 
-  factory _CreateMainQuestRequest.fromJson(Map<String, dynamic> json) =
-      _$CreateMainQuestRequestImpl.fromJson;
+/// @nodoc
+class _$CreateMainQuestRequestCopyWithImpl<$Res>
+    implements $CreateMainQuestRequestCopyWith<$Res> {
+  _$CreateMainQuestRequestCopyWithImpl(this._self, this._then);
+
+  final CreateMainQuestRequest _self;
+  final $Res Function(CreateMainQuestRequest) _then;
+
+  /// Create a copy of CreateMainQuestRequest
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? userId = null,
+    Object? title = null,
+    Object? description = null,
+    Object? note = null,
+  }) {
+    return _then(_self.copyWith(
+      userId: null == userId
+          ? _self.userId
+          : userId // ignore: cast_nullable_to_non_nullable
+              as String,
+      title: null == title
+          ? _self.title
+          : title // ignore: cast_nullable_to_non_nullable
+              as String,
+      description: null == description
+          ? _self.description
+          : description // ignore: cast_nullable_to_non_nullable
+              as String,
+      note: null == note
+          ? _self.note
+          : note // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _CreateMainQuestRequest implements CreateMainQuestRequest {
+  const _CreateMainQuestRequest(
+      {required this.userId,
+      required this.title,
+      required this.description,
+      required this.note});
+  factory _CreateMainQuestRequest.fromJson(Map<String, dynamic> json) =>
+      _$CreateMainQuestRequestFromJson(json);
 
   @override
-  String get userId;
+  final String userId;
   @override
-  String get title;
+  final String title;
   @override
-  String get description;
+  final String description;
   @override
-  String get note;
+  final String note;
 
   /// Create a copy of CreateMainQuestRequest
   /// with the given fields replaced by the non-null parameter values.
   @override
   @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$CreateMainQuestRequestImplCopyWith<_$CreateMainQuestRequestImpl>
-  get copyWith => throw _privateConstructorUsedError;
+  @pragma('vm:prefer-inline')
+  _$CreateMainQuestRequestCopyWith<_CreateMainQuestRequest> get copyWith =>
+      __$CreateMainQuestRequestCopyWithImpl<_CreateMainQuestRequest>(
+          this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$CreateMainQuestRequestToJson(
+      this,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _CreateMainQuestRequest &&
+            (identical(other.userId, userId) || other.userId == userId) &&
+            (identical(other.title, title) || other.title == title) &&
+            (identical(other.description, description) ||
+                other.description == description) &&
+            (identical(other.note, note) || other.note == note));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, userId, title, description, note);
+
+  @override
+  String toString() {
+    return 'CreateMainQuestRequest(userId: $userId, title: $title, description: $description, note: $note)';
+  }
 }
+
+/// @nodoc
+abstract mixin class _$CreateMainQuestRequestCopyWith<$Res>
+    implements $CreateMainQuestRequestCopyWith<$Res> {
+  factory _$CreateMainQuestRequestCopyWith(_CreateMainQuestRequest value,
+          $Res Function(_CreateMainQuestRequest) _then) =
+      __$CreateMainQuestRequestCopyWithImpl;
+  @override
+  @useResult
+  $Res call({String userId, String title, String description, String note});
+}
+
+/// @nodoc
+class __$CreateMainQuestRequestCopyWithImpl<$Res>
+    implements _$CreateMainQuestRequestCopyWith<$Res> {
+  __$CreateMainQuestRequestCopyWithImpl(this._self, this._then);
+
+  final _CreateMainQuestRequest _self;
+  final $Res Function(_CreateMainQuestRequest) _then;
+
+  /// Create a copy of CreateMainQuestRequest
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? userId = null,
+    Object? title = null,
+    Object? description = null,
+    Object? note = null,
+  }) {
+    return _then(_CreateMainQuestRequest(
+      userId: null == userId
+          ? _self.userId
+          : userId // ignore: cast_nullable_to_non_nullable
+              as String,
+      title: null == title
+          ? _self.title
+          : title // ignore: cast_nullable_to_non_nullable
+              as String,
+      description: null == description
+          ? _self.description
+          : description // ignore: cast_nullable_to_non_nullable
+              as String,
+      note: null == note
+          ? _self.note
+          : note // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+// dart format on

--- a/core/network_model/lib/src/quest/create_main_quest_request.g.dart
+++ b/core/network_model/lib/src/quest/create_main_quest_request.g.dart
@@ -6,20 +6,20 @@ part of 'create_main_quest_request.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$CreateMainQuestRequestImpl _$$CreateMainQuestRequestImplFromJson(
-  Map<String, dynamic> json,
-) => _$CreateMainQuestRequestImpl(
-  userId: json['userId'] as String,
-  title: json['title'] as String,
-  description: json['description'] as String,
-  note: json['note'] as String,
-);
+_CreateMainQuestRequest _$CreateMainQuestRequestFromJson(
+        Map<String, dynamic> json) =>
+    _CreateMainQuestRequest(
+      userId: json['userId'] as String,
+      title: json['title'] as String,
+      description: json['description'] as String,
+      note: json['note'] as String,
+    );
 
-Map<String, dynamic> _$$CreateMainQuestRequestImplToJson(
-  _$CreateMainQuestRequestImpl instance,
-) => <String, dynamic>{
-  'userId': instance.userId,
-  'title': instance.title,
-  'description': instance.description,
-  'note': instance.note,
-};
+Map<String, dynamic> _$CreateMainQuestRequestToJson(
+        _CreateMainQuestRequest instance) =>
+    <String, dynamic>{
+      'userId': instance.userId,
+      'title': instance.title,
+      'description': instance.description,
+      'note': instance.note,
+    };

--- a/core/network_model/lib/src/quest/network_main_quest.dart
+++ b/core/network_model/lib/src/quest/network_main_quest.dart
@@ -8,7 +8,7 @@ part 'network_main_quest.g.dart';
 ///
 /// {@category Model}
 @freezed
-class NetworkMainQuest with _$NetworkMainQuest {
+abstract class NetworkMainQuest with _$NetworkMainQuest {
   const factory NetworkMainQuest({
     required String id,
     required String title,

--- a/core/network_model/lib/src/quest/network_main_quest.freezed.dart
+++ b/core/network_model/lib/src/quest/network_main_quest.freezed.dart
@@ -1,3 +1,4 @@
+// dart format width=80
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint
@@ -9,157 +10,87 @@ part of 'network_main_quest.dart';
 // FreezedGenerator
 // **************************************************************************
 
+// dart format off
 T _$identity<T>(T value) => value;
-
-final _privateConstructorUsedError = UnsupportedError(
-  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
-);
-
-NetworkMainQuest _$NetworkMainQuestFromJson(Map<String, dynamic> json) {
-  return _NetworkMainQuest.fromJson(json);
-}
 
 /// @nodoc
 mixin _$NetworkMainQuest {
-  String get id => throw _privateConstructorUsedError;
-  String get title => throw _privateConstructorUsedError;
-  String get description => throw _privateConstructorUsedError;
-  DateTime? get begunAt => throw _privateConstructorUsedError;
-  DateTime? get endedAt => throw _privateConstructorUsedError;
-  String? get categoryId => throw _privateConstructorUsedError;
-  String get status => throw _privateConstructorUsedError;
-  String? get coverImageUrl => throw _privateConstructorUsedError;
-  String get note => throw _privateConstructorUsedError;
-
-  /// Serializes this NetworkMainQuest to a JSON map.
-  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  String get id;
+  String get title;
+  String get description;
+  DateTime? get begunAt;
+  DateTime? get endedAt;
+  String? get categoryId;
+  String get status;
+  String? get coverImageUrl;
+  String get note;
 
   /// Create a copy of NetworkMainQuest
   /// with the given fields replaced by the non-null parameter values.
   @JsonKey(includeFromJson: false, includeToJson: false)
-  $NetworkMainQuestCopyWith<NetworkMainQuest> get copyWith =>
-      throw _privateConstructorUsedError;
-}
-
-/// @nodoc
-abstract class $NetworkMainQuestCopyWith<$Res> {
-  factory $NetworkMainQuestCopyWith(
-    NetworkMainQuest value,
-    $Res Function(NetworkMainQuest) then,
-  ) = _$NetworkMainQuestCopyWithImpl<$Res, NetworkMainQuest>;
-  @useResult
-  $Res call({
-    String id,
-    String title,
-    String description,
-    DateTime? begunAt,
-    DateTime? endedAt,
-    String? categoryId,
-    String status,
-    String? coverImageUrl,
-    String note,
-  });
-}
-
-/// @nodoc
-class _$NetworkMainQuestCopyWithImpl<$Res, $Val extends NetworkMainQuest>
-    implements $NetworkMainQuestCopyWith<$Res> {
-  _$NetworkMainQuestCopyWithImpl(this._value, this._then);
-
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
-
-  /// Create a copy of NetworkMainQuest
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
+  $NetworkMainQuestCopyWith<NetworkMainQuest> get copyWith =>
+      _$NetworkMainQuestCopyWithImpl<NetworkMainQuest>(
+          this as NetworkMainQuest, _$identity);
+
+  /// Serializes this NetworkMainQuest to a JSON map.
+  Map<String, dynamic> toJson();
+
   @override
-  $Res call({
-    Object? id = null,
-    Object? title = null,
-    Object? description = null,
-    Object? begunAt = freezed,
-    Object? endedAt = freezed,
-    Object? categoryId = freezed,
-    Object? status = null,
-    Object? coverImageUrl = freezed,
-    Object? note = null,
-  }) {
-    return _then(
-      _value.copyWith(
-            id: null == id
-                ? _value.id
-                : id // ignore: cast_nullable_to_non_nullable
-                      as String,
-            title: null == title
-                ? _value.title
-                : title // ignore: cast_nullable_to_non_nullable
-                      as String,
-            description: null == description
-                ? _value.description
-                : description // ignore: cast_nullable_to_non_nullable
-                      as String,
-            begunAt: freezed == begunAt
-                ? _value.begunAt
-                : begunAt // ignore: cast_nullable_to_non_nullable
-                      as DateTime?,
-            endedAt: freezed == endedAt
-                ? _value.endedAt
-                : endedAt // ignore: cast_nullable_to_non_nullable
-                      as DateTime?,
-            categoryId: freezed == categoryId
-                ? _value.categoryId
-                : categoryId // ignore: cast_nullable_to_non_nullable
-                      as String?,
-            status: null == status
-                ? _value.status
-                : status // ignore: cast_nullable_to_non_nullable
-                      as String,
-            coverImageUrl: freezed == coverImageUrl
-                ? _value.coverImageUrl
-                : coverImageUrl // ignore: cast_nullable_to_non_nullable
-                      as String?,
-            note: null == note
-                ? _value.note
-                : note // ignore: cast_nullable_to_non_nullable
-                      as String,
-          )
-          as $Val,
-    );
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is NetworkMainQuest &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.title, title) || other.title == title) &&
+            (identical(other.description, description) ||
+                other.description == description) &&
+            (identical(other.begunAt, begunAt) || other.begunAt == begunAt) &&
+            (identical(other.endedAt, endedAt) || other.endedAt == endedAt) &&
+            (identical(other.categoryId, categoryId) ||
+                other.categoryId == categoryId) &&
+            (identical(other.status, status) || other.status == status) &&
+            (identical(other.coverImageUrl, coverImageUrl) ||
+                other.coverImageUrl == coverImageUrl) &&
+            (identical(other.note, note) || other.note == note));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, id, title, description, begunAt,
+      endedAt, categoryId, status, coverImageUrl, note);
+
+  @override
+  String toString() {
+    return 'NetworkMainQuest(id: $id, title: $title, description: $description, begunAt: $begunAt, endedAt: $endedAt, categoryId: $categoryId, status: $status, coverImageUrl: $coverImageUrl, note: $note)';
   }
 }
 
 /// @nodoc
-abstract class _$$NetworkMainQuestImplCopyWith<$Res>
-    implements $NetworkMainQuestCopyWith<$Res> {
-  factory _$$NetworkMainQuestImplCopyWith(
-    _$NetworkMainQuestImpl value,
-    $Res Function(_$NetworkMainQuestImpl) then,
-  ) = __$$NetworkMainQuestImplCopyWithImpl<$Res>;
-  @override
+abstract mixin class $NetworkMainQuestCopyWith<$Res> {
+  factory $NetworkMainQuestCopyWith(
+          NetworkMainQuest value, $Res Function(NetworkMainQuest) _then) =
+      _$NetworkMainQuestCopyWithImpl;
   @useResult
-  $Res call({
-    String id,
-    String title,
-    String description,
-    DateTime? begunAt,
-    DateTime? endedAt,
-    String? categoryId,
-    String status,
-    String? coverImageUrl,
-    String note,
-  });
+  $Res call(
+      {String id,
+      String title,
+      String description,
+      DateTime? begunAt,
+      DateTime? endedAt,
+      String? categoryId,
+      String status,
+      String? coverImageUrl,
+      String note});
 }
 
 /// @nodoc
-class __$$NetworkMainQuestImplCopyWithImpl<$Res>
-    extends _$NetworkMainQuestCopyWithImpl<$Res, _$NetworkMainQuestImpl>
-    implements _$$NetworkMainQuestImplCopyWith<$Res> {
-  __$$NetworkMainQuestImplCopyWithImpl(
-    _$NetworkMainQuestImpl _value,
-    $Res Function(_$NetworkMainQuestImpl) _then,
-  ) : super(_value, _then);
+class _$NetworkMainQuestCopyWithImpl<$Res>
+    implements $NetworkMainQuestCopyWith<$Res> {
+  _$NetworkMainQuestCopyWithImpl(this._self, this._then);
+
+  final NetworkMainQuest _self;
+  final $Res Function(NetworkMainQuest) _then;
 
   /// Create a copy of NetworkMainQuest
   /// with the given fields replaced by the non-null parameter values.
@@ -176,66 +107,62 @@ class __$$NetworkMainQuestImplCopyWithImpl<$Res>
     Object? coverImageUrl = freezed,
     Object? note = null,
   }) {
-    return _then(
-      _$NetworkMainQuestImpl(
-        id: null == id
-            ? _value.id
-            : id // ignore: cast_nullable_to_non_nullable
-                  as String,
-        title: null == title
-            ? _value.title
-            : title // ignore: cast_nullable_to_non_nullable
-                  as String,
-        description: null == description
-            ? _value.description
-            : description // ignore: cast_nullable_to_non_nullable
-                  as String,
-        begunAt: freezed == begunAt
-            ? _value.begunAt
-            : begunAt // ignore: cast_nullable_to_non_nullable
-                  as DateTime?,
-        endedAt: freezed == endedAt
-            ? _value.endedAt
-            : endedAt // ignore: cast_nullable_to_non_nullable
-                  as DateTime?,
-        categoryId: freezed == categoryId
-            ? _value.categoryId
-            : categoryId // ignore: cast_nullable_to_non_nullable
-                  as String?,
-        status: null == status
-            ? _value.status
-            : status // ignore: cast_nullable_to_non_nullable
-                  as String,
-        coverImageUrl: freezed == coverImageUrl
-            ? _value.coverImageUrl
-            : coverImageUrl // ignore: cast_nullable_to_non_nullable
-                  as String?,
-        note: null == note
-            ? _value.note
-            : note // ignore: cast_nullable_to_non_nullable
-                  as String,
-      ),
-    );
+    return _then(_self.copyWith(
+      id: null == id
+          ? _self.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      title: null == title
+          ? _self.title
+          : title // ignore: cast_nullable_to_non_nullable
+              as String,
+      description: null == description
+          ? _self.description
+          : description // ignore: cast_nullable_to_non_nullable
+              as String,
+      begunAt: freezed == begunAt
+          ? _self.begunAt
+          : begunAt // ignore: cast_nullable_to_non_nullable
+              as DateTime?,
+      endedAt: freezed == endedAt
+          ? _self.endedAt
+          : endedAt // ignore: cast_nullable_to_non_nullable
+              as DateTime?,
+      categoryId: freezed == categoryId
+          ? _self.categoryId
+          : categoryId // ignore: cast_nullable_to_non_nullable
+              as String?,
+      status: null == status
+          ? _self.status
+          : status // ignore: cast_nullable_to_non_nullable
+              as String,
+      coverImageUrl: freezed == coverImageUrl
+          ? _self.coverImageUrl
+          : coverImageUrl // ignore: cast_nullable_to_non_nullable
+              as String?,
+      note: null == note
+          ? _self.note
+          : note // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
   }
 }
 
 /// @nodoc
 @JsonSerializable()
-class _$NetworkMainQuestImpl implements _NetworkMainQuest {
-  const _$NetworkMainQuestImpl({
-    required this.id,
-    required this.title,
-    required this.description,
-    required this.begunAt,
-    required this.endedAt,
-    required this.categoryId,
-    required this.status,
-    required this.coverImageUrl,
-    required this.note,
-  });
-
-  factory _$NetworkMainQuestImpl.fromJson(Map<String, dynamic> json) =>
-      _$$NetworkMainQuestImplFromJson(json);
+class _NetworkMainQuest implements NetworkMainQuest {
+  const _NetworkMainQuest(
+      {required this.id,
+      required this.title,
+      required this.description,
+      required this.begunAt,
+      required this.endedAt,
+      required this.categoryId,
+      required this.status,
+      required this.coverImageUrl,
+      required this.note});
+  factory _NetworkMainQuest.fromJson(Map<String, dynamic> json) =>
+      _$NetworkMainQuestFromJson(json);
 
   @override
   final String id;
@@ -256,16 +183,26 @@ class _$NetworkMainQuestImpl implements _NetworkMainQuest {
   @override
   final String note;
 
+  /// Create a copy of NetworkMainQuest
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  String toString() {
-    return 'NetworkMainQuest(id: $id, title: $title, description: $description, begunAt: $begunAt, endedAt: $endedAt, categoryId: $categoryId, status: $status, coverImageUrl: $coverImageUrl, note: $note)';
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$NetworkMainQuestCopyWith<_NetworkMainQuest> get copyWith =>
+      __$NetworkMainQuestCopyWithImpl<_NetworkMainQuest>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$NetworkMainQuestToJson(
+      this,
+    );
   }
 
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$NetworkMainQuestImpl &&
+            other is _NetworkMainQuest &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.title, title) || other.title == title) &&
             (identical(other.description, description) ||
@@ -282,75 +219,97 @@ class _$NetworkMainQuestImpl implements _NetworkMainQuest {
 
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  int get hashCode => Object.hash(
-    runtimeType,
-    id,
-    title,
-    description,
-    begunAt,
-    endedAt,
-    categoryId,
-    status,
-    coverImageUrl,
-    note,
-  );
-
-  /// Create a copy of NetworkMainQuest
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  @pragma('vm:prefer-inline')
-  _$$NetworkMainQuestImplCopyWith<_$NetworkMainQuestImpl> get copyWith =>
-      __$$NetworkMainQuestImplCopyWithImpl<_$NetworkMainQuestImpl>(
-        this,
-        _$identity,
-      );
+  int get hashCode => Object.hash(runtimeType, id, title, description, begunAt,
+      endedAt, categoryId, status, coverImageUrl, note);
 
   @override
-  Map<String, dynamic> toJson() {
-    return _$$NetworkMainQuestImplToJson(this);
+  String toString() {
+    return 'NetworkMainQuest(id: $id, title: $title, description: $description, begunAt: $begunAt, endedAt: $endedAt, categoryId: $categoryId, status: $status, coverImageUrl: $coverImageUrl, note: $note)';
   }
 }
 
-abstract class _NetworkMainQuest implements NetworkMainQuest {
-  const factory _NetworkMainQuest({
-    required final String id,
-    required final String title,
-    required final String description,
-    required final DateTime? begunAt,
-    required final DateTime? endedAt,
-    required final String? categoryId,
-    required final String status,
-    required final String? coverImageUrl,
-    required final String note,
-  }) = _$NetworkMainQuestImpl;
+/// @nodoc
+abstract mixin class _$NetworkMainQuestCopyWith<$Res>
+    implements $NetworkMainQuestCopyWith<$Res> {
+  factory _$NetworkMainQuestCopyWith(
+          _NetworkMainQuest value, $Res Function(_NetworkMainQuest) _then) =
+      __$NetworkMainQuestCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {String id,
+      String title,
+      String description,
+      DateTime? begunAt,
+      DateTime? endedAt,
+      String? categoryId,
+      String status,
+      String? coverImageUrl,
+      String note});
+}
 
-  factory _NetworkMainQuest.fromJson(Map<String, dynamic> json) =
-      _$NetworkMainQuestImpl.fromJson;
+/// @nodoc
+class __$NetworkMainQuestCopyWithImpl<$Res>
+    implements _$NetworkMainQuestCopyWith<$Res> {
+  __$NetworkMainQuestCopyWithImpl(this._self, this._then);
 
-  @override
-  String get id;
-  @override
-  String get title;
-  @override
-  String get description;
-  @override
-  DateTime? get begunAt;
-  @override
-  DateTime? get endedAt;
-  @override
-  String? get categoryId;
-  @override
-  String get status;
-  @override
-  String? get coverImageUrl;
-  @override
-  String get note;
+  final _NetworkMainQuest _self;
+  final $Res Function(_NetworkMainQuest) _then;
 
   /// Create a copy of NetworkMainQuest
   /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$NetworkMainQuestImplCopyWith<_$NetworkMainQuestImpl> get copyWith =>
-      throw _privateConstructorUsedError;
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? id = null,
+    Object? title = null,
+    Object? description = null,
+    Object? begunAt = freezed,
+    Object? endedAt = freezed,
+    Object? categoryId = freezed,
+    Object? status = null,
+    Object? coverImageUrl = freezed,
+    Object? note = null,
+  }) {
+    return _then(_NetworkMainQuest(
+      id: null == id
+          ? _self.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      title: null == title
+          ? _self.title
+          : title // ignore: cast_nullable_to_non_nullable
+              as String,
+      description: null == description
+          ? _self.description
+          : description // ignore: cast_nullable_to_non_nullable
+              as String,
+      begunAt: freezed == begunAt
+          ? _self.begunAt
+          : begunAt // ignore: cast_nullable_to_non_nullable
+              as DateTime?,
+      endedAt: freezed == endedAt
+          ? _self.endedAt
+          : endedAt // ignore: cast_nullable_to_non_nullable
+              as DateTime?,
+      categoryId: freezed == categoryId
+          ? _self.categoryId
+          : categoryId // ignore: cast_nullable_to_non_nullable
+              as String?,
+      status: null == status
+          ? _self.status
+          : status // ignore: cast_nullable_to_non_nullable
+              as String,
+      coverImageUrl: freezed == coverImageUrl
+          ? _self.coverImageUrl
+          : coverImageUrl // ignore: cast_nullable_to_non_nullable
+              as String?,
+      note: null == note
+          ? _self.note
+          : note // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
 }
+
+// dart format on

--- a/core/network_model/lib/src/quest/network_main_quest.g.dart
+++ b/core/network_model/lib/src/quest/network_main_quest.g.dart
@@ -6,34 +6,32 @@ part of 'network_main_quest.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$NetworkMainQuestImpl _$$NetworkMainQuestImplFromJson(
-  Map<String, dynamic> json,
-) => _$NetworkMainQuestImpl(
-  id: json['id'] as String,
-  title: json['title'] as String,
-  description: json['description'] as String,
-  begunAt: json['begunAt'] == null
-      ? null
-      : DateTime.parse(json['begunAt'] as String),
-  endedAt: json['endedAt'] == null
-      ? null
-      : DateTime.parse(json['endedAt'] as String),
-  categoryId: json['categoryId'] as String?,
-  status: json['status'] as String,
-  coverImageUrl: json['coverImageUrl'] as String?,
-  note: json['note'] as String,
-);
+_NetworkMainQuest _$NetworkMainQuestFromJson(Map<String, dynamic> json) =>
+    _NetworkMainQuest(
+      id: json['id'] as String,
+      title: json['title'] as String,
+      description: json['description'] as String,
+      begunAt: json['begunAt'] == null
+          ? null
+          : DateTime.parse(json['begunAt'] as String),
+      endedAt: json['endedAt'] == null
+          ? null
+          : DateTime.parse(json['endedAt'] as String),
+      categoryId: json['categoryId'] as String?,
+      status: json['status'] as String,
+      coverImageUrl: json['coverImageUrl'] as String?,
+      note: json['note'] as String,
+    );
 
-Map<String, dynamic> _$$NetworkMainQuestImplToJson(
-  _$NetworkMainQuestImpl instance,
-) => <String, dynamic>{
-  'id': instance.id,
-  'title': instance.title,
-  'description': instance.description,
-  'begunAt': instance.begunAt?.toIso8601String(),
-  'endedAt': instance.endedAt?.toIso8601String(),
-  'categoryId': instance.categoryId,
-  'status': instance.status,
-  'coverImageUrl': instance.coverImageUrl,
-  'note': instance.note,
-};
+Map<String, dynamic> _$NetworkMainQuestToJson(_NetworkMainQuest instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'title': instance.title,
+      'description': instance.description,
+      'begunAt': instance.begunAt?.toIso8601String(),
+      'endedAt': instance.endedAt?.toIso8601String(),
+      'categoryId': instance.categoryId,
+      'status': instance.status,
+      'coverImageUrl': instance.coverImageUrl,
+      'note': instance.note,
+    };

--- a/core/network_model/pubspec.yaml
+++ b/core/network_model/pubspec.yaml
@@ -8,11 +8,11 @@ environment:
 resolution: workspace
 
 dependencies:
-  freezed_annotation: 2.4.4
+  freezed_annotation: 3.0.0
   json_annotation: 4.9.0
 
 dev_dependencies:
   build_runner: 2.4.14
-  freezed: 2.5.7
-  json_serializable: 6.8.0
+  freezed: 3.0.6
+  json_serializable: 6.9.5
   yumemi_lints: 4.0.0

--- a/core/ui/lib/src/component/toast/toast_data.dart
+++ b/core/ui/lib/src/component/toast/toast_data.dart
@@ -4,7 +4,7 @@ part 'toast_data.freezed.dart';
 
 /// トーストのデータ
 @freezed
-class ToastData with _$ToastData {
+abstract class ToastData with _$ToastData {
   const factory ToastData({
     required String id,
     required String message,

--- a/core/ui/lib/src/component/toast/toast_data.freezed.dart
+++ b/core/ui/lib/src/component/toast/toast_data.freezed.dart
@@ -1,3 +1,4 @@
+// dart format width=80
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint
@@ -9,187 +10,29 @@ part of 'toast_data.dart';
 // FreezedGenerator
 // **************************************************************************
 
+// dart format off
 T _$identity<T>(T value) => value;
-
-final _privateConstructorUsedError = UnsupportedError(
-  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
-);
 
 /// @nodoc
 mixin _$ToastData {
-  String get id => throw _privateConstructorUsedError;
-  String get message => throw _privateConstructorUsedError;
-  ToastType get type => throw _privateConstructorUsedError;
-  Duration get duration => throw _privateConstructorUsedError;
-  DateTime get createdAt => throw _privateConstructorUsedError;
+  String get id;
+  String get message;
+  ToastType get type;
+  Duration get duration;
+  DateTime get createdAt;
 
   /// Create a copy of ToastData
   /// with the given fields replaced by the non-null parameter values.
   @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
   $ToastDataCopyWith<ToastData> get copyWith =>
-      throw _privateConstructorUsedError;
-}
-
-/// @nodoc
-abstract class $ToastDataCopyWith<$Res> {
-  factory $ToastDataCopyWith(ToastData value, $Res Function(ToastData) then) =
-      _$ToastDataCopyWithImpl<$Res, ToastData>;
-  @useResult
-  $Res call({
-    String id,
-    String message,
-    ToastType type,
-    Duration duration,
-    DateTime createdAt,
-  });
-}
-
-/// @nodoc
-class _$ToastDataCopyWithImpl<$Res, $Val extends ToastData>
-    implements $ToastDataCopyWith<$Res> {
-  _$ToastDataCopyWithImpl(this._value, this._then);
-
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
-
-  /// Create a copy of ToastData
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? id = null,
-    Object? message = null,
-    Object? type = null,
-    Object? duration = null,
-    Object? createdAt = null,
-  }) {
-    return _then(
-      _value.copyWith(
-            id: null == id
-                ? _value.id
-                : id // ignore: cast_nullable_to_non_nullable
-                      as String,
-            message: null == message
-                ? _value.message
-                : message // ignore: cast_nullable_to_non_nullable
-                      as String,
-            type: null == type
-                ? _value.type
-                : type // ignore: cast_nullable_to_non_nullable
-                      as ToastType,
-            duration: null == duration
-                ? _value.duration
-                : duration // ignore: cast_nullable_to_non_nullable
-                      as Duration,
-            createdAt: null == createdAt
-                ? _value.createdAt
-                : createdAt // ignore: cast_nullable_to_non_nullable
-                      as DateTime,
-          )
-          as $Val,
-    );
-  }
-}
-
-/// @nodoc
-abstract class _$$ToastDataImplCopyWith<$Res>
-    implements $ToastDataCopyWith<$Res> {
-  factory _$$ToastDataImplCopyWith(
-    _$ToastDataImpl value,
-    $Res Function(_$ToastDataImpl) then,
-  ) = __$$ToastDataImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call({
-    String id,
-    String message,
-    ToastType type,
-    Duration duration,
-    DateTime createdAt,
-  });
-}
-
-/// @nodoc
-class __$$ToastDataImplCopyWithImpl<$Res>
-    extends _$ToastDataCopyWithImpl<$Res, _$ToastDataImpl>
-    implements _$$ToastDataImplCopyWith<$Res> {
-  __$$ToastDataImplCopyWithImpl(
-    _$ToastDataImpl _value,
-    $Res Function(_$ToastDataImpl) _then,
-  ) : super(_value, _then);
-
-  /// Create a copy of ToastData
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? id = null,
-    Object? message = null,
-    Object? type = null,
-    Object? duration = null,
-    Object? createdAt = null,
-  }) {
-    return _then(
-      _$ToastDataImpl(
-        id: null == id
-            ? _value.id
-            : id // ignore: cast_nullable_to_non_nullable
-                  as String,
-        message: null == message
-            ? _value.message
-            : message // ignore: cast_nullable_to_non_nullable
-                  as String,
-        type: null == type
-            ? _value.type
-            : type // ignore: cast_nullable_to_non_nullable
-                  as ToastType,
-        duration: null == duration
-            ? _value.duration
-            : duration // ignore: cast_nullable_to_non_nullable
-                  as Duration,
-        createdAt: null == createdAt
-            ? _value.createdAt
-            : createdAt // ignore: cast_nullable_to_non_nullable
-                  as DateTime,
-      ),
-    );
-  }
-}
-
-/// @nodoc
-
-class _$ToastDataImpl implements _ToastData {
-  const _$ToastDataImpl({
-    required this.id,
-    required this.message,
-    required this.type,
-    required this.duration,
-    required this.createdAt,
-  });
-
-  @override
-  final String id;
-  @override
-  final String message;
-  @override
-  final ToastType type;
-  @override
-  final Duration duration;
-  @override
-  final DateTime createdAt;
-
-  @override
-  String toString() {
-    return 'ToastData(id: $id, message: $message, type: $type, duration: $duration, createdAt: $createdAt)';
-  }
+      _$ToastDataCopyWithImpl<ToastData>(this as ToastData, _$identity);
 
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$ToastDataImpl &&
+            other is ToastData &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.message, message) || other.message == message) &&
             (identical(other.type, type) || other.type == type) &&
@@ -203,39 +46,178 @@ class _$ToastDataImpl implements _ToastData {
   int get hashCode =>
       Object.hash(runtimeType, id, message, type, duration, createdAt);
 
+  @override
+  String toString() {
+    return 'ToastData(id: $id, message: $message, type: $type, duration: $duration, createdAt: $createdAt)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $ToastDataCopyWith<$Res> {
+  factory $ToastDataCopyWith(ToastData value, $Res Function(ToastData) _then) =
+      _$ToastDataCopyWithImpl;
+  @useResult
+  $Res call(
+      {String id,
+      String message,
+      ToastType type,
+      Duration duration,
+      DateTime createdAt});
+}
+
+/// @nodoc
+class _$ToastDataCopyWithImpl<$Res> implements $ToastDataCopyWith<$Res> {
+  _$ToastDataCopyWithImpl(this._self, this._then);
+
+  final ToastData _self;
+  final $Res Function(ToastData) _then;
+
   /// Create a copy of ToastData
   /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? message = null,
+    Object? type = null,
+    Object? duration = null,
+    Object? createdAt = null,
+  }) {
+    return _then(_self.copyWith(
+      id: null == id
+          ? _self.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      message: null == message
+          ? _self.message
+          : message // ignore: cast_nullable_to_non_nullable
+              as String,
+      type: null == type
+          ? _self.type
+          : type // ignore: cast_nullable_to_non_nullable
+              as ToastType,
+      duration: null == duration
+          ? _self.duration
+          : duration // ignore: cast_nullable_to_non_nullable
+              as Duration,
+      createdAt: null == createdAt
+          ? _self.createdAt
+          : createdAt // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _ToastData implements ToastData {
+  const _ToastData(
+      {required this.id,
+      required this.message,
+      required this.type,
+      required this.duration,
+      required this.createdAt});
+
+  @override
+  final String id;
+  @override
+  final String message;
+  @override
+  final ToastType type;
+  @override
+  final Duration duration;
+  @override
+  final DateTime createdAt;
+
+  /// Create a copy of ToastData
+  /// with the given fields replaced by the non-null parameter values.
+  @override
   @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$ToastDataCopyWith<_ToastData> get copyWith =>
+      __$ToastDataCopyWithImpl<_ToastData>(this, _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _ToastData &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.message, message) || other.message == message) &&
+            (identical(other.type, type) || other.type == type) &&
+            (identical(other.duration, duration) ||
+                other.duration == duration) &&
+            (identical(other.createdAt, createdAt) ||
+                other.createdAt == createdAt));
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, id, message, type, duration, createdAt);
+
+  @override
+  String toString() {
+    return 'ToastData(id: $id, message: $message, type: $type, duration: $duration, createdAt: $createdAt)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$ToastDataCopyWith<$Res>
+    implements $ToastDataCopyWith<$Res> {
+  factory _$ToastDataCopyWith(
+          _ToastData value, $Res Function(_ToastData) _then) =
+      __$ToastDataCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {String id,
+      String message,
+      ToastType type,
+      Duration duration,
+      DateTime createdAt});
+}
+
+/// @nodoc
+class __$ToastDataCopyWithImpl<$Res> implements _$ToastDataCopyWith<$Res> {
+  __$ToastDataCopyWithImpl(this._self, this._then);
+
+  final _ToastData _self;
+  final $Res Function(_ToastData) _then;
+
+  /// Create a copy of ToastData
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
-  _$$ToastDataImplCopyWith<_$ToastDataImpl> get copyWith =>
-      __$$ToastDataImplCopyWithImpl<_$ToastDataImpl>(this, _$identity);
+  $Res call({
+    Object? id = null,
+    Object? message = null,
+    Object? type = null,
+    Object? duration = null,
+    Object? createdAt = null,
+  }) {
+    return _then(_ToastData(
+      id: null == id
+          ? _self.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      message: null == message
+          ? _self.message
+          : message // ignore: cast_nullable_to_non_nullable
+              as String,
+      type: null == type
+          ? _self.type
+          : type // ignore: cast_nullable_to_non_nullable
+              as ToastType,
+      duration: null == duration
+          ? _self.duration
+          : duration // ignore: cast_nullable_to_non_nullable
+              as Duration,
+      createdAt: null == createdAt
+          ? _self.createdAt
+          : createdAt // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+    ));
+  }
 }
 
-abstract class _ToastData implements ToastData {
-  const factory _ToastData({
-    required final String id,
-    required final String message,
-    required final ToastType type,
-    required final Duration duration,
-    required final DateTime createdAt,
-  }) = _$ToastDataImpl;
-
-  @override
-  String get id;
-  @override
-  String get message;
-  @override
-  ToastType get type;
-  @override
-  Duration get duration;
-  @override
-  DateTime get createdAt;
-
-  /// Create a copy of ToastData
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$ToastDataImplCopyWith<_$ToastDataImpl> get copyWith =>
-      throw _privateConstructorUsedError;
-}
+// dart format on

--- a/core/ui/lib/src/component/toast/toaster.g.dart
+++ b/core/ui/lib/src/component/toast/toaster.g.dart
@@ -13,9 +13,8 @@ String _$toastListKeyHash() => r'2b32578c742f2546637c9d8c7e2000ff45151ee3';
 final toastListKeyProvider = Provider<GlobalKey<AnimatedListState>>.internal(
   toastListKey,
   name: r'toastListKeyProvider',
-  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
-      ? null
-      : _$toastListKeyHash,
+  debugGetCreateSourceHash:
+      const bool.fromEnvironment('dart.vm.product') ? null : _$toastListKeyHash,
   dependencies: null,
   allTransitiveDependencies: null,
 );
@@ -29,14 +28,13 @@ String _$toasterHash() => r'246e5af54027bdba0015ad996bc4c5da55e32d6a';
 @ProviderFor(Toaster)
 final toasterProvider =
     AutoDisposeNotifierProvider<Toaster, List<ToastData>>.internal(
-      Toaster.new,
-      name: r'toasterProvider',
-      debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
-          ? null
-          : _$toasterHash,
-      dependencies: null,
-      allTransitiveDependencies: null,
-    );
+  Toaster.new,
+  name: r'toasterProvider',
+  debugGetCreateSourceHash:
+      const bool.fromEnvironment('dart.vm.product') ? null : _$toasterHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
 
 typedef _$Toaster = AutoDisposeNotifier<List<ToastData>>;
 // ignore_for_file: type=lint

--- a/core/ui/pubspec.yaml
+++ b/core/ui/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   flutter_localizations:
     sdk: flutter
   flutter_riverpod: 2.6.1
-  freezed_annotation: 2.4.4
+  freezed_annotation: 3.0.0
   intl: 0.20.2
   riverpod: 2.6.1
   riverpod_annotation: 2.6.1
@@ -28,8 +28,8 @@ dev_dependencies:
   core_testing: any
   flutter_test:
     sdk: flutter
-  freezed: 2.5.7
-  riverpod_generator: 2.6.3
+  freezed: 3.0.6
+  riverpod_generator: 2.6.5
   yumemi_lints: 4.0.0
 
 flutter:

--- a/feature/feed/pubspec.yaml
+++ b/feature/feed/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
     sdk: flutter
   flutter_localizations:
     sdk: flutter
-  freezed_annotation: 2.4.4
+  freezed_annotation: 3.0.0
   hooks_riverpod: 2.6.1
   intl: 0.20.2
   riverpod_annotation: 2.6.1
@@ -27,8 +27,8 @@ dev_dependencies:
   core_testing: any
   flutter_test:
     sdk: flutter
-  freezed: 2.5.7
-  riverpod_generator: 2.6.3
+  freezed: 3.0.6
+  riverpod_generator: 2.6.5
   yumemi_lints: 4.0.0
 
 flutter:

--- a/feature/quest/pubspec.yaml
+++ b/feature/quest/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   flutter_hooks: 0.20.5
   flutter_localizations:
     sdk: flutter
-  freezed_annotation: 2.4.4
+  freezed_annotation: 3.0.0
   hooks_riverpod: 2.6.1
   intl: 0.20.2
   riverpod_annotation: 2.6.1
@@ -29,8 +29,8 @@ dev_dependencies:
   core_testing: any
   flutter_test:
     sdk: flutter
-  freezed: 2.5.7
-  riverpod_generator: 2.6.3
+  freezed: 3.0.6
+  riverpod_generator: 2.6.5
   yumemi_lints: 4.0.0
 
 flutter:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,10 +5,10 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: "16e298750b6d0af7ce8a3ba7c18c69c3785d11b15ec83f6dcd0ad2a0009b3cab"
+      sha256: c57b02f47e021c9d7ced6d2e28824b315e0fd585578274bc4c2a5db0626f154a
       url: "https://pub.dev"
     source: hosted
-    version: "76.0.0"
+    version: "75.0.0"
   _flutterfire_internals:
     dependency: transitive
     description:
@@ -31,13 +31,13 @@ packages:
     source: hosted
     version: "2.3.0"
   analyzer:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
       name: analyzer
-      sha256: "1f14db053a8c23e260789e9b0980fa27f2680dd640932cae5e1137cce0e46e1e"
+      sha256: ef226c581b7cd875f734125b1b9928df3db08cc85ff87ce7d9be89a677aaee23
       url: "https://pub.dev"
     source: hosted
-    version: "6.11.0"
+    version: "6.10.0"
   analyzer_plugin:
     dependency: transitive
     description:
@@ -162,10 +162,10 @@ packages:
     dependency: transitive
     description:
       name: built_value_generator
-      sha256: "6ba3effca656e7f88102142e7d62b71373504d654132ca2895896b3a7013e567"
+      sha256: be8640bd52d67a5e6747379778b81ca2e6a40f61df475f81beb72fde62e32524
       url: "https://pub.dev"
     source: hosted
-    version: "8.9.3"
+    version: "8.9.5"
   characters:
     dependency: transitive
     description:
@@ -330,10 +330,10 @@ packages:
     dependency: transitive
     description:
       name: device_frame_plus
-      sha256: "6b68d43a30a08465f86f33592ac60efcd1499979ef1310fbe3445d94f367297b"
+      sha256: "61b10153b7f2b143265cfb9b84684e660a676f7002e70cc1acd2e3a7caed958b"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.2+1"
+    version: "1.3.1"
   dio:
     dependency: transitive
     description:
@@ -362,18 +362,18 @@ packages:
     dependency: transitive
     description:
       name: drift
-      sha256: c2d073d35ad441730812f4ea05b5dd031fb81c5f9786a4f5fb77ecd6307b6f74
+      sha256: b584ddeb2b74436735dd2cf746d2d021e19a9a6770f409212fd5cbc2814ada85
       url: "https://pub.dev"
     source: hosted
-    version: "2.22.1"
+    version: "2.26.1"
   drift_dev:
     dependency: transitive
     description:
       name: drift_dev
-      sha256: f4ab5d6976b1e31551ceb82ff597a505bda7818ff4f7be08a1da9d55eb6e730c
+      sha256: "54dc207c6e4662741f60e5752678df183957ab907754ffab0372a7082f6d2816"
       url: "https://pub.dev"
     source: hosted
-    version: "2.22.1"
+    version: "2.26.1"
   dynamic_color:
     dependency: transitive
     description:
@@ -386,18 +386,18 @@ packages:
     dependency: transitive
     description:
       name: envied
-      sha256: "129a0dbf32b90344fa2e9d6943569fdec8f17904e66161e0a1f09ee3416508ae"
+      sha256: a4e2b1d0caa479b5d61332ae516518c175a6d09328a35a0bc0a53894cc5d7e4d
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "1.1.1"
   envied_generator:
     dependency: transitive
     description:
       name: envied_generator
-      sha256: "76aec98907872ce8488f021e68d213bd0d9bf224eb393a094be1708cc3180d41"
+      sha256: "894f6c5eb624c60a1ce6f642b6fd7ec68bc3440aa6f1881837aa9acbbeade0c8"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "1.1.1"
   equatable:
     dependency: transitive
     description:
@@ -646,18 +646,18 @@ packages:
     dependency: transitive
     description:
       name: freezed
-      sha256: "44c19278dd9d89292cf46e97dc0c1e52ce03275f40a97c5a348e802a924bf40e"
+      sha256: "6022db4c7bfa626841b2a10f34dd1e1b68e8f8f9650db6112dcdeeca45ca793c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.7"
+    version: "3.0.6"
   freezed_annotation:
     dependency: transitive
     description:
       name: freezed_annotation
-      sha256: c2e2d632dd9b8a2b7751117abcfc2b4888ecfe181bd9fca7170d9ef02e595fe2
+      sha256: c87ff004c8aa6af2d531668b46a4ea379f7191dc6dfa066acd53d506da6e044b
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.4"
+    version: "3.0.0"
   frontend_server_client:
     dependency: transitive
     description:
@@ -902,10 +902,10 @@ packages:
     dependency: transitive
     description:
       name: json_serializable
-      sha256: ea1432d167339ea9b5bb153f0571d0039607a873d6e04e0117af043f14a1fd4b
+      sha256: c50ef5fc083d5b5e12eef489503ba3bf5ccc899e487d691584699b4bdefeea8c
       url: "https://pub.dev"
     source: hosted
-    version: "6.8.0"
+    version: "6.9.5"
   leak_tracker:
     dependency: transitive
     description:
@@ -1262,10 +1262,10 @@ packages:
     dependency: transitive
     description:
       name: riverpod_analyzer_utils
-      sha256: c6b8222b2b483cb87ae77ad147d6408f400c64f060df7a225b127f4afef4f8c8
+      sha256: "03a17170088c63aab6c54c44456f5ab78876a1ddb6032ffde1662ddab4959611"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.8"
+    version: "0.5.10"
   riverpod_annotation:
     dependency: transitive
     description:
@@ -1278,10 +1278,10 @@ packages:
     dependency: transitive
     description:
       name: riverpod_generator
-      sha256: "63546d70952015f0981361636bf8f356d9cfd9d7f6f0815e3c07789a41233188"
+      sha256: "44a0992d54473eb199ede00e2260bd3c262a86560e3c6f6374503d86d0580e36"
       url: "https://pub.dev"
     source: hosted
-    version: "2.6.3"
+    version: "2.6.5"
   rust:
     dependency: transitive
     description:
@@ -1427,10 +1427,10 @@ packages:
     dependency: transitive
     description:
       name: source_gen
-      sha256: "14658ba5f669685cd3d63701d01b31ea748310f7ab854e471962670abcf57832"
+      sha256: "35c8150ece9e8c8d263337a265153c3329667640850b9304861faea59fc98f6b"
       url: "https://pub.dev"
     source: hosted
-    version: "1.5.0"
+    version: "2.0.0"
   source_helper:
     dependency: transitive
     description:
@@ -1491,10 +1491,10 @@ packages:
     dependency: transitive
     description:
       name: sqlparser
-      sha256: "4cad4b2c5f63dc9ea1a8dcffb58cf762322bea5dd8836870164a65e913bdae41"
+      sha256: "27dd0a9f0c02e22ac0eb42a23df9ea079ce69b52bb4a3b478d64e0ef34a263ee"
       url: "https://pub.dev"
     source: hosted
-    version: "0.40.0"
+    version: "0.41.0"
   stack_trace:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,6 +36,7 @@ dev_dependencies:
   yumemi_lints: 4.0.0
 
 dependency_overrides:
+  analyzer: 6.10.0
   collection: 1.19.1
   file: 7.0.0
   intl: 0.20.2


### PR DESCRIPTION
## Summary
- Freezed v2からv3へのマイグレーションを実施
- すべてのFreezedクラスを`abstract class`構文に変換
- 依存関係の互換性問題を解決

## Changes
- Freezed関連パッケージのバージョンアップデート
  - freezed: 2.5.7 → 3.0.6
  - freezed_annotation: 2.4.4 → 3.0.0
- すべてのモデルクラスを`abstract class`構文に更新
- analyzer互換性のための依存関係オーバーライドを追加
- 関連する依存関係（riverpod_generator、json_serializable等）の更新

## Test plan
- [x] `melos bootstrap` が正常に完了
- [x] `melos gen` ですべてのコード生成が成功
- [x] `melos analyze` でエラーなし
- [x] ビルドエラーの解消を確認

🤖 Generated with [Claude Code](https://claude.ai/code)